### PR TITLE
Prevent search indexes indexing email signup pages on search

### DIFF
--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @taxon['title'] %>
 <% content_for :head do %>
-  <meta NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+  <meta name="robots" content="noindex, nofollow">
 <% end %>
 <%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
 

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, @taxon['title'] %>
-
+<% content_for :head do %>
+  <meta NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<% end %>
 <%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
 
 <div class='grid-row'>


### PR DESCRIPTION
Added meta tag to stop email alert pages from being indexed by search engines.

Trello: https://trello.com/c/s7JviEzz/131-prevent-search-indexes-indexing-email-signup-pages-on-search