### PR TITLE
Render fieldset on frequency page from component

### DIFF
--- a/app/assets/stylesheets/application-without-elements.scss
+++ b/app/assets/stylesheets/application-without-elements.scss
@@ -6,6 +6,7 @@
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/radio";
+@import "govuk_publishing_components/components/fieldset";
 
 // Components from this application:
 @import "components/confirmation_box";

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -26,9 +26,7 @@
       <%= hidden_field_tag :topic_id, @topic_id %>
 
       <div class="form-group">
-        <p><strong>You can get updates about changes:</strong>
-
-        <fieldset>
+        <%= render "govuk_publishing_components/components/fieldset", legend_text: "You can get updates about changes:" do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "frequency",
             items: [
@@ -47,7 +45,7 @@
               }
             ]
           } %>
-        </fieldset>
+        <% end %>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
Import the govuk components fieldset scss.
Render the fieldset on the frequency page from the component. This adds
a margin-bottom between the radio buttons and the "Next" button as well.
Move the text "You can get updates about changes:" into the fieldset
legend to enhance accessibility. This loses the bold on the text.

### Before

```
<p><strong>You can get updates about changes:</strong></p>
<fieldset>
    <div class="gem-c-radio">
      <input class="gem-c-radio__input" id="radio-e9014fbd-0" name="frequency" type="radio" value="immediately" checked>
...
```
<img width="507" alt="screen shot 2018-02-08 at 08 57 28" src="https://user-images.githubusercontent.com/647311/35963911-25314da8-0cae-11e8-88fe-a4b5626cae26.png">

### After

```
<fieldset class="gem-c-fieldset">
  <legend class="gem-c-fieldset__legend">
     You can get updates about changes:
  </legend>
  <div class="gem-c-radio">
    <input class="gem-c-radio__input" id="radio-7bcba18f-0" name="frequency" type="radio" value="immediately" checked>
...
```
<img width="520" alt="screen shot 2018-02-08 at 08 54 27" src="https://user-images.githubusercontent.com/647311/35963930-2e39b9a8-0cae-11e8-87ca-46f7582d31d9.png">
