### PR TITLE
Remove forgery protection from unsubscribe

### DIFF
--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -1,4 +1,5 @@
 class UnsubscriptionsController < ApplicationController
+  protect_from_forgery except: [:confirmed]
   before_action :set_title, :set_uuid
 
   def confirm; end


### PR DESCRIPTION
Most GOV.UK front end services have cookies stripped by Varnish for both
request and response. Rails by default sets and `authenticity_token` on
forms to mitigate CSRF attacks. This causes an error because Rails
attempts to verify the token, but cannot because we have no sessions.

We have decided to turn off forgery protection for the confirm method,
following prior art.

We did consider disabling sessions completely, however doing so with
`Rails.application.config.session_store :disabled` does not disable the
CSRF protection checks. It does work if used in conjunction with `protect_from_forgery
with: :reset_session` does work while keeping the `authenticity_token`
in the form.

Keeping the disabling well contained in scope to only methods that need it seems like a good thing since we are going against defaults.
[Trello](https://trello.com/c/zuvvVOmK/423-investigating-disabling-sessions-on-email-alert-frontend)