### PR TITLE
Revert app to not use foreman in startup.sh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby File.read(".ruby-version").strip
 gem 'rails', '5.1.5'
 
 gem 'decent_exposure', '~> 3.0'
-gem 'foreman', '~> 0.84.0'
 gem 'sass-rails', '~> 5.0'
 gem 'slimmer', '~> 11.0'
 gem 'uglifier', '~> 4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,8 +100,6 @@ GEM
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.21)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -319,7 +317,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
@@ -352,7 +350,6 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.5)
   decent_exposure (~> 3.0)
-  foreman (~> 0.84.0)
   gds-api-adapters (~> 51.1)
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,7 @@ if [[ $1 == "--live" ]] ; then
   GOVUK_WEBSITE_ROOT=https://www.gov.uk \
   PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api \
   PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk \
-  bundle exec foreman run web
+  bundle exec rails s -p 3099
 else
-  bundle exec foreman run web
+  bundle exec rails s -p 3099
 fi


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

There are still some problems to resolve running the app via unicorn in
a dev environment and these may take a while to be resolved. So this
reverts this back to the previous dev experience of starting rails
server directly. This can then be switched around later if the problems
are resolved.