### PR TITLE
Test fixes and cleanup for email alert signup

### DIFF
--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -1,7 +1,7 @@
 Given(/^a content item exists for an email alert signup page$/) do
   content_item = govuk_content_schema_example("email_alert_signup")
   @base_path = content_item["base_path"]
-  @tags = content_item["details"]["tags"]
+  @tags = content_item["details"]["signup_tags"]
   @alert_type = content_item["details"]["email_alert_type"]
   @parent_id = content_item["links"]["parent"].first["content_id"]
   content_store_has_item(@base_path, content_item.to_json)

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -8,7 +8,7 @@ describe EmailAlertSignup do
   let(:base_url)      { "http://some-domain" }
   let(:api_client)    { GdsApi::EmailAlertApi.new(base_url) }
 
-  let(:content_item) {
+  let(:signup_page) {
     dummy_http_response = double("net http response",
       code: 200,
       body: govuk_content_schema_example('email_alert_signup').except('govdelivery_title').to_json,
@@ -17,7 +17,7 @@ describe EmailAlertSignup do
     GdsApi::Response.new(dummy_http_response).to_ostruct
   }
 
-  let(:govdelivery_title_content_item) {
+  let(:signup_page_with_govdelivery_title) {
     dummy_http_response = double("net http response",
       code: 200,
       body: govuk_content_schema_example('email_alert_signup').to_json,
@@ -26,36 +26,18 @@ describe EmailAlertSignup do
     GdsApi::Response.new(dummy_http_response).to_ostruct
   }
 
-  let (:subscription_params) {
-    {
-      "title" => "Employment",
-      "tags" => {
-        "policy" => ["employment"]
-      },
-      "subscription_url" => "http://govdelivery_signup_url"
-    }
-  }
-
-  let (:govdelivery_title_subscription_params) {
-    {
-      "title" => "Employment Policy",
-      "tags" => {
-        "policy" => ["employment"]
-      },
-      "subscription_url" => "http://govdelivery_signup_url"
-    }
-  }
-
-  let (:create_subscriber_list_request) {
-    email_alert_api_creates_subscriber_list(subscription_params)
-  }
-
   before do
     EmailAlertFrontend.register_service(:email_alert_api, api_client)
   end
 
-  it "is invalid with no content item" do
+  it "is invalid with no signup page" do
     expect(EmailAlertSignup.new(nil)).not_to be_valid
+  end
+
+  it "does not attempt to create a subscription if no signup page is provided" do
+    expect(api_client).not_to receive(:find_or_create_subscriber_list)
+
+    expect(EmailAlertSignup.new(nil).save).to eq(false)
   end
 
   describe "#save" do
@@ -64,65 +46,39 @@ describe EmailAlertSignup do
         .with(
           {
            "title" => "Employment policy",
-           "tags"  => {"policy"=>["employment"]},
+           "tags"  => {"policies"=>["employment"]},
            "links" => {"policies"=>["f8c3682c-3a88-4f35-afba-3607384e39e6"]}
           }
         )
-        .and_return(double(subscriber_list: double(subscription_url: 'foo')))
+        .and_return(double(subscriber_list: double(subscription_url: 'http://foo')))
 
-      email_signup = EmailAlertSignup.new(content_item)
+      email_signup = EmailAlertSignup.new(signup_page)
       email_signup.save
-    end
-
-    it "creates the topic in GovDelivery using the tag and title if there is no govdelivery_title" do
-      email_alert_api_does_not_have_subscriber_list(subscription_params)
-      create_subscriber_list_request = email_alert_api_creates_subscriber_list(subscription_params)
-      email_signup = EmailAlertSignup.new(content_item)
-
-      expect email_signup.save
-      expect(create_subscriber_list_request).to have_been_requested
-    end
-
-    it "creates the topic in GovDelivery using the tag and govdelivery_title" do
-      email_alert_api_does_not_have_subscriber_list(govdelivery_title_subscription_params)
-      create_subscriber_list_request_with_govdelivery_title = email_alert_api_creates_subscriber_list(govdelivery_title_subscription_params)
-      email_signup = EmailAlertSignup.new(govdelivery_title_content_item)
-
-      expect email_signup.save
-      expect(create_subscriber_list_request_with_govdelivery_title).to have_been_requested
-    end
-
-    it "creates the topic in GovDelivery using the tag and title" do
-      email_alert_api_does_not_have_subscriber_list(subscription_params)
-      create_subscriber_list_request = email_alert_api_creates_subscriber_list(subscription_params)
-      email_signup = EmailAlertSignup.new(content_item)
-
-      expect email_signup.save
-      expect(create_subscriber_list_request).to have_been_requested
-    end
-
-    it "does not create a subscription if the subtopic is missing" do
-      expect(api_client).not_to receive(:find_or_create_subscriber_list)
-
-      expect(EmailAlertSignup.new(nil).save).to eq(false)
     end
   end
 
   describe "#subscription_url" do
     it "is the subscription_url returned by the API" do
-      email_alert_api_has_subscriber_list(subscription_params)
+      expect(api_client).to receive(:find_or_create_subscriber_list)
+        .with(
+          {
+           "title" => "Employment policy",
+           "tags"  => {"policies"=>["employment"]},
+           "links" => {"policies"=>["f8c3682c-3a88-4f35-afba-3607384e39e6"]}
+          }
+        )
+        .and_return(double(subscriber_list: double(subscription_url: 'http://foo')))
 
-      email_signup = EmailAlertSignup.new(content_item)
+      email_signup = EmailAlertSignup.new(signup_page)
       email_signup.save
 
-      expect("http://govdelivery_signup_url").to eq(email_signup.subscription_url)
+      expect("http://foo").to eq(email_signup.subscription_url)
     end
   end
 
   describe "#breadcrumbs" do
     it "returns a nested hash of the breadcrumbs" do
-      email_signup = EmailAlertSignup.new(content_item)
-
+      email_signup = EmailAlertSignup.new(signup_page)
       expected_breadcrumbs = {
         title: "Employment",
         link: "https://www.gov.uk/government/policies/employment",


### PR DESCRIPTION
Previous merge was green on CI prior to a set of govuk-content-schema
changes going in. As it wasn't rebuilt after that change, these updates are
required to fix master. In the process of doing so, this commit removes
some tests of questionable value.