### PR TITLE
Use the email_alert_type when constructing the email-alert-api payload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'decent_exposure', '~> 2.3.2'
 gem 'gds-api-adapters', '~> 20.1.1'
 
 group :development, :test do
-  gem 'byebug'
+  gem 'pry-byebug'
   gem 'better_errors'
   gem 'binding_of_caller'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,8 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    byebug (6.0.0)
+    byebug (5.0.0)
+      columnize (= 0.9.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -57,6 +58,7 @@ GEM
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
     coderay (1.1.0)
+    columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     cucumber (1.3.20)
@@ -110,6 +112,7 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.8.0)
@@ -120,6 +123,13 @@ GEM
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     plek (1.11.0)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.2.0)
+      byebug (~> 5.0)
+      pry (~> 0.10)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -190,6 +200,7 @@ GEM
       plek (>= 1.1.0)
       rack (>= 1.3.5)
       rest-client
+    slop (3.6.0)
     sprockets (3.3.1)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
@@ -225,7 +236,6 @@ DEPENDENCIES
   airbrake (~> 4.1.0)
   better_errors
   binding_of_caller
-  byebug
   cucumber-rails (~> 1.4.2)
   decent_exposure (~> 2.3.2)
   gds-api-adapters (~> 20.1.1)
@@ -233,6 +243,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (~> 3.1.0)
   launchy
   plek (~> 1.11.0)
+  pry-byebug
   quiet_assets (~> 1.1.0)
   rails (= 4.2.3)
   rspec-rails (~> 3.2.1)

--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -52,13 +52,14 @@ private
     {
       title: govdelivery_title.present? ? govdelivery_title : title,
       tags: openstruct_to_hash(tags),
-      links: extract_signup_page_parent,
+      links: construct_links_payload_for_alert_api,
     }.deep_stringify_keys
   end
 
-  def extract_signup_page_parent
+  def construct_links_payload_for_alert_api
+    email_alert_type = signup_page.details.email_alert_type
     parent_id = signup_page.links.parent.first.content_id
-    { parent: [parent_id] }
+    { email_alert_type => [parent_id] }
   end
 
   def raw_breadcrumbs

--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -3,16 +3,16 @@ require 'active_model'
 class EmailAlertSignup
   include ActiveModel::Model
 
-  validates_presence_of :content_item
+  validates_presence_of :signup_page
 
-  delegate :title, to: :content_item
-  delegate :summary, :tags, :govdelivery_title, to: :"content_item.details"
+  delegate :title, to: :signup_page
+  delegate :summary, :tags, :govdelivery_title, to: :"signup_page.details"
 
   attr_reader :subscription_url
 
-  def initialize(content_item)
-    @content_item = content_item
-    @base_path = content_item.base_path if content_item
+  def initialize(signup_page)
+    @signup_page = signup_page
+    @base_path = signup_page.base_path if signup_page
   end
 
   def save
@@ -46,24 +46,24 @@ class EmailAlertSignup
   end
 
 private
-  attr_reader :content_item, :base_path
+  attr_reader :signup_page, :base_path
 
   def subscription_params
     {
       title: govdelivery_title.present? ? govdelivery_title : title,
       tags: openstruct_to_hash(tags),
-      links: extract_content_item_parent,
+      links: extract_signup_page_parent,
     }.deep_stringify_keys
   end
 
-  def extract_content_item_parent
-    parent_id = content_item.links.parent.first.content_id
+  def extract_signup_page_parent
+    parent_id = signup_page.links.parent.first.content_id
     { parent: [parent_id] }
   end
 
   def raw_breadcrumbs
-    if content_item.details.breadcrumbs
-      content_item.details.breadcrumbs.map(&method(:openstruct_to_hash))
+    if signup_page.details.breadcrumbs
+      signup_page.details.breadcrumbs.map(&method(:openstruct_to_hash))
     end
   end
 

--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -51,8 +51,14 @@ private
   def subscription_params
     {
       title: govdelivery_title.present? ? govdelivery_title : title,
-      tags: openstruct_to_hash(tags)
+      tags: openstruct_to_hash(tags),
+      links: extract_content_item_parent,
     }.deep_stringify_keys
+  end
+
+  def extract_content_item_parent
+    parent_id = content_item.links.parent.first.content_id
+    { parent: [parent_id] }
   end
 
   def raw_breadcrumbs

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -2,6 +2,7 @@ Given(/^a content item exists for an email alert signup page$/) do
   content_item = govuk_content_schema_example("email_alert_signup")
   @base_path = content_item["base_path"]
   @tags = content_item["details"]["tags"]
+  @alert_type = content_item["details"]["email_alert_type"]
   @parent_id = content_item["links"]["parent"].first["content_id"]
   content_store_has_item(@base_path, content_item.to_json)
 end
@@ -20,7 +21,7 @@ When(/^I sign up to the email alerts$/) do
   @subscription_params = {
     "title" => "Employment policy",
     "tags" => @tags,
-    "links" => { "parent" => [@parent_id] }
+    "links" => { @alert_type => [@parent_id] }
   }
   allow(EmailAlertFrontend.services(:email_alert_api)).
     to receive(:find_or_create_subscriber_list).

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -1,9 +1,9 @@
 Given(/^a content item exists for an email alert signup page$/) do
