### PR TITLE
Wrap the fieldset component in a govspeak div

### DIFF
--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -29,27 +29,35 @@
           <h2>How often do you want to get updates?</h2>
           <p>You can get updates about changes:</p>
         <% end %>
-        <%= render "govuk_component/govspeak", {
-          content: intro
-        } %>
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "frequency",
-          items: [
-            {
-              value: "immediately",
-              text: "As soon as they happen",
-              checked: true,
-            },
-            {
-              value: "daily",
-              text: "No more than once a day",
-            },
-            {
-              value: "weekly",
-              text: "No more than once a week",
-            }
-          ]
-        } %>
+        <% radio = capture do %>
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "frequency",
+            items: [
+              {
+                value: "immediately",
+                text: "As soon as they happen",
+                checked: true,
+              },
+              {
+                value: "daily",
+                text: "No more than once a day",
+              },
+              {
+                value: "weekly",
+                text: "No more than once a week",
+              }
+            ]
+          } %>
+        <% end %>
+
+        <%# Note govspeak component is not used as it won't render a form and
+            is thus not easy to test %>
+        <div class="govuk-govspeak">
+          <%= render "govuk_publishing_components/components/fieldset", {
+            legend_text: intro,
+            text: radio,
+          } %>
+        </div>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
This allows us to have govspeak styling within the legend element of the
fieldset. We can't use the govspeak component to do this unfortunately
as it won't render the HTML correctly in test environments (presumably
it wasn't anticipated to be used for wrapping forms).

It changes the presentation of our form
from:
<img width="611" alt="screen shot 2018-02-20 at 12 19 33" src="https://user-images.githubusercontent.com/282717/36423559-5b73f1de-1638-11e8-8faf-0af58b727c2a.png">

to:
<img width="635" alt="screen shot 2018-02-20 at 12 19 18" src="https://user-images.githubusercontent.com/282717/36423562-607064f6-1638-11e8-98cc-61a1acedabf6.png">
