### PR TITLE
Revert "Bump slimmer from 11.1.1 to 12.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'rails', '5.1.5'
 gem 'decent_exposure', '~> 3.0'
 gem 'foreman', '~> 0.84.0'
 gem 'sass-rails', '~> 5.0'
-gem 'slimmer', '~> 12.0'
+gem 'slimmer', '~> 11.0'
 gem 'uglifier', '~> 4.1'
 
 gem 'gds-api-adapters', '~> 51.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,7 +303,7 @@ GEM
       sass (~> 3.5.3)
     sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
-    slimmer (12.0.0)
+    slimmer (11.1.1)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -369,7 +369,7 @@ DEPENDENCIES
   rails (= 5.1.5)
   rspec-rails (~> 3.6)
   sass-rails (~> 5.0)
-  slimmer (~> 12.0)
+  slimmer (~> 11.0)
   timecop (~> 0.9.1)
   uglifier (~> 4.1)
   webmock (~> 3.3)


### PR DESCRIPTION
Reverts alphagov/email-alert-frontend#122. 

Version 12 contains a breaking change which removes the "Is there anything wrong with this page?" link from the footer. It has to be replaced with the feedback component, but that isn't ready yet. I'll upgrade this app later this week.