### PR TITLE
Update schemas to use the new subscriber_list details format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'plek', '~> 1.11.0'
 gem 'airbrake', '~> 4.1.0'
 gem 'decent_exposure', '~> 2.3.2'
 
-gem 'gds-api-adapters', '~> 20.1.1'
+gem 'gds-api-adapters', '~> 29.4.0'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,11 +81,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (20.1.2)
+    gds-api-adapters (29.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gherkin (2.12.2)
@@ -134,7 +134,7 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -240,7 +240,7 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.4.2)
   decent_exposure (~> 2.3.2)
-  gds-api-adapters (~> 20.1.1)
+  gds-api-adapters (~> 29.4.0)
   govuk-content-schema-test-helpers (~> 1.0.2)
   govuk_frontend_toolkit (~> 3.1.0)
   launchy

--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -49,28 +49,25 @@ private
   attr_reader :signup_page, :base_path
 
   def subscription_params
-    {
-      title: govdelivery_title.present? ? govdelivery_title : title,
-      tags: construct_tags_payload_for_alert_api,
-      links: construct_links_payload_for_alert_api,
-    }.deep_stringify_keys
-  end
+    subscriber_list = signup_page.details.subscriber_list
 
-  def construct_tags_payload_for_alert_api
-    # FIXME: a (very) temporary conditional check - once govuk-schema changes
-    # are deployed for email_alert_signup content items, change the below to
-    # safely rely on signup_tags being present.
-    if signup_page.details.signup_tags.present?
-      signup_page.details.signup_tags.to_h
-    else
-      signup_page.details.tags.to_h
+    subscription_params = {
+      title: govdelivery_title.present? ? govdelivery_title : title
+    }
+
+    if subscriber_list.document_type.present?
+      subscription_params[:document_type] = subscriber_list.document_type
     end
-  end
 
-  def construct_links_payload_for_alert_api
-    email_alert_type = signup_page.details.email_alert_type
-    parent_id = signup_page.links.parent.first.content_id
-    { email_alert_type => [parent_id] }
+    if subscriber_list.tags.present?
+      subscription_params[:tags] = subscriber_list.tags.to_h
+    end
+
+    if subscriber_list.links.present?
+      subscription_params[:links] = subscriber_list.links.to_h
+    end
+
+    subscription_params.deep_stringify_keys
   end
 
   def raw_breadcrumbs

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -1,9 +1,9 @@
 Given(/^a content item exists for an email alert signup page$/) do
-  content_item = govuk_content_schema_example("email_alert_signup")
+  content_item = govuk_content_schema_example("policy_email_alert_signup")
   @base_path = content_item["base_path"]
-  @tags = content_item["details"]["signup_tags"]
   @alert_type = content_item["details"]["email_alert_type"]
   @parent_id = content_item["links"]["parent"].first["content_id"]
+  @tags = content_item["details"]["subscriber_list"]["tags"]
   content_store_has_item(@base_path, content_item.to_json)
 end
 
@@ -21,7 +21,6 @@ When(/^I sign up to the email alerts$/) do
   @subscription_params = {
     "title" => "Employment policy",
     "tags" => @tags,
-    "links" => { @alert_type => [@parent_id] }
   }
   allow(EmailAlertFrontend.services(:email_alert_api)).
     to receive(:find_or_create_subscriber_list).


### PR DESCRIPTION
**We will merge the pull requests ourselves in the Publishing Platform team when everyone's happy.**

https://trello.com/c/oqGCU2XP/525-add-email-signup-links-to-travel-advice-on-frontend

We've been migrating travel advice over to use the new email-alert-frontend workflow rather than the old pagewatch workflow.

Whilst doing this work, we noticed that policy publisher passes through subscriber list information as implicit links on the signup content item (which should really be reserved for more general associations with other content items). After talking with @tijmenb and @mobaig in Finding Things we concluded that the details hash is the best place for that information.

Therefore, this work consists of four parts:

1) An update to travel advice publisher to create the new email alert signup forms
https://github.com/alphagov/travel-advice-publisher/pull/123

2) An update to policy publisher to change the structure of the subscriber list data
https://github.com/alphagov/policy-publisher/pull/129

3) An update the email-alert-frontend to support searching by document_type (required for travel index)
https://github.com/alphagov/email-alert-frontend/pull/25

4) An update to the content schemas to reflect the new subscriber list data structure
https://github.com/alphagov/govuk-content-schemas/pull/261

We'd like to merge and deploy all four pull requests at (roughly) the same time. Please could comment as usual and state whether you are happy for the pull requests to be merged.