### PR TITLE
Update govuk-content-schemas-test-helpers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     gherkin (4.1.3)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    govuk-content-schema-test-helpers (1.4.0)
+    govuk-content-schema-test-helpers (1.5.0)
       json-schema (~> 2.5.1)
     govuk_app_config (0.2.0)
       sentry-raven (~> 2.6.3)
@@ -288,4 +288,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4


### PR DESCRIPTION
To try avoid the build breaking when
https://github.com/alphagov/govuk-content-schemas/pull/634
is merged