### PR TITLE
Pin to older ffi 1.9.18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,10 @@ gem 'govuk_navigation_helpers', '~> 9.0'
 gem 'govuk_publishing_components', '~> 5.1'
 gem 'plek', '~> 2.1'
 
+# Currently we can't install the latest version of this on GOV.UK
+# infrastructure due to a lack of libffi-dev
+gem 'ffi', '1.9.18'
+
 group :development, :test do
   gem 'better_errors'
   gem 'binding_of_caller'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     execjs (2.7.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.21)
+    ffi (1.9.18)
     foreman (0.84.0)
       thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
@@ -352,6 +352,7 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.5)
   decent_exposure (~> 3.0)
+  ffi (= 1.9.18)
   foreman (~> 0.84.0)
   gds-api-adapters (~> 51.1)
   govuk-content-schema-test-helpers (~> 1.6)


### PR DESCRIPTION
We can't currently build 1.9.21 on GOV.UK infrastructure due to a
missing library.