### PR TITLE
Enable Heroku review apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read(".ruby-version").strip
+
 gem 'rails', '5.1.3'
 gem 'slimmer', '~> 11.0'
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: GOVUK_ASSET_ROOT=https://${HEROKU_APP_NAME}.herokuapp.com bin/rails server -p $PORT -e $RAILS_ENV

--- a/app.json
+++ b/app.json
@@ -1,0 +1,37 @@
+{
+  "name": "Email Alert Frontend",
+  "repository": "https://github.com/alphagov/email-alert-frontend",
+  "env": {
+    "GOVUK_APP_DOMAIN": {
+      "value": "www.gov.uk"
+    },
+    "GOVUK_ASSET_ROOT": {
+      "value": "https://email-alert-frontend.herokuapp.com"
+    },
+    "GOVUK_WEBSITE_ROOT": {
+      "value": "https://www.gov.uk"
+    },
+    "PLEK_SERVICE_CONTENT_STORE_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_STATIC_URI": {
+      "value": "assets.digital.cabinet-office.gov.uk"
+    },
+    "RAILS_SERVE_STATIC_ASSETS": {
+      "value": "yes"
+    },
+    "SECRET_KEY_BASE": {
+      "generator": "secret"
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    }
+  },
+  "image": "heroku/ruby",
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "addons": []
+}


### PR DESCRIPTION
* Heroku needs to read ruby version from Gemfile
* https://devcenter.heroku.com/articles/github-integration-review-apps

Master automatically deploys to:
http://email-alert-frontend.herokuapp.com/

PR review apps will be available at:
http://email-alert-frontend-pr-XXX.herokuapp.com/