### PR TITLE
Remove non-working breadcrumb code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rails', '4.2.5.2'
-gem 'slimmer', '9.0.1'
+gem 'slimmer', '10.0.0'
 
 gem 'govuk_frontend_toolkit', '~> 3.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,13 +193,13 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
-    slimmer (9.0.1)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     sprockets (3.5.2)
@@ -250,7 +250,7 @@ DEPENDENCIES
   rails (= 4.2.5.2)
   rspec-rails (~> 3.2.1)
   sass-rails (~> 5.0)
-  slimmer (= 9.0.1)
+  slimmer (= 10.0.0)
   timecop (~> 0.7.1)
   uglifier (>= 2.7.2)
   unicorn

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A consistent frontend for displaying email alert signup pages.
 
 - Email Alert Signup: a page displaying the title of what the User is signing up to
 - Tags: A key and array value pair which when are used by the [Email Alert API](https://github.com/alphagov/email-alert-api) to forward the user onto the govdelivery signup URL
-- Breadcrumbs: array of hashes containing a `link` and `title` used to generate breadcrumb navigation for the Email Alert Signup page's parent page(s).
 
 ## Dependences
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
   include Slimmer::SharedTemplates
 
   # Prevent CSRF attacks by raising an exception.

--- a/app/controllers/email_alert_signups_controller.rb
+++ b/app/controllers/email_alert_signups_controller.rb
@@ -2,7 +2,6 @@ class EmailAlertSignupsController < ApplicationController
   protect_from_forgery except: [:create]
 
   def new
-    set_slimmer_dummy_artefact(email_alert_signup.breadcrumbs)
   end
 
   def create

--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -29,14 +29,6 @@ class EmailAlertSignup
       .find_or_create_subscriber_list(subscription_params)
   end
 
-  def breadcrumbs
-    return {} if raw_breadcrumbs.blank?
-
-    raw_breadcrumbs.reverse.reduce { |memo, crumb|
-      crumb.merge(parent: memo)
-    }
-  end
-
   def government?
     base_path.starts_with?("/government")
   end
@@ -68,12 +60,6 @@ private
     end
 
     subscription_params.deep_stringify_keys
-  end
-
-  def raw_breadcrumbs
-    if signup_page.details.breadcrumbs
-      signup_page.details.breadcrumbs.map(&method(:openstruct_to_hash))
-    end
   end
 
   def openstruct_to_hash(openstruct)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -32,5 +32,9 @@ require 'slimmer/test'
 ActionController::Base.allow_rescue = false
 
 require_relative '../../lib/govuk_content_schema_examples'
-require 'slimmer/test_helpers/shared_templates'
-include Slimmer::TestHelpers::SharedTemplates
+require 'slimmer/test_helpers/govuk_components'
+include Slimmer::TestHelpers::GovukComponents
+
+Before do
+  stub_shared_component_locales
+end

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -125,18 +125,4 @@ describe EmailAlertSignup do
       expect("http://foo").to eq(email_signup.subscription_url)
     end
   end
-
-  describe "#breadcrumbs" do
-    let(:signup_page) { mock_response(policy_item) }
-
-    it "returns a nested hash of the breadcrumbs" do
-      email_signup = EmailAlertSignup.new(signup_page)
-      expected_breadcrumbs = {
-        title: "Employment",
-        link: "https://www.gov.uk/government/policies/employment",
-      }
-
-      expect(email_signup.breadcrumbs).to eq(expected_breadcrumbs)
-    end
-  end
 end


### PR DESCRIPTION
The breadcrumbs in this application seem to never have worked. The code constructs a hash and passes this into slimmer as a "dummy artefact". But this only works for pages that are rendered with the `core_layout ` layout from static, and these pages are rendered with `core_layout`.

The first commit removes the code, since it's not working. It allows us to upgrade to a new slimmer version in the second.

https://trello.com/c/7wohUbyo
