### PR TITLE
Revert "Collapse taxonomy signup breadcrumbs on mobile"

### DIFF
--- a/app/views/taxonomy_signups/confirm.html.erb
+++ b/app/views/taxonomy_signups/confirm.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @taxon['title'] %>
 
-<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs, collapse_on_mobile: true %>
+<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
 
 <div class='grid-row'>
 <div class='email-signup column-two-thirds'>

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @taxon['title'] %>
 
-<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs, collapse_on_mobile: true %>
+<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
 
 <div class='grid-row'>
 <div class='column-two-thirds'>


### PR DESCRIPTION
This reverts commit 21a1c312332167c4ed714e4f2d2d1b7750aa5d57.

This reverts that change that leaves the link to the parent of the page the
user come in from instead of the page the user come in from.

Correct setting `is_parent_page` should get this to work as expected:
https://github.com/alphagov/static/blob/85b60d08fa2be3abf68fec3d6c9bc240d6d888a5/app/views/govuk_component/breadcrumbs.raw.html.erb#L18