### PR TITLE
Add meta descriptions

### DIFF
--- a/app/views/email_alert_signups/new.html.erb
+++ b/app/views/email_alert_signups/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, email_alert_signup.title %>
+<% content_for :meta_description, email_alert_signup.summary %>
 
 <% if email_alert_signup.government? %>
   <%= render partial: 'govuk_component/government_navigation', locals: { active: email_alert_signup.government_content_section } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,9 @@
     <title><%= yield :title %> - GOV.UK</title>
     <%= stylesheet_link_tag "application" %>
     <%= csrf_meta_tags %>
+    <% if content_for(:meta_description).present? %>
+      <meta name="description" content="<%= content_for(:meta_description) %>" />
+    <% end %>
     <%= yield :head %>
   </head>
 


### PR DESCRIPTION
This commit adds meta description tags to all email alert pages, the contents of which are set to the summary associated with the relevant alert. This adds descriptions to external search engine results when the pages are re-indexed.

Trello: https://trello.com/c/bbAwFAQ1/108-add-meta-descriptions-to-pages-missing-them