### PR TITLE
Add margin bottom to unsubscribe button

### DIFF
--- a/app/assets/stylesheets/unsubscriptions.scss
+++ b/app/assets/stylesheets/unsubscriptions.scss
@@ -1,0 +1,3 @@
+.email-alert-frontend-content {
+  margin-bottom: 45px;
+}


### PR DESCRIPTION
On the /email/unsubscribe pages, the Unsubscribe button and "Is there anything wrong with this page?" text look a bit squashed. Add a `margin-bottom` to the main div to space
things out a little.

## Before

<img width="305" alt="screen shot 2017-12-14 at 14 46 20" src="https://user-images.githubusercontent.com/647311/33997845-a28f379e-e0dd-11e7-88d5-81fcd577204b.png">

------

## After

<img width="308" alt="screen shot 2017-12-14 at 14 46 00" src="https://user-images.githubusercontent.com/647311/33997852-aa250826-e0dd-11e7-8764-b0ef7f90e404.png">