-  @base_path = "/government/policies/employment/email-signup"
-  @tags = {
-    "policy"=> ["employment"]
-  }
-  content_store_has_email_alert_signup(base_path: @base_path, tags: @tags)
+  content_item = govuk_content_schema_example("email_alert_signup")
+  @base_path = content_item["base_path"]
+  @tags = content_item["details"]["tags"]
+  @parent_id = content_item["links"]["parent"].first["content_id"]
+  content_store_has_item(@base_path, content_item.to_json)
 end
 
 When(/^I access the email signup page$/) do
@@ -17,20 +17,27 @@ Then(/^I see the email signup page$/) do
 end
 
 When(/^I sign up to the email alerts$/) do
-  subscribe_to_email_alerts
+  @subscription_params = {
+    "title" => "Employment policy",
+    "tags" => @tags,
+    "links" => { "parent" => [@parent_id] }
+  }
+  allow(EmailAlertFrontend.services(:email_alert_api)).
+    to receive(:find_or_create_subscriber_list).
+    with(@subscription_params).
+    and_return(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => @base_path)))
+
+  click_on "Create subscription"
 end
 
 Then(/^my subscription should be registered$/) do
-  expect_registration_to(title: "Employment policy", tags: @tags, base_path: @base_path)
+  expect(EmailAlertFrontend.services(:email_alert_api))
+    .to have_received(:find_or_create_subscriber_list)
+    .with(@subscription_params)
 end
 
 Given(/^a government email alert page exists$/) do
-  content_store_has_email_alert_signup(
-    base_path: "/government/policies/employment/email-signup",
-    tags: {
-        "policy"=> ["employment"]
-    }
-  )
+  step("a content item exists for an email alert signup page")
 end
 
 Then(/^I can see the government header$/) do

--- a/features/support/email_alert_signup_helper.rb
+++ b/features/support/email_alert_signup_helper.rb
@@ -1,31 +1,5 @@
-require 'ostruct'
-
 module EmailAlertSignupHelper
   include GovukContentSchemaExamples
-
-  def content_store_has_email_alert_signup(base_path:, tags:)
-    content_store_has_item(base_path, govuk_content_schema_example("email_alert_signup").merge(tags).to_json)
-  end
-
-  def expect_registration_to(title:, tags:, base_path:)
-    subscription_params = {
-      "title" => title,
-      "tags" => tags
-    }
-
-    allow(EmailAlertFrontend.services(:email_alert_api)).
-      to receive(:find_or_create_subscriber_list).
-      with(subscription_params).
-      and_return(OpenStruct.new("subscriber_list" => OpenStruct.new("subscription_url" => base_path)))
-
-    expect(EmailAlertFrontend.services(:email_alert_api)).
-      to have_received(:find_or_create_subscriber_list).
-      with(subscription_params)
-  end
-
-  def subscribe_to_email_alerts
-    click_on "Create subscription"
-  end
 end
 
 World(EmailAlertSignupHelper)

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -65,7 +65,7 @@ describe EmailAlertSignup do
           {
            "title" => "Employment policy",
            "tags"  => {"policy"=>["employment"]},
-           "links" => {"parent"=>["f8c3682c-3a88-4f35-afba-3607384e39e6"]}
+           "links" => {"policies"=>["f8c3682c-3a88-4f35-afba-3607384e39e6"]}
           }
         )
         .and_return(double(subscriber_list: double(subscription_url: 'foo')))

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -36,10 +36,6 @@ describe EmailAlertSignup do
     }
   }
 
-  let (:create_subscriber_list_request) {
-    email_alert_api_creates_subscriber_list(subscription_params)
-  }
-
   let (:govdelivery_title_subscription_params) {
     {
       "title" => "Employment Policy",
@@ -50,8 +46,8 @@ describe EmailAlertSignup do
     }
   }
 
-  let (:create_subscriber_list_request_with_govdelivery_title) {
-    email_alert_api_creates_subscriber_list(govdelivery_title_subscription_params)
+  let (:create_subscriber_list_request) {
+    email_alert_api_creates_subscriber_list(subscription_params)
   }
 
   before do
@@ -63,6 +59,21 @@ describe EmailAlertSignup do
   end
 
   describe "#save" do
+    it "sends the correct subscription params to the email alert api" do
+      expect(api_client).to receive(:find_or_create_subscriber_list)
+        .with(
+          {
+           "title" => "Employment policy",
+           "tags"  => {"policy"=>["employment"]},
+           "links" => {"parent"=>["f8c3682c-3a88-4f35-afba-3607384e39e6"]}
+          }
+        )
+        .and_return(double(subscriber_list: double(subscription_url: 'foo')))
+
+      email_signup = EmailAlertSignup.new(content_item)
+      email_signup.save
+    end
+
     it "creates the topic in GovDelivery using the tag and title if there is no govdelivery_title" do
       email_alert_api_does_not_have_subscriber_list(subscription_params)
       create_subscriber_list_request = email_alert_api_creates_subscriber_list(subscription_params)


### PR DESCRIPTION
Please merge https://github.com/alphagov/email-alert-api/pull/93 first.

This makes use of a new field on email_alert_signup content items -
'email_alert_type' - to construct the payload for the email-alert-api
when sending a subscription request. Using the field means the frontend
doesn't need to have explicit knowledge of the types of email alert that
are supported. Currently only policy subscriptions are handled in this
way, but the implementation leaves open the possibility of migrating
topics (for example) to make use of the email-alert-frontend as well.

Govuk content schemas determine which values of email_alert_type are valid,
ensuring that the email-alert-api receives expected values.
