### PR TITLE
Render the frequency question in a legend

### DIFF
--- a/app/assets/stylesheets/application-without-elements.scss
+++ b/app/assets/stylesheets/application-without-elements.scss
@@ -6,3 +6,10 @@
 
 // Components from this application:
 @import "components/confirmation_box";
+
+.app-legend-title {
+  margin: 0 0 $gem-spacing-scale-4;
+  @include media(tablet) {
+    margin-bottom: $gem-spacing-scale-5;
+  }
+}

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -25,31 +25,28 @@
       <%= hidden_field_tag :topic_id, @topic_id %>
 
       <div class="form-group">
-        <% intro = capture do %>
-          <h2>How often do you want to get updates?</h2>
-          <p>You can get updates about changes:</p>
+        <%= render "govuk_publishing_components/components/fieldset", {
+          legend_text: render("govuk_component/govspeak", content: %{<h2 class="app-legend-title">How often do you want to get updates?</h2>}),
+        } do %>
+          <%= render "govuk_publishing_components/components/radio", {
+            name: "frequency",
+            items: [
+              {
+                value: "immediately",
+                text: "As soon as they happen",
+                checked: true,
+              },
+              {
+                value: "daily",
+                text: "No more than once a day",
+              },
+              {
+                value: "weekly",
+                text: "No more than once a week",
+              }
+            ]
+          } %>
         <% end %>
-        <%= render "govuk_component/govspeak", {
-          content: intro
-        } %>
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "frequency",
-          items: [
-            {
-              value: "immediately",
-              text: "As soon as they happen",
-              checked: true,
-            },
-            {
-              value: "daily",
-              text: "No more than once a day",
-            },
-            {
-              value: "weekly",
-              text: "No more than once a week",
-            }
-          ]
-        } %>
       </div>
 
       <div class="form-group">


### PR DESCRIPTION
This uses a govspeak component inside the legend of the form to inherit
govspeak styles. We also apply a class to the header so that we can give
this title a bottom margin.

This also drops the second line "You can get updates about changes:" as
having this in the legend made for a confusing screenreader experience.

Before:
<img width="584" alt="screen shot 2018-02-21 at 18 37 12" src="https://user-images.githubusercontent.com/282717/36498468-44cd9ee0-1736-11e8-940d-89df17612b04.png">

After:
<img width="587" alt="screen shot 2018-02-21 at 18 36 43" src="https://user-images.githubusercontent.com/282717/36498472-46b9e9d4-1736-11e8-86b1-c18b11d3adcb.png">


