### PR TITLE
Upgrade gds-api-adapters from 29.4.0 to 40.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'plek', '~> 1.11.0'
 gem 'airbrake', '~> 4.1.0'
 gem 'decent_exposure', '~> 2.3.2'
 
-gem 'gds-api-adapters', '~> 29.4.0'
+gem 'gds-api-adapters', '~> 40.1'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,17 +77,17 @@ GEM
     debug_inspector (0.0.2)
     decent_exposure (2.3.2)
     diff-lcs (1.2.5)
-    domain_name (0.5.24)
+    domain_name (0.5.20170223)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (29.4.0)
+    gds-api-adapters (40.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     gherkin (2.12.2)
       multi_json (~> 1.3)
     globalid (0.3.6)
@@ -97,7 +97,7 @@ GEM
     govuk_frontend_toolkit (3.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
@@ -114,12 +114,12 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.3)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
     multi_test (0.1.2)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     null_logger (0.0.1)
@@ -133,8 +133,8 @@ GEM
       pry (~> 0.10)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
-    rack-cache (1.6.1)
+    rack (1.6.5)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -164,10 +164,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
     rake (10.5.0)
-    rest-client (1.8.0)
+    rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.2.3)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.1)
@@ -220,7 +220,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -240,7 +240,7 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.4.2)
   decent_exposure (~> 2.3.2)
-  gds-api-adapters (~> 29.4.0)
+  gds-api-adapters (~> 40.1)
   govuk-content-schema-test-helpers (~> 1.0.2)
   govuk_frontend_toolkit (~> 3.1.0)
   launchy
@@ -257,4 +257,4 @@ DEPENDENCIES
   webmock (~> 1.20.4)
 
 BUNDLED WITH
-   1.11.2
+   1.14.5

--- a/app/controllers/email_alert_signups_controller.rb
+++ b/app/controllers/email_alert_signups_controller.rb
@@ -19,7 +19,7 @@ private
   end
 
   def email_alert_signup
-    @email_alert_signup ||= EmailAlertSignup.new(content_store.content_item!("/#{params[:base_path]}"))
+    @email_alert_signup ||= EmailAlertSignup.new(content_store.content_item("/#{params[:base_path]}"))
   end
   helper_method :email_alert_signup
 end

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -12,14 +12,16 @@ describe EmailAlertSignup do
   let(:travel_index_item) { govuk_content_schema_example('travel_advice_index_email_alert_signup') }
   let(:travel_country_item) { govuk_content_schema_example('travel_advice_country_email_alert_signup') }
 
-  let(:mock_subscriber_list) { double(subscriber_list: double(subscription_url: 'http://foo')) }
+  let(:mock_subscriber_list) do
+    mock_response(subscriber_list: { subscription_url: "http://foo" })
+  end
 
   def mock_response(body)
     GdsApi::Response.new(double("net http response",
       code: 200,
       body: body.to_json,
       headers: {},
-    )).to_ostruct
+    ))
   end
 
   before do


### PR DESCRIPTION
Need the latest version of the adapters in order to use the
govuk_taxonomy_helpers gem and its breadcrumb functionality.

https://trello.com/c/lPlSbZnX/166-3-build-3-types-of-sign-up-pages-backend