### PR TITLE
Don't protect_from_forgery on create

### DIFF
--- a/app/controllers/email_alert_signups_controller.rb
+++ b/app/controllers/email_alert_signups_controller.rb
@@ -1,4 +1,6 @@
 class EmailAlertSignupsController < ApplicationController
+  protect_from_forgery except: [:create]
+
   def new
     set_slimmer_dummy_artefact(email_alert_signup.breadcrumbs)
   end


### PR DESCRIPTION
When hitting the create action, we don't want to protect from forgery as
caching interferes with the token.