### PR TITLE
Guard against taxon content items that are gone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,15 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
+  rescue_from GdsApi::HTTPGone, with: :gone
 
 private
 
   def error_not_found
     render status: :not_found, plain: "404 error not found"
+  end
+
+  def gone
+    render status: :gone, plain: "410 gone"
   end
 end

--- a/spec/controllers/taxonomy_signups_controller_spec.rb
+++ b/spec/controllers/taxonomy_signups_controller_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe TaxonomySignupsController do
       expect(response.status).to eq 404
     end
 
+    it 'returns a 410 if taxon is gone' do
+      content_store_has_gone_item('/taxon-is-gone')
+      make_request(topic: '/taxon-is-gone')
+
+      expect(response.status).to eq 410
+    end
+
     it 'redirects to root unless the content item is a taxon' do
       content_store_has_item('/cma-cases', document_type: 'finder')
       make_request(topic: '/cma-cases')


### PR DESCRIPTION
When attempting to subscribe to a taxon that has been removed, the
`TaxonomySignupController` currently triggers a 500 because a
GdsApi::HTTPGone exception is being thrown. This commit catches
the exception in the ApplicationController and returns a 410, similar to
how it currently works with 404 responses.