### PR TITLE
[do not merge] Consolidate finder-frontend email signups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,5 @@ group :test do
   gem 'launchy'
   gem 'webmock', '~> 3.0'
   gem 'timecop', '~> 0.9.1'
-  gem 'govuk-content-schema-test-helpers', '~> 1.4'
+  gem 'govuk-content-schema-test-helpers', '~> 1.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,7 +270,7 @@ DEPENDENCIES
   cucumber-rails (~> 1.5)
   decent_exposure (~> 3.0)
   gds-api-adapters (~> 47.9)
-  govuk-content-schema-test-helpers (~> 1.4)
+  govuk-content-schema-test-helpers (~> 1.5)
   govuk_app_config (~> 0.2.0)
   govuk_elements_rails (~> 3.1)
   govuk_frontend_toolkit (~> 7.0)

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -1,0 +1,68 @@
+require 'email_alert_signup_api'
+require 'gds_api/helpers'
+
+class EmailAlertSubscriptionsController < ApplicationController
+  include GdsApi::Helpers
+  protect_from_forgery except: :create
+
+  def new
+    @signup = signup_presenter
+  end
+
+  def create
+    if valid_choices?
+      redirect_to email_alert_signup_api.signup_url
+    else
+      @signup = signup_presenter
+      @error_message = "Please choose an email alert"
+      render action: :new
+    end
+  end
+
+private
+
+  def valid_choices?
+    available_choices.blank? || chosen_options.present?
+  end
+
+  def signup_presenter
+    @signup_presenter ||= SignupPresenter.new(content)
+  end
+
+  def content
+    @content ||= content_store.content_item!(request.path)
+  end
+
+  def finder
+    FinderPresenter.new(content_store.content_item!(finder_base_path))
+  end
+
+  def finder_format
+    finder.filter.document_type
+  end
+
+  def available_choices
+    content.details.email_signup_choice
+  end
+
+  def email_alert_signup_api
+    EmailAlertSignupAPI.new(
+      email_alert_api: email_alert_api,
+      attributes: email_signup_attributes,
+      subscription_list_title_prefix: content.details.subscription_list_title_prefix,
+      available_choices: available_choices,
+      filter_key: content.details.email_filter_by,
+    )
+  end
+
+  def chosen_options
+    params["filter"]
+  end
+
+  def email_signup_attributes
+    {
+      "format" => [finder_format],
+      "filter" => chosen_options,
+    }
+  end
+end

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -26,15 +26,19 @@ private
   end
 
   def signup_presenter
-    @signup_presenter ||= SignupPresenter.new(content)
+    @signup_presenter ||= SignupPresenter.new(signup_content_item)
   end
 
-  def content
-    @content ||= content_store.content_item!(request.path)
+  def signup_content_item
+    @signup_content_item ||= content_store.content_item(request.path)
   end
 
-  def finder
-    FinderPresenter.new(content_store.content_item!(finder_base_path))
+  def finder_content_item
+    @finder_content_item ||= content_store.content_item(finder_base_path)
+  end
+
+  def finder_base_path
+    "/#{params.fetch(:slug)}"
   end
 
   def finder_format
@@ -42,16 +46,16 @@ private
   end
 
   def available_choices
-    content.details.email_signup_choice
+    signup_content_item.details.email_signup_choice
   end
 
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
       email_alert_api: email_alert_api,
       attributes: email_signup_attributes,
-      subscription_list_title_prefix: content.details.subscription_list_title_prefix,
+      subscription_list_title_prefix: signup_content_item.details.subscription_list_title_prefix,
       available_choices: available_choices,
-      filter_key: content.details.email_filter_by,
+      filter_key: signup_content_item.details.email_filter_by,
     )
   end
 

--- a/app/controllers/email_alert_subscriptions_controller.rb
+++ b/app/controllers/email_alert_subscriptions_controller.rb
@@ -33,6 +33,10 @@ private
     @signup_content_item ||= content_store.content_item(request.path)
   end
 
