### PR TITLE
Upgrade Slimmer, stop explicitly setting 'core_layout'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.3'
-gem 'slimmer', '~> 8.1.0'
+gem 'slimmer', '9.0.0'
 
 gem 'govuk_frontend_toolkit', '~> 3.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
-    slimmer (8.1.0)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -237,7 +237,7 @@ DEPENDENCIES
   rails (= 4.2.3)
   rspec-rails (~> 3.2.1)
   sass-rails (~> 5.0)
-  slimmer (~> 8.1.0)
+  slimmer (= 9.0.0)
   timecop (~> 0.7.1)
   uglifier (>= 1.3.0)
   unicorn

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,6 @@ class ApplicationController < ActionController::Base
   include Slimmer::Headers
   include Slimmer::SharedTemplates
 
-  before_filter :set_slimmer_template
-
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
@@ -11,10 +9,6 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
 
 private
-
-  def set_slimmer_template
-    set_slimmer_headers(template: 'core_layout')
-  end
 
   def error_not_found
     render status: :not_found, text: "404 error not found"


### PR DESCRIPTION
This should be a no-op change to app behaviour. The Slimmer upgrade will cancel
out the removal of explicitly setting slimmer template.

Note; these leaves `include Slimmer::Headers` in `ApplicationController` as its
depended on by `set_slimmer_dummy_artefact` in `EmailAlertSignupsController`.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps using legacy layout should set it explicitly, so
they're easily identified as outliers to be fixed.

Apps using `core_layout` shouldn't set slimmer template at all, which simplies
the app controller code too.

[1] https://github.com/alphagov/slimmer/pull/136