### PR TITLE
Use govdelivery-title if available

### DIFF
--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -6,7 +6,7 @@ class EmailAlertSignup
   validates_presence_of :content_item
 
   delegate :title, to: :content_item
-  delegate :summary, :tags, to: :"content_item.details"
+  delegate :summary, :tags, :govdelivery_title, to: :"content_item.details"
 
   attr_reader :subscription_url
 
@@ -50,7 +50,7 @@ private
 
   def subscription_params
     {
-      title: title,
+      title: govdelivery_title.present? ? govdelivery_title : title,
       tags: openstruct_to_hash(tags)
     }.deep_stringify_keys
   end

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -21,7 +21,7 @@ When(/^I sign up to the email alerts$/) do
 end
 
 Then(/^my subscription should be registered$/) do
-  expect_registration_to(title: "Employment", tags: @tags, base_path: @base_path)
+  expect_registration_to(title: "Employment policy", tags: @tags, base_path: @base_path)
 end
 
 Given(/^a government email alert page exists$/) do


### PR DESCRIPTION
If a different govdelivery-title is present, use that for the name of
the govdelivery topic when creating the subscription params.