### PR TITLE
Add subscription page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'decent_exposure', '~> 3.0'
-gem 'gds-api-adapters', '~> 50.1'
+gem 'gds-api-adapters', '~> 50.4'
 gem 'govuk_app_config', '~> 0.2.0'
 gem 'govuk_elements_rails', '~> 3.1'
 gem 'govuk_frontend_toolkit', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    gds-api-adapters (50.1.0)
+    gds-api-adapters (50.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -301,7 +301,7 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.5)
   decent_exposure (~> 3.0)
-  gds-api-adapters (~> 50.1)
+  gds-api-adapters (~> 50.4)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint
   govuk_app_config (~> 0.2.0)
@@ -324,4 +324,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,11 @@
+class SubscriptionsController < ApplicationController
+  def new
+    @subscribable_id = params[:subscribable_id]
+  end
+
+  def create
+    redirect_to subscription_path
+  end
+
+  def show; end
+end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,6 +1,12 @@
 class SubscriptionsController < ApplicationController
   def new
-    @subscribable_id = params[:subscribable_id]
+    @topic_id = params[:topic_id]
+
+    api_response = api.get_subscribable(reference: @topic_id).to_h
+    subscribable = api_response["subscribable"]
+
+    @title = subscribable["title"]
+    @subscribable_id = subscribable["id"]
   end
 
   def create
@@ -8,4 +14,10 @@ class SubscriptionsController < ApplicationController
   end
 
   def show; end
+
+private
+
+  def api
+    EmailAlertFrontend.services(:email_alert_api)
+  end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -10,6 +10,10 @@ class SubscriptionsController < ApplicationController
   end
 
   def create
+    api.subscribe(
+      subscribable_id: params[:subscribable_id],
+      address: params[:address]
+    )
     redirect_to subscription_path
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,4 +1,6 @@
 class SubscriptionsController < ApplicationController
+  protect_from_forgery except: [:create]
+
   def new
     @topic_id = params[:topic_id]
 

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -8,11 +8,15 @@
   <div class='column-two-thirds'>
     <%= render partial: 'govuk_component/title', locals: {
       average_title_length: "long",
-      title: "Subscribe to email alerts for: #{@subscribable_id}"
+      title: "Subscribe to email alerts for: #{@title}"
     } %>
   <%= form_tag "/email/subscriptions",  method: :post do %>
     <label for="address">Address</label>
-    <input type="text" id="address"/>
+    <input type="text" id="address" name="address"/>
+    <input type="hidden" 
+           id="subscribable_id" 
+           name="subscribable_id" 
+           value="<%= @subscribable_id%>"/>
     <button>Subscribe</button>
   <%- end -%>
   </div>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, "Email - create subscription"%>
+<% content_for :head do %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>
+<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
+
+<div class='grid-row'>
+  <div class='column-two-thirds'>
+    <%= render partial: 'govuk_component/title', locals: {
+      average_title_length: "long",
+      title: "Subscribe to email alerts for: #{@subscribable_id}"
+    } %>
+  <%= form_tag "/email/subscriptions",  method: :post do %>
+    <label for="address">Address</label>
+    <input type="text" id="address"/>
+    <button>Subscribe</button>
+  <%- end -%>
+  </div>
+</div>

--- a/app/views/subscriptions/show.html.erb
+++ b/app/views/subscriptions/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, "Email - subscribed" %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>
+<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
+
+<div class='grid-row'>
+  <div class='column-two-thirds'>
+    <%= render partial: 'govuk_component/title', locals: {
+      average_title_length: "long",
+      title: "Subscription successfully created"
+    } %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,9 @@ Rails.application.routes.draw do
   get '/email/unsubscribe/:uuid' => 'unsubscriptions#confirm', as: :confirm_unsubscribe
   post '/email/unsubscribe/:uuid' => 'unsubscriptions#confirmed', as: :unsubscribe
 
-  if Rails.env != "production" || ENV["GOVUK_APP_DOMAIN"] =~ /integration/
-    scope '/email' do
-      resources :subscriptions, only: %i[create new]
-      get '/subscriptions/complete' => 'subscriptions#show', as: :subscription
-    end
+  scope '/email' do
+    resources :subscriptions, only: %i[create new]
+    get '/subscriptions/complete' => 'subscriptions#show', as: :subscription
   end
 
   if Rails.env.test?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,11 @@ Rails.application.routes.draw do
   get '/email/unsubscribe/:uuid' => 'unsubscriptions#confirm', as: :confirm_unsubscribe
   post '/email/unsubscribe/:uuid' => 'unsubscriptions#confirmed', as: :unsubscribe
 
-  scope '/email' do
-    resources :subscriptions, only: %i[create new]
-    get '/subscriptions/complete' => 'subscriptions#show', as: :subscription
+  if Rails.env != "production" || ENV["GOVUK_APP_DOMAIN"] =~ /integration/
+    scope '/email' do
+      resources :subscriptions, only: %i[create new]
+      get '/subscriptions/complete' => 'subscriptions#show', as: :subscription
+    end
   end
 
   if Rails.env.test?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
   get '/email/unsubscribe/:uuid' => 'unsubscriptions#confirm', as: :confirm_unsubscribe
   post '/email/unsubscribe/:uuid' => 'unsubscriptions#confirmed', as: :unsubscribe
 
+  scope '/email' do
+    resources :subscriptions, only: %i[create new]
+    get '/subscriptions/complete' => 'subscriptions#show', as: :subscription
+  end
+
   if Rails.env.test?
     get '/govdelivery-redirect', to: proc { [200, {}, ['']] }
   end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -61,4 +61,29 @@ namespace :publishing_api do
       rendering_app: "email-alert-frontend"
     )
   end
+
+  desc "Publish /email/subscriptions prefix route"
+  task publish_email_subscriptions_prefix: :environment do
+    logger = Logger.new(STDOUT)
+
+    publishing_api = GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+
+    special_route_publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
+      logger: logger,
+      publishing_api: publishing_api
+    )
+
+    special_route_publisher.publish(
+      content_id: "1773511a-b3c9-4f37-8692-91a718d5b6ae",
+      title: "Email - create subscription",
+      description: "Prefix route to allow users to create email subscriptions",
+      base_path: "/email/subscriptions",
+      type: "prefix",
+      publishing_app: "email-alert-frontend",
+      rendering_app: "email-alert-frontend"
+    )
+  end
 end

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "subscribing", type: :feature do
+  context "successfully" do
+    it "renders the success page" do
+      visit "/email/subscriptions/new?topic_id=test135"
+      fill_in :address, with: "test@test.com"
+      click_button "Subscribe"
+      expect(page).to have_content("Subscription successfully created")
+    end
+  end
+end

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -13,6 +13,16 @@ RSpec.describe "subscribing", type: :feature do
           title: "Test Subscriber List"
         }
       )
+
+      subscribable_id = "10"
+      address = "test@test.com"
+      returned_subscription_id = 50
+
+      email_alert_api_creates_a_subscription(
+        subscribable_id,
+        address,
+        returned_subscription_id
+      )
     end
 
     it "subscribes and renders the success page" do

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -1,10 +1,24 @@
 require 'rails_helper'
+require 'gds_api/test_helpers/email_alert_api'
 
 RSpec.describe "subscribing", type: :feature do
+  include GdsApi::TestHelpers::EmailAlertApi
+
   context "successfully" do
-    it "renders the success page" do
+    before do
+      email_alert_api_has_subscribable(
+        reference: "test135",
+        returned_attributes: {
+          id: 10,
+          title: "Test Subscriber List"
+        }
+      )
+    end
+
+    it "subscribes and renders the success page" do
       visit "/email/subscriptions/new?topic_id=test135"
       fill_in :address, with: "test@test.com"
+      expect(page).to have_content("Test Subscriber List")
       click_button "Subscribe"
       expect(page).to have_content("Subscription successfully created")
     end

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/email_alert_api'
+
+RSpec.describe "subscriptions", type: :request do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  describe "POST create" do
+    it "creates a subscription via email-alert-api" do
+      subscribable_id = "5"
+      address = "test@test.com"
+      returned_subscription_id = 10
+      email_alert_api_creates_a_subscription(
+        subscribable_id, address, returned_subscription_id
+      )
+
+      post "/email/subscriptions", params: { subscribable_id: 5, address: "test@test.com" }
+      assert_subscribed(subscribable_id, address)
+    end
+  end
+end


### PR DESCRIPTION
This is a very bare bones implementation of a subscription page on email-alert-frontend that we can use to replace the GovDelivery version e.g (https://public.govdelivery.com/accounts/UKGOVUK/subscriber/new?topic_id=UKGOVUK_2332)

The journey begins.. (dun, dun, darrrrr) at `/email/subscriptions/new?topic_id=UKGOVUK_2332` and entering an email address into there and submitting the form will create a subscription for the supplied 'topic'.

Currently missing:

* the form isn't built or styled by a professional
* a 404 response (or anything other than a success) from email-alert-api when fetching the subscribable isn't handled, email-alert-frontend will 500
* handling failure to actually create the subscription

... and probably lots of other things but it does give us enough to test 'end to end' now and something to build out from.

I've restricted the routes in production so this should only be served on integration for now as that was the simplest way I could come up with.

[Trello](https://trello.com/b/luhhZk3B/govuk-email-2017-18-doing)