### PR TITLE
Bump Plek to 1.11.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'
 gem 'quiet_assets', '1.1.0'
 
-gem 'plek', '1.10.0'
+gem 'plek', '1.11.0'
 gem 'airbrake', '4.1.0'
 gem 'decent_exposure', '2.3.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
-    plek (1.10.0)
+    plek (1.11.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -238,7 +238,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk_frontend_toolkit (= 3.1.0)
   launchy
-  plek (= 1.10.0)
+  plek (= 1.11.0)
   quiet_assets (= 1.1.0)
   rails (= 4.2.2)
   rspec-rails (= 3.2.1)


### PR DESCRIPTION
Adds support for PLEK_HOSTNAME_PREFIX to enable it to talk to the draft content-store.