+  def details
+    signup_content_item[:details] || {}
+  end
+
   def finder_content_item
     @finder_content_item ||= content_store.content_item(finder_base_path)
   end
@@ -42,20 +46,20 @@ private
   end
 
   def finder_format
-    finder.filter.document_type
+    finder_content_item.dig(:filter, :document_type)
   end
 
   def available_choices
-    signup_content_item.details.email_signup_choice
+    details[:email_signup_choice]
   end
 
   def email_alert_signup_api
     EmailAlertSignupAPI.new(
       email_alert_api: email_alert_api,
       attributes: email_signup_attributes,
-      subscription_list_title_prefix: signup_content_item.details.subscription_list_title_prefix,
+      subscription_list_title_prefix: details[:subscription_list_title_prefix],
       available_choices: available_choices,
-      filter_key: signup_content_item.details.email_filter_by,
+      filter_key: details[:email_filter_by],
     )
   end
 

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -1,0 +1,49 @@
+class SignupPresenter
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def page_title
+    "#{name} emails"
+  end
+
+  def name
+    content_item.title
+  end
+
+  def body
+    content_item.description
+  end
+
+  def beta?
+    content_item.details.beta
+  end
+
+  def choices?
+    choice_data.present?
+  end
+
+  def choices
+    choice_data
+  end
+
+  def choice_name(choice)
+    choice_data.copy[choice]["radio_button_name"]
+  end
+
+  def choice_body(choice)
+    choice_data.copy[choice]["body"]
+  end
+
+  def target
+    "#"
+  end
+
+private
+
+  def choice_data
+    content_item.details["email_signup_choice"]
+  end
+end

--- a/app/presenters/signup_presenter.rb
+++ b/app/presenters/signup_presenter.rb
@@ -10,15 +10,15 @@ class SignupPresenter
   end
 
   def name
-    content_item.title
+    content_item[:title]
   end
 
   def body
-    content_item.description
+    content_item[:description]
   end
 
   def beta?
-    content_item.details.beta
+    content_item.dig(:details, :beta)
   end
 
   def choices?
@@ -30,11 +30,11 @@ class SignupPresenter
   end
 
   def choice_name(choice)
-    choice_data.copy[choice]["radio_button_name"]
+    choice_data.clone.dig(choice, :radio_button_name)
   end
 
   def choice_body(choice)
-    choice_data.copy[choice]["body"]
+    choice_data.clone.dig(choice, :body)
   end
 
   def target
@@ -44,6 +44,6 @@ class SignupPresenter
 private
 
   def choice_data
-    content_item.details["email_signup_choice"]
+    content_item.dig(:details, :email_signup_choice)
   end
 end

--- a/app/views/email_alert_subscriptions/_email_alert_subscription_meta.html.erb
+++ b/app/views/email_alert_subscriptions/_email_alert_subscription_meta.html.erb
@@ -1,0 +1,3 @@
+<% if email_alert_subscription.body %>
+  <meta name="description" content="<%= email_alert_subscription.body %>">
+<% end %>

