### PR TITLE
Add back links to collection pages as per service manual

### DIFF
--- a/app/assets/stylesheets/application-without-elements.scss
+++ b/app/assets/stylesheets/application-without-elements.scss
@@ -2,6 +2,7 @@
 @import "design-patterns/buttons";
 
 // Components from govuk_publishing_components:
+@import "components/back-link";
 @import "components/label";
 
 // Components from this application:

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -5,6 +5,7 @@ class SubscriptionsController < ApplicationController
   before_action :assign_address
   before_action :assign_subscribable
   before_action :assign_title
+  before_action :assign_back_url
 
   def create
     if @address.present? && subscribe
@@ -31,6 +32,21 @@ private
 
   def assign_title
     @title = @subscribable["title"]
+  end
+
+  def assign_back_url
+    @back_url = url_for(action: :new, topic_id: @topic_id)
+    @back_url = govuk_url if params[:action] == "new"
+  end
+
+  def govuk_url
+    referer = request.referer
+
+    if referer && referer.exclude?("/email/subscriptions")
+      referer
+    else
+      "https://www.gov.uk/"
+    end
   end
 
   def subscribe

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -10,6 +10,10 @@
 
 <%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
 
+<%= render "components/back_link", {
+  href: @back_url,
+} %>
+
 <div class='grid-row'>
   <div class='column-two-thirds'>
     <%= render partial: 'govuk_component/title', locals: {

--- a/app/views/subscriptions/show.html.erb
+++ b/app/views/subscriptions/show.html.erb
@@ -10,6 +10,10 @@
 
 <%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
 
+<%= render "components/back_link", {
+  href: @back_url,
+} %>
+
 <div class='grid-row'>
   <div class='column-two-thirds'>
     <%= render 'components/confirmation_box', {

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -38,5 +38,30 @@ RSpec.describe "subscribing", type: :feature do
       page.execute_script("document.querySelector('form').submit()")
       expect(page).to have_content("Subscribed successfully")
     end
+
+    it "lets the user go back" do
+      page.driver.add_header("Referer", "http://example.com", permanent: false)
+
+      visit "/email/subscriptions/new?topic_id=#{topic_id}"
+      expect(back_link_href).to eq("http://example.com/")
+
+      fill_in :address, with: address
+      page.execute_script("document.querySelector('form').submit()")
+      expect(page).to have_content("Subscribed successfully")
+
+      expect(back_link_href).to include(
+        "/email/subscriptions/new?topic_id=GOVUK_123"
+      )
+
+      click_link "Back"
+
+      # The referer points back to the confirmation page, which probably isn't
+      # helpful if they're on the form, so fallback to somewhere sensible.
+      expect(back_link_href).to eq("https://www.gov.uk/")
+    end
+  end
+
+  def back_link_href
+    page.find("a", text: "Back")[:href]
   end
 end


### PR DESCRIPTION
https://trello.com/c/HSre7K10/453-style-the-mvp-email-collection-page-needed-by-jan
https://www.gov.uk/service-manual/design/question-pages#back-link

Screenshots:
![screen shot 2018-01-09 at 12 28 25](https://user-images.githubusercontent.com/892251/34721252-fb4b4dd0-f539-11e7-9879-2852f8fd1706.png)
![screen shot 2018-01-09 at 12 28 35](https://user-images.githubusercontent.com/892251/34721254-fb664d56-f539-11e7-97b0-da23ad8f0d04.png)
