### PR TITLE
Add bearer token for email-alert-api

### DIFF
--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -13,5 +13,11 @@ module EmailAlertFrontend
   end
 end
 
-EmailAlertFrontend.register_service(:email_alert_api, GdsApi::EmailAlertApi.new(Plek.new.find('email-alert-api')))
+EmailAlertFrontend.register_service(
+  :email_alert_api,
+  GdsApi::EmailAlertApi.new(
+    Plek.new.find('email-alert-api'),
+    bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "bearer_token")
+  )
+)
 EmailAlertFrontend.register_service(:content_store, GdsApi::ContentStore.new(Plek.new.find('content-store')))


### PR DESCRIPTION
Email-alert-api is getting authentication/authorisation. This commit adds a bearer token for it.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)