### PR TITLE
Render gov nav if base_path has "/government"

### DIFF
--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -12,6 +12,7 @@ class EmailAlertSignup
 
   def initialize(content_item)
     @content_item = content_item
+    @base_path = content_item.base_path if content_item
   end
 
   def save
@@ -36,8 +37,16 @@ class EmailAlertSignup
     }
   end
 
+  def government?
+    base_path.starts_with?("/government")
+  end
+
+  def government_content_section
+    base_path.split('/')[2]
+  end
+
 private
-  attr_reader :content_item
+  attr_reader :content_item, :base_path
 
   def subscription_params
     {

--- a/app/views/email_alert_signups/new.html.erb
+++ b/app/views/email_alert_signups/new.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, email_alert_signup.title %>
 
+<% if email_alert_signup.government? %>
+  <%= render partial: 'govuk_component/government_navigation', locals: { active: email_alert_signup.government_content_section } %>
+<% end %>
+
 <header>
   <%= render partial: 'govuk_component/title', locals: {
     title: email_alert_signup.title,

--- a/features/email_alerts.feature
+++ b/features/email_alerts.feature
@@ -10,3 +10,7 @@ Feature: Email alert signup
     Then I see the email signup page
     When I sign up to the email alerts
     Then my subscription should be registered
+
+  Scenario: Visit a government email alert page
+    Given a government email alert page exists
+    Then I can see the government header

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -3,7 +3,7 @@ Given(/^a content item exists for an email alert signup page$/) do
   @tags = {
     "policy"=> ["employment"]
   }
-  content_store_has_employment_email_alert_signup(base_path: @base_path, tags: @tags)
+  content_store_has_email_alert_signup(base_path: @base_path, tags: @tags)
 end
 
 When(/^I access the email signup page$/) do
@@ -22,4 +22,18 @@ end
 
 Then(/^my subscription should be registered$/) do
   expect_registration_to(title: "Employment", tags: @tags, base_path: @base_path)
+end
+
+Given(/^a government email alert page exists$/) do
+  content_store_has_email_alert_signup(
+    base_path: "/government/policies/employment/email-signup",
+    tags: {
+        "policy"=> ["employment"]
+    }
+  )
+end
+
+Then(/^I can see the government header$/) do
+  visit email_alert_signup_path('government/policies/employment/email-signup')
+  expect(page).to have_css(shared_component_selector('government_navigation'))
 end

--- a/features/support/email_alert_signup_helper.rb
+++ b/features/support/email_alert_signup_helper.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 module EmailAlertSignupHelper
   include GovukContentSchemaExamples
 
-  def content_store_has_employment_email_alert_signup(base_path:, tags:)
+  def content_store_has_email_alert_signup(base_path:, tags:)
     content_store_has_item(base_path, govuk_content_schema_example("email_alert_signup").merge(tags).to_json)
   end
 


### PR DESCRIPTION
When a email alert signup starts with "/government" in its base path, we should be displaying the government navigation. This commit does that by checking the `base_path` and getting the second section of this to mark the active link in the nav. This follows the same approach as Finder Frontend.

Screenshot:
![screen shot 2015-04-23 at 17 05 05](https://cloud.githubusercontent.com/assets/449004/7301500/ed5a29b6-e9da-11e4-9931-e44142735880.png)
