### PR TITLE
Support subscriptions to associated taxons

### DIFF
--- a/app/models/taxonomy_signup.rb
+++ b/app/models/taxonomy_signup.rb
@@ -22,13 +22,17 @@ private
 
   def subscription_params
     {
-      'title' => taxon['title'],
+      'title' => title,
       'links' => {
         # 'taxon_tree' is the key used in email-alert-service for
         # notifications, so create a subscriber list with this key.
         'taxon_tree' => [taxon['content_id']]
       }
     }
+  end
+
+  def title
+    taxon['details'] && taxon['details']['internal_name'] || taxon['title']
   end
 end
 

--- a/spec/models/taxonomy_signup_spec.rb
+++ b/spec/models/taxonomy_signup_spec.rb
@@ -43,6 +43,30 @@ RSpec.describe TaxonomySignup do
         expect(signup.subscription_management_url).to eq nil
       end
     end
+
+    context 'when the taxon has an internal_name' do
+      let(:fake_taxon){
+        {
+          'title' => 'Birth, death and marriage abroad',
+          'content_id' => 'foo-id',
+          'details' => {
+            'internal_name' => 'Birth, death and marriage abroad (India)'
+          }
+        }
+      }
+
+      it 'creates the subscription using the internal name' do
+        signup = TaxonomySignup.new(fake_taxon)
+
+        expect(signup.save).to be
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with(
+            'title' => 'Birth, death and marriage abroad (India)',
+            'links' => { 'taxon_tree' => ['foo-id'] }
+          )
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Associated taxons (those that are included within another taxon e.g. `/world/birth-death-and-marriage-abroad` that is included in all country taxons) are currently causing errors when users try to subscribe to them.

This is because, whilst they get a different slug and content id, their title within the content item stays the same. Govdelivery currently enforces a uniqueness constraint on subscription names and we use the content item title for this purpose.

Consequently, when a user tries to subscribe to an associated taxon it will fail if that title has already been used. Ideally, this constraint would be removed at Govdelivery as it seems to serve no purpose given that the subscription topics already have a unique ID there. As we are unable to make this happen currently this commit favours the taxon `'details' => {'internal_name' => <title>}` if it is present.

[Trello](https://trello.com/c/VSVow1r6/78-investigate-email-alert-frontend-errors-for-some-taxonomy-subscriptions)