--- a/app/views/email_alert_subscriptions/new.html.erb
+++ b/app/views/email_alert_subscriptions/new.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, @signup.page_title %>
+<% content_for :head do %>
+  <%= render 'email_alert_subscription_meta', email_alert_subscription: @signup %>
+<% end %>
+
+<% if @signup.beta? %>
+  <%= render partial: 'govuk_component/beta_label' %>
+<% end %>
+<header>
+ <div class="title-and-metadata">
+    <%= render partial: 'govuk_component/title', locals: {
+      title: @signup.name,
+      context: "Email alert subscription"
+    } %>
+  </div>
+</header>
+
+<div class="outer-block">
+  <div class="signup-content">
+    <%= form_tag email_alert_subscriptions_path, class: 'signup-choices form' do %>
+      <% if @signup.choices? %>
+        <fieldset<%= ' class="invalid"'.html_safe if @error_message.present? %> aria-labelledby="fieldset-title">
+          <p id="fieldset-title">
+            Select the email alerts you need
+          </p>
+          <% @signup.choices.each do |choice| %>
+            <%= label_tag "filter_#{choice.key}", class: 'block-label' do %>
+              <%= check_box_tag "filter[]", choice.key, choice.prechecked, class: 'checkbox', id: "filter_#{choice.key}" %>
+              <%= choice.radio_button_name %>
+            <% end %>
+          <% end %>
+        </fieldset>
+        <% if @error_message.present? %>
+          <p class="validation-message"><%= @error_message %></p>
+        <% end %>
+      <% end %>
+
+      <p><%= @signup.body %></p>
+      <%= submit_tag 'Create subscription', class: "button" %>
+    <% end %>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
   get '/email-signup/confirm' => 'taxonomy_signups#confirm', as: :confirm_taxonomy_signup
   post '/email-signup' => 'taxonomy_signups#create'
 
+  get '/*slug/email-signup' => 'email_alert_subscriptions#new', as: :new_email_alert_subscriptions
+  post '/*slug/email-signup' => 'email_alert_subscriptions#create', as: :email_alert_subscriptions
+
   if Rails.env.test?
     get '/govdelivery-redirect', to: proc { [200, {}, ['']] }
   end

--- a/features/fixtures/cma_cases_signup_content_item.json
+++ b/features/fixtures/cma_cases_signup_content_item.json
@@ -1,0 +1,6 @@
+{
+  "details": {
+    "email_signup_choice": [],
+    "subscription_list_title_prefix": {}
+  }
+}

--- a/lib/email_alert_signup_api.rb
+++ b/lib/email_alert_signup_api.rb
@@ -1,0 +1,58 @@
+class EmailAlertSignupAPI
+  def initialize(dependencies = {})
+    @email_alert_api = dependencies.fetch(:email_alert_api)
+    @attributes = dependencies.fetch(:attributes)
+    @subscription_list_title_prefix = dependencies.fetch(:subscription_list_title_prefix)
+    @available_choices = dependencies.fetch(:available_choices)
+    @filter_key = dependencies.fetch(:filter_key)
+    if attributes['filter'].blank? && !available_choices.blank?
+      raise ArgumentError, "User must choose at least one of the available options"
+    end
+  end
+
+  def signup_url
+    subscriber_list.subscription_url
+  end
+
+private
+
+  attr_reader :email_alert_api, :attributes, :subscription_list_title_prefix, :available_choices, :filter_key
+
+  def subscriber_list
+    response = email_alert_api.find_or_create_subscriber_list("tags" => massaged_attributes, "title" => title)
+    response.subscriber_list
+  end
+
+  def title
+    if available_choices.empty?
+      title = subscription_list_title_prefix.to_s
+    else
+      plural_or_single = if attributes.fetch("filter").length == 1
+                           "singular"
+                         else
+                           "plural"
+                         end
+      title = (subscription_list_title_prefix[plural_or_single].to_s + topic_names.to_sentence).humanize
+    end
+
+    title
+  end
+
+  def topic_names
+    attributes.fetch("filter").collect { |x| choice_hash_by_key(x).topic_name }
+  end
+
+  def choice_hash_by_key(key)
+    available_choices.select { |x| x.key == key }[0]
+  end
+
+  def massaged_attributes
+    massaged_attributes = attributes.dup
+    if available_choices.empty?
+      massaged_attributes.delete("filter")
+    else
+      massaged_attributes[@filter_key] = massaged_attributes.delete("filter")
+    end
+    massaged_attributes
+  end
+end

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/content_store'
+include GdsApi::TestHelpers::ContentStore
+include FixturesHelper
+
+describe EmailAlertSubscriptionsController, type: :controller do
+  include GovukContentSchemaExamples
+
+  describe 'GET #new' do
+    describe "finder email signup item doesn't exist" do
+      it 'returns a 404, rather than 5xx' do
+        content_store_does_not_have_item('/does-not-exist/email-signup')
+
+        get :new, params: { slug: 'does-not-exist' }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe 'POST "#create"' do
+    let(:alert_name) { double(:alert_name) }
+    let(:alert_identifier) { double(:alert_identifier) }
+    let(:delivery_api) { double(:delivery_api) }
+    let(:finder) { govuk_content_schema_example('policy_email_alert_signup').to_hash.merge(title: alert_name) }
+    let(:signup_finder) { cma_cases_signup_content_item }
+    let(:signup_api_wrapper) {
+      double(:signup_api_wrapper, signup_url: 'http://www.example.com')
+    }
+
+    before do
+      content_store_has_item('/cma-cases', finder)
+      content_store_has_item('/cma-cases/email-signup', signup_finder)
+      allow(controller).to receive(:email_alert_api).and_return(delivery_api)
+      allow(EmailAlertSignupAPI).to receive(:new).and_return(signup_api_wrapper)
+    end
+
+    it 'redirects to the correct email subscription url' do
+      post :create, params: { slug: 'cma-cases' }
+      expect(subject).to redirect_to('http://www.example.com')
+    end
+  end
+end

