### PR TITLE
Add email volume estimates to signup confirm page

### DIFF
--- a/app/controllers/taxonomy_signups_controller.rb
+++ b/app/controllers/taxonomy_signups_controller.rb
@@ -10,6 +10,7 @@ class TaxonomySignupsController < ApplicationController
     redirect_to '/' and return unless valid_query_param?
 
     load_taxon
+    load_estimated_email_frequency
     load_breadcrumbs
   end
 
@@ -47,5 +48,9 @@ private
       .taxon_breadcrumbs[:breadcrumbs]
     @breadcrumbs.last.merge!(is_current_page: false, url: @taxon['base_path'])
     @breadcrumbs << { title: 'Get email alerts', is_current_page: true }
+  end
+
+  def load_estimated_email_frequency
+    @estimated_email_frequency = WeeklyEmailVolume.new(@taxon).estimate
   end
 end

--- a/app/models/weekly_email_volume.rb
+++ b/app/models/weekly_email_volume.rb
@@ -1,0 +1,35 @@
+class WeeklyEmailVolume
+  HIGH = '40-60'.freeze
+  MEDIUM = '0-20'.freeze
+  LOW = '0-5'.freeze
+
+  def initialize(taxon)
+    @taxon = taxon
+  end
+
+  def estimate
+    parent_taxon = extract_parent_from(@taxon)
+
+    # Is at the top of the taxonomy
+    return HIGH if parent_taxon.blank?
+
+    # Is a 2nd level taxon
+    grandparent_taxon = extract_parent_from(
+      fetch_content_item(parent_taxon.fetch('base_path'))
+    )
+    return MEDIUM if grandparent_taxon.blank?
+
+    # Is a 3rd level taxon or below
+    return LOW
+  end
+
+private
+
+  def extract_parent_from(content_item)
+    Array(content_item.dig('links', 'parent_taxons')).first
+  end
+
+  def fetch_content_item(base_path)
+    EmailAlertFrontend.services(:content_store).content_item(base_path)
+  end
+end

--- a/app/views/taxonomy_signups/confirm.html.erb
+++ b/app/views/taxonomy_signups/confirm.html.erb
@@ -15,7 +15,7 @@
   </p>
 
   <p>
-    This might be from [number] updates a week.
+    This might be from <%= @estimated_email_frequency %> updates a week.
   </p>
 
   <p>

--- a/features/step_definitions/taxonomy_email_alert_steps.rb
+++ b/features/step_definitions/taxonomy_email_alert_steps.rb
@@ -34,6 +34,10 @@ Given(/^a taxon in the middle of the taxonomy$/) do
   }
 
   content_store_has_item(@taxon[:base_path], @taxon)
+  content_store_has_item(
+    @taxon.dig(:links, :parent_taxons).first[:base_path],
+    @taxon.dig(:links, :parent_taxons).first
+  )
 end
 
 When(/^i visit its signup page$/) do
@@ -53,6 +57,8 @@ end
 
 Then(/^i see a confirmation page$/) do
   expect(page).to have_content("You can set your preferences once you've signed up.")
+  # Based on the position of this taxon in the taxonomy:
+  expect(page).to have_content("This might be from 0-20 updates a week")
   expect(page).to have_button('Sign up now')
 end
 

--- a/spec/models/weekly_email_volume_spec.rb
+++ b/spec/models/weekly_email_volume_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe WeeklyEmailVolume do
+  include GdsApi::TestHelpers::ContentStore
+
+  describe "#estimate" do
+    let(:top_taxon) do
+      { base_path: '/top', links: { parent_taxons: [] } }.deep_stringify_keys
+    end
+
+    let(:second_taxon) do
+      {
+        base_path: '/second', links: { parent_taxons: [ { base_path: '/top' } ] }
+      }.deep_stringify_keys
+    end
+
+    context 'given a top level taxon' do
+      it 'returns a HIGH range' do
+        expect(WeeklyEmailVolume.new(top_taxon).estimate).to eq WeeklyEmailVolume::HIGH
+      end
+    end
+
+    context 'given a 2nd level taxon' do
+
+      before do
+        content_store_has_item(top_taxon['base_path'], top_taxon)
+      end
+
+      it 'returns a MEDIUM range' do
+        expect(WeeklyEmailVolume.new(second_taxon).estimate).to eq WeeklyEmailVolume::MEDIUM
+      end
+    end
+
+    context 'given a 3rd level taxon' do
+      let(:third_taxon) do
+        {
+          base_path: '/third', links: { parent_taxons: [ { base_path: '/second' } ] }
+        }.deep_stringify_keys
+      end
+
+      before do
+        content_store_has_item(second_taxon['base_path'], second_taxon)
+      end
+
+      it 'returns a LOW range' do
+        expect(WeeklyEmailVolume.new(third_taxon).estimate).to eq WeeklyEmailVolume::LOW
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add very rough guesses about the weekly volume of email a user can
expect depending on which level of the taxonomy they sign up to. These
figures are based on analysis of historical email volume.

Note that the original requirement here was to treat 2nd level taxons that are also bottom level taxons as being LOW frequency - I've made a decision here to simplify the implementation because of time constraints. This is unlikely to be problematic given these numbers are very rough estimates. Discussed and agreed with Rob Rankin.

https://trello.com/c/lPlSbZnX/166-3-build-3-types-of-sign-up-pages-backend