### PR TITLE
Exclude taxonomy signup action from request forgery protection

### DIFF
--- a/app/controllers/taxonomy_signups_controller.rb
+++ b/app/controllers/taxonomy_signups_controller.rb
@@ -1,4 +1,6 @@
 class TaxonomySignupsController < ApplicationController
+  protect_from_forgery except: [:create]
+
   def new
     redirect_to '/' and return unless valid_query_param?
 


### PR DESCRIPTION
CSRF protection on this action leads to InvalidAuthenticityToken
exceptions, seemingly because of caching on the confirm page. Skip
protection so that the user can be taken to GovDelivery to manage their
subscription.

https://trello.com/c/lPlSbZnX/166-3-build-3-types-of-sign-up-pages-backend