--- a/spec/controllers/email_alert_subscriptions_controller_spec.rb
+++ b/spec/controllers/email_alert_subscriptions_controller_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 require 'gds_api/test_helpers/content_store'
-include GdsApi::TestHelpers::ContentStore
-include FixturesHelper
 
 describe EmailAlertSubscriptionsController, type: :controller do
   include GovukContentSchemaExamples
+  include GdsApi::TestHelpers::ContentStore
+  include FixturesHelper
 
   describe 'GET #new' do
     describe "finder email signup item doesn't exist" do

--- a/spec/lib/email_alert_signup_api_spec.rb
+++ b/spec/lib/email_alert_signup_api_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+require 'email_alert_signup_api'
+
+describe EmailAlertSignupAPI do
+  let(:email_alert_api) { double(:email_alert_api) }
+  let(:attributes) {
+    {
+      "format" => "test-reports",
+      "filter" => %w(first second),
+    }
+  }
+  let(:available_choices) {
+    [
+      OpenStruct.new(
+        "key" => "first",
+        "radio_button_name" => "First thing",
+        "topic_name" => "first thing",
+        "prechecked" => false,
+      ),
+      OpenStruct.new(
+        "key" => "second",
+        "radio_button_name" => "Second thing",
+        "topic_name" => "second thing",
+        "prechecked" => false,
+      ),
+    ]
+  }
+  let(:subscription_list_title_prefix) {
+    {
+      "singular" => "Format with report type: ",
+      "plural" => "Format with report types: ",
+    }
+  }
+  let(:filter_key) { "alert_type" }
+  let(:subscription_url) { "http://www.example.org/list-id/signup" }
+  let(:mock_subscriber_list) { double(:mock_subscriber_list, subscription_url: subscription_url) }
+  let(:mock_response) { double(:mock_response, subscriber_list: mock_subscriber_list) }
+  subject(:signup_api_wrapper) {
+    EmailAlertSignupAPI.new(
+      email_alert_api: email_alert_api,
+      attributes: attributes,
+      available_choices: available_choices,
+      subscription_list_title_prefix: subscription_list_title_prefix,
+      filter_key: filter_key
+    )
+  }
+
+  before do
+    allow(email_alert_api).to receive(:find_or_create_subscriber_list).and_return(mock_response)
+  end
+
+  describe '#signup_url' do
+    it 'returns the url email-alert-api gives back' do
+      expect(signup_api_wrapper.signup_url).to eql subscription_url
+    end
+
+    context 'with multiple choices selected and a title prefix' do
+      it 'asks email-alert-api to find or create the subscriber list' do
+        signup_api_wrapper.signup_url
+
+        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+          "tags" => {
+            "format" => "test-reports",
+            "alert_type" => %w(first second),
+          },
+          "title" => "Format with report types: first thing and second thing",
+        )
+      end
+    end
+
+    context 'with one choice selected and a title prefix' do
+      let(:attributes) {
+        {
+          "format" => "test-reports",
+          "filter" => ["first"],
+        }
+      }
+      it 'asks email-alert-api to find or create the subscriber list' do
+        signup_api_wrapper.signup_url
+
+        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+          "tags" => {
+            "format" => "test-reports",
+            "alert_type" => ["first"],
+          },
+          "title" => "Format with report type: first thing",
+        )
+      end
+    end
+
+    context 'with no choice selected' do
+      let(:attributes) {
+        {
+          "format" => "test-reports",
+          "filter" => [],
+        }
+      }
+      it 'raises an error' do
+        expect { signup_api_wrapper.signup_url }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'without a title prefix' do
+      let(:subscription_list_title_prefix) {
+        {}
+      }
+      it 'asks email-alert-api to find or create the subscriber list' do
+        signup_api_wrapper.signup_url
+
+        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+          "tags" => {
+            "format" => "test-reports",
+            "alert_type" => %w(first second),
+          },
+          "title" => "First thing and second thing",
+        )
+      end
+    end
+
+    context 'no options available' do
+      let(:available_choices) { [] }
+      let(:attributes) {
+        {
+          "format" => "test-reports",
+        }
+      }
+      let(:filter_key) { nil }
+      let(:subscription_list_title_prefix) { "Format" }
+      it 'asks email-alert-api to find or create the subscriber list' do
+        signup_api_wrapper.signup_url
+
+        expect(email_alert_api).to have_received(:find_or_create_subscriber_list).with(
+          "tags" => {
+            "format" => "test-reports",
+          },
+          "title" => "Format",
+        )
+      end
+    end
+  end
+end

