### PR TITLE
Update front end styling on unsubscription pages

### DIFF
--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, "Confirm unsubscription" %>
+<header>
+  <%= render partial: 'govuk_component/title', locals: {
+    title: @title,
+    context: "Confirm your unsubscription"
+  } %>
+</header>
 
 <% if @title %>
   <p>You are unsubscribing from <%= @title %></p>
@@ -6,12 +12,7 @@
   <p>Confirm your unsubscription</p>
 <% end %>
 
-<div class="grid-row">
-  <div class="email-signup columnt-two-thirds">
-    <%= form_tag(action: :confirmed) do %>
-      <%= hidden_field_tag(:title, @title) %>
-      <%= submit_tag('Confirm', class: 'button') %>
-    <% end %>
-  </div>
-</div>
-
+<%= form_tag(action: :confirmed) do %>
+  <%= hidden_field_tag(:title, @title) %>
+  <%= button_tag 'Unsubscribe' %>
+<% end %>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -1,3 +1,10 @@
+<% content_for :title, "Confirm unsubscription" %>
+<header>
+  <%= render partial: 'govuk_component/title', locals: {
+    title: @title,
+    context: "Successfully unsubscribed"
+  } %>
+</header>
 <% if @title %>
   <p>You have been unsubscribed from <%= @title %></p>
 <% else %>


### PR DESCRIPTION
Add GOV.UK header component on both confirm and confirmed pages with some context and a title.

Remove the grid styling on the confirm page to bring text and button into correct alignment.

Change the submit button on the confirm page from an `input type="submit"` tag to a `button` tag to honour the GOV.UK Static Component Guide.

[Trello](https://trello.com/c/qX0rhWF8/421-add-a-little-style-to-unsubscribe-pages)

## Before
### Confirm page:

<img width="437" alt="screen shot 2017-12-04 at 11 50 45" src="https://user-images.githubusercontent.com/647311/33551599-ca0aafca-d8e9-11e7-9fce-2f591d9f71e6.png">

---

### Confirmed page:

<img width="474" alt="screen shot 2017-12-04 at 11 53 19" src="https://user-images.githubusercontent.com/647311/33551600-ce933a80-d8e9-11e7-90de-ccb9bfbb68f5.png">


## After
### Confirm page:

<img width="492" alt="screen shot 2017-12-04 at 11 49 45" src="https://user-images.githubusercontent.com/647311/33551609-d6864f34-d8e9-11e7-8a74-114b775b88c4.png">

---

### Confirmed page:

<img width="480" alt="screen shot 2017-12-04 at 11 50 04" src="https://user-images.githubusercontent.com/647311/33551622-df29000a-d8e9-11e7-9729-667b8f7bb072.png">


