### PR TITLE
Bump GDS API Adapters to 51.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 ruby File.read(".ruby-version").strip
 
 gem 'decent_exposure', '~> 3.0'
-gem 'gds-api-adapters', '~> 51.0'
+gem 'gds-api-adapters', '~> 51.1'
 gem 'govuk_app_config', '~> 1.2.1'
 gem 'govuk_elements_rails', '~> 3.1'
 gem 'govuk_frontend_toolkit', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
-    gds-api-adapters (51.0.0)
+    gds-api-adapters (51.1.1)
       addressable
       link_header
       lrucache (~> 0.1.1)
@@ -349,7 +349,7 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.5)
   decent_exposure (~> 3.0)
-  gds-api-adapters (~> 51.0)
+  gds-api-adapters (~> 51.1)
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
   govuk_app_config (~> 1.2.1)

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "subscribing", type: :feature do
       email_alert_api_creates_a_subscription(
         subscribable_id,
         address,
+        "immediately",
         returned_subscription_id
       )
     end

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "subscriptions", type: :request do
     before do
       returned_subscription_id = 50
       email_alert_api_creates_a_subscription(
-        subscribable_id, address, returned_subscription_id
+        subscribable_id, address, "immediately", returned_subscription_id
       )
     end
 


### PR DESCRIPTION
Bump the version of GDS API Adapters to 51.1.

Add frequency param when calling `email_alert_api_creates_a_subscription` so that we properly satisfy the interface.

Supersedes https://github.com/alphagov/email-alert-frontend/pull/107