--- a/spec/presenters/signup_presenter_spec.rb
+++ b/spec/presenters/signup_presenter_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe SignupPresenter do
+  include FixturesHelper
+
+  let(:signup_finder) { cma_cases_signup_content_item }
+
+  subject do
+    described_class.new(
+      title: "title",
+      description: "description",
+      details: {
+        beta: true,
+        email_signup_choice: [
+          {
+            radio_button_name: "radio 0",
+            body: "body 0",
+          },
+          {
+            radio_button_name: "radio 1",
+            body: "body 1",
+          },
+        ]
+      }
+    )
+  end
+
+  it "has some attributes" do
+    expect(subject.page_title).to eq("title emails")
+    expect(subject.name).to eq("title")
+    expect(subject.body).to eq("description")
+    expect(subject.beta?).to eq(true)
+    expect(subject.choices?).to eq(true)
+    expect(subject.choices).to eq [
+      { radio_button_name: "radio 0", body: "body 0" },
+      { radio_button_name: "radio 1", body: "body 1" },
+    ]
+
+    expect(subject.choice_name(0)).to eq("radio 0")
+    expect(subject.choice_body(1)).to eq("body 1")
+    expect(subject.target).to eq("#")
+  end
+end

--- a/spec/support/fixtures_helper.rb
+++ b/spec/support/fixtures_helper.rb
@@ -1,0 +1,13 @@
+module FixturesHelper
+  def fixtures_path
+    File.expand_path(Rails.root + "features/fixtures")
+  end
+
+  def cma_cases_content_item
+    JSON.parse(File.read(fixtures_path + "/cma_cases_content_item.json"))
+  end
+
+  def cma_cases_signup_content_item
+    JSON.parse(File.read(fixtures_path + "/cma_cases_signup_content_item.json"))
+  end
+end


### PR DESCRIPTION
To do:

- get the thing rendering
- add controller test coverage that actually renders the views
- disambiguate the routes
- name everything so it's obvious this controller serves specialist publisher only
- review / merge / deploy
- publish the signup content items at the new path
- republish the finders to point to the new path
- delete code from finder-frontend