### PR TITLE
Bump GDS API adapters to 20.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'plek', '1.10.0'
 gem 'airbrake', '4.1.0'
 gem 'decent_exposure', '2.3.2'
 
-gem 'gds-api-adapters', '18.2.0'
+gem 'gds-api-adapters', '20.1.1'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,15 +79,17 @@ GEM
     debugger-linecache (1.2.0)
     decent_exposure (2.3.2)
     diff-lcs (1.2.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.3.0)
-    gds-api-adapters (18.2.0)
+    gds-api-adapters (20.1.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
       rack-cache
-      rest-client (~> 1.7.3)
+      rest-client (~> 1.8.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.5)
@@ -97,6 +99,8 @@ GEM
     govuk_frontend_toolkit (3.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
     json-schema (2.5.1)
@@ -123,7 +127,7 @@ GEM
     plek (1.10.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.2)
+    rack (1.6.4)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-test (0.6.3)
@@ -154,7 +158,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
     rake (10.4.2)
-    rest-client (1.7.3)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec-core (3.2.3)
@@ -206,6 +211,9 @@ GEM
     uglifier (2.7.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -226,7 +234,7 @@ DEPENDENCIES
   byebug
   cucumber-rails
   decent_exposure (= 2.3.2)
-  gds-api-adapters (= 18.2.0)
+  gds-api-adapters (= 20.1.1)
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 3.1.0)
   launchy


### PR DESCRIPTION
This changes the user agent to include the app
name in API requests.

https://trello.com/c/qkHdtob4/247-bump-gds-api-adapters-everywhere-it-s-used-to-include-user-agent-information