### PR TITLE
Handle error cases when creating a subscription

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'decent_exposure', '~> 3.0'
-gem 'gds-api-adapters', '~> 50.4'
+gem 'gds-api-adapters', '~> 50.5'
 gem 'govuk_app_config', '~> 0.2.0'
 gem 'govuk_elements_rails', '~> 3.1'
 gem 'govuk_frontend_toolkit', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    gds-api-adapters (50.4.0)
+    gds-api-adapters (50.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -301,7 +301,7 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.5)
   decent_exposure (~> 3.0)
-  gds-api-adapters (~> 50.4)
+  gds-api-adapters (~> 50.5)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint
   govuk_app_config (~> 0.2.0)

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,27 +1,45 @@
 class SubscriptionsController < ApplicationController
   protect_from_forgery except: [:create]
 
-  def new
-    @topic_id = params[:topic_id]
-
-    api_response = api.get_subscribable(reference: @topic_id).to_h
-    subscribable = api_response["subscribable"]
-
-    @title = subscribable["title"]
-    @subscribable_id = subscribable["id"]
+  with_options only: %i(new create) do
+    before_action :assign_topic_id
+    before_action :assign_address
+    before_action :assign_subscribable
+    before_action :assign_title
   end
 
   def create
-    api.subscribe(
-      subscribable_id: params[:subscribable_id],
-      address: params[:address]
-    )
-    redirect_to subscription_path
+    if @address.present? && subscribe
+      redirect_to subscription_path
+    else
+      flash.now[:error] = "Please enter a valid email address."
+      render :new
+    end
   end
 
-  def show; end
-
 private
+
+  def assign_topic_id
+    @topic_id = params.fetch(:topic_id)
+  end
+
+  def assign_address
+    @address = params[:address]
+  end
+
+  def assign_subscribable
+    @subscribable = api.get_subscribable(reference: @topic_id).to_h.fetch("subscribable")
+  end
+
+  def assign_title
+    @title = @subscribable["title"]
+  end
+
+  def subscribe
+    api.subscribe(subscribable_id: @subscribable["id"], address: @address)
+  rescue GdsApi::HTTPUnprocessableEntity
+    false
+  end
 
   def api
     EmailAlertFrontend.services(:email_alert_api)

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -10,13 +10,15 @@
       average_title_length: "long",
       title: "Subscribe to email alerts for: #{@title}"
     } %>
-  <%= form_tag "/email/subscriptions",  method: :post do %>
+
+  <%= flash[:error] %>
+
+  <%= form_tag "/email/subscriptions", method: :post do %>
+    <%= hidden_field_tag :topic_id, @topic_id %>
+
     <label for="address">Address</label>
-    <input type="text" id="address" name="address"/>
-    <input type="hidden" 
-           id="subscribable_id" 
-           name="subscribable_id" 
-           value="<%= @subscribable_id%>"/>
+    <%= text_field_tag :address, @address %>
+
     <button>Subscribe</button>
   <%- end -%>
   </div>

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -4,20 +4,21 @@ require 'gds_api/test_helpers/email_alert_api'
 RSpec.describe "subscribing", type: :feature do
   include GdsApi::TestHelpers::EmailAlertApi
 
+  let(:topic_id) { "GOVUK_123" }
+  let(:subscribable_id) { 10 }
+  let(:address) { "test@test.com" }
+
   context "successfully" do
     before do
       email_alert_api_has_subscribable(
-        reference: "test135",
+        reference: topic_id,
         returned_attributes: {
-          id: 10,
+          id: subscribable_id,
           title: "Test Subscriber List"
         }
       )
 
-      subscribable_id = "10"
-      address = "test@test.com"
       returned_subscription_id = 50
-
       email_alert_api_creates_a_subscription(
         subscribable_id,
         address,
@@ -26,8 +27,8 @@ RSpec.describe "subscribing", type: :feature do
     end
 
     it "subscribes and renders the success page" do
-      visit "/email/subscriptions/new?topic_id=test135"
-      fill_in :address, with: "test@test.com"
+      visit "/email/subscriptions/new?topic_id=#{topic_id}"
+      fill_in :address, with: address
       expect(page).to have_content("Test Subscriber List")
       click_button "Subscribe"
       expect(page).to have_content("Subscription successfully created")

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -4,17 +4,68 @@ require 'gds_api/test_helpers/email_alert_api'
 RSpec.describe "subscriptions", type: :request do
   include GdsApi::TestHelpers::EmailAlertApi
 
+  let(:topic_id) { "GOVUK_123" }
+  let(:subscribable_id) { 10 }
+
+  before do
+    email_alert_api_has_subscribable(
+      reference: topic_id,
+      returned_attributes: {
+        id: subscribable_id,
+        title: "Test Subscriber List",
+      }
+    )
+  end
+
+  describe "GET /new" do
+    it "returns a 200" do
+      get "/email/subscriptions/new", params: { topic_id: topic_id }
+      expect(response.status).to eq(200)
+    end
+
+    context "when no topic param is provided" do
+      it "returns a 400" do
+        get "/email/subscriptions/new", params: {}
+        expect(response.status).to eq(400)
+      end
+    end
+
+    context "when a topic params is provided for something that doesn't exist" do
+      before do
+        email_alert_api_does_not_have_subscribable(reference: "missing")
+      end
+
+      it "returns a 404" do
+        get "/email/subscriptions/new", params: { topic_id: "missing" }
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
   describe "POST create" do
-    it "creates a subscription via email-alert-api" do
-      subscribable_id = "5"
-      address = "test@test.com"
-      returned_subscription_id = 10
+    let(:address) { "test@test.com" }
+
+    before do
+      returned_subscription_id = 50
       email_alert_api_creates_a_subscription(
         subscribable_id, address, returned_subscription_id
       )
+    end
 
-      post "/email/subscriptions", params: { subscribable_id: 5, address: "test@test.com" }
+    it "creates a subscription via email-alert-api" do
+      post "/email/subscriptions", params: { topic_id: topic_id, address: address }
       assert_subscribed(subscribable_id, address)
+    end
+
+    context "when no address is provided" do
+      let(:address) { nil }
+
+      it "shows an error message on the form" do
+        post "/email/subscriptions", params: { topic_id: topic_id, address: address }
+
+        expect(response.status).to eq(200)
+        expect(response.body).to include("Please enter a valid email address")
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/amAa5HkV/444-handle-error-cases-for-capturing-a-users-email-address

- show an error if the user tries to submit
without an address
- show an error if the user tries to submit with
an invalid address
- preserve the address input text if the form
fails to submit
- add test coverage for other error cases, e.g.
when no subscribable exists for the topic_id

Additionally, we probably don’t want to expose the
internal database id for a subscribable in the
form, so this looks up the subscribable again from
the topic_id parameter in #create.