### PR TITLE
Validate user input more thoroughly for taxonomy signups

### DIFF
--- a/app/controllers/taxonomy_signups_controller.rb
+++ b/app/controllers/taxonomy_signups_controller.rb
@@ -2,6 +2,7 @@ class TaxonomySignupsController < ApplicationController
   protect_from_forgery except: [:create]
   before_action :require_taxon_param
   before_action :load_taxon
+  before_action :validate_taxon_document_type
 
   def new
     load_breadcrumbs
@@ -44,6 +45,10 @@ private
     @taxon ||= EmailAlertFrontend
       .services(:content_store)
       .content_item(taxon_path)
+  end
+
+  def validate_taxon_document_type
+    redirect_to '/' and return unless @taxon['document_type'] == 'taxon'
   end
 
   def load_breadcrumbs

--- a/app/controllers/taxonomy_signups_controller.rb
+++ b/app/controllers/taxonomy_signups_controller.rb
@@ -29,7 +29,9 @@ private
   end
 
   def valid_taxon_param?
-    taxon_path.present?
+    taxon_path.to_s.starts_with?('/') && URI.parse(taxon_path).relative?
+  rescue URI::InvalidURIError
+    false
   end
 
   def taxon_path

--- a/app/controllers/taxonomy_signups_controller.rb
+++ b/app/controllers/taxonomy_signups_controller.rb
@@ -1,23 +1,18 @@
 class TaxonomySignupsController < ApplicationController
   protect_from_forgery except: [:create]
+  before_action :require_taxon_param
+  before_action :load_taxon
 
   def new
-    redirect_to '/' and return unless valid_query_param?
-
-    load_taxon
     load_breadcrumbs
   end
 
   def confirm
-    redirect_to '/' and return unless valid_query_param?
-
-    load_taxon
     load_estimated_email_frequency
     load_breadcrumbs
   end
 
   def create
-    load_taxon
     signup = TaxonomySignup.new(@taxon.to_h)
 
     if signup.save
@@ -29,7 +24,11 @@ class TaxonomySignupsController < ApplicationController
 
 private
 
-  def valid_query_param?
+  def require_taxon_param
+    redirect_to '/' and return unless valid_taxon_param?
+  end
+
+  def valid_taxon_param?
     taxon_path.present?
   end
 

--- a/features/step_definitions/taxonomy_email_alert_steps.rb
+++ b/features/step_definitions/taxonomy_email_alert_steps.rb
@@ -4,6 +4,7 @@ Given(/^a taxon in the middle of the taxonomy$/) do
     base_path: '/education/further-education',
     title: 'Further education',
     description: 'Further education content',
+    document_type: 'taxon',
     links: {
       parent_taxons: [
         {

--- a/spec/controllers/taxonomy_signups_controller_spec.rb
+++ b/spec/controllers/taxonomy_signups_controller_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe TaxonomySignupsController do
   include GdsApi::TestHelpers::ContentStore
 
-  describe "GET new" do
-    it 'redirects to root unless valid query param provided' do
-      get :new, bad_param: '/education/some-rando-item'
+  shared_examples 'handles bad input data correctly' do
+    it 'redirects to root if topic param is missing' do
+      make_request(bad_param: '/education/some-rando-item')
 
       expect(response.status).to eq 302
       expect(response.location).to eq 'http://test.host/'
@@ -13,9 +13,33 @@ RSpec.describe TaxonomySignupsController do
 
     it 'errors if no taxon found' do
       content_store_does_not_have_item('/education/some-rando-item')
-      get :new, topic: '/education/some-rando-item'
+      make_request(topic: '/education/some-rando-item')
 
       expect(response.status).to eq 404
     end
+  end
+
+  describe "#new" do
+    def make_request(params)
+      get :new, params
+    end
+
+    it_behaves_like 'handles bad input data correctly'
+  end
+
+  describe "#confirm" do
+    def make_request(params)
+      get :confirm, params
+    end
+
+    it_behaves_like 'handles bad input data correctly'
+  end
+
+  describe "#create" do
+    def make_request(params)
+      post :create, params
+    end
+
+    it_behaves_like 'handles bad input data correctly'
   end
 end

--- a/spec/controllers/taxonomy_signups_controller_spec.rb
+++ b/spec/controllers/taxonomy_signups_controller_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe TaxonomySignupsController do
 
       expect(response.status).to eq 404
     end
+
+    it 'redirects to root unless the content item is a taxon' do
+      content_store_has_item('/cma-cases', document_type: 'finder')
+      make_request(topic: '/cma-cases')
+
+      expect(response.status).to eq 302
+      expect(response.location).to eq 'http://test.host/'
+    end
   end
 
   describe "#new" do

--- a/spec/controllers/taxonomy_signups_controller_spec.rb
+++ b/spec/controllers/taxonomy_signups_controller_spec.rb
@@ -11,6 +11,20 @@ RSpec.describe TaxonomySignupsController do
       expect(response.location).to eq 'http://test.host/'
     end
 
+    it "redirects to root if topic param isn't a valid path" do
+      get :new, topic: '/with unencoded spaces'
+
+      expect(response.status).to eq 302
+      expect(response.location).to eq 'http://test.host/'
+    end
+
+    it "redirects to root if topic param isn't interpreted as a string" do
+      get :new, topic: ['/a']
+
+      expect(response.status).to eq 302
+      expect(response.location).to eq 'http://test.host/'
+    end
+
     it 'errors if no taxon found' do
       content_store_does_not_have_item('/education/some-rando-item')
       make_request(topic: '/education/some-rando-item')


### PR DESCRIPTION
This makes the existing checks more consistent, and adds a couple of new ones. We had some [requests over the weekend with unexpected param values](https://errbit.publishing.service.gov.uk/apps/5501a9da0da115b6b8004b79/problems/58e9474665786327ddc80b00) and it's better to not return an error response if we can avoid it.

I considered also adding a check for the [content store response being 400](https://errbit.publishing.service.gov.uk/apps/5501a9da0da115b6b8004b79/problems/58e9474765786327ed000b00) but wasn't sure if that's expected behaviour - maybe that should be fixed in content store?