### PR TITLE
Force referer to be on gov.uk

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -72,7 +72,12 @@ private
     referer = request.referer
 
     if referer && referer.exclude?("/email/subscriptions")
-      referer
+      referer_uri = URI(referer)
+      sanitised_referer_uri = Plek.new.website_uri
+      sanitised_referer_uri.path = referer_uri.path
+      sanitised_referer_uri.query = referer_uri.query
+      sanitised_referer_uri.fragment = referer_uri.fragment
+      sanitised_referer_uri.to_s
     else
       Plek.new.website_root
     end

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -53,10 +53,10 @@ RSpec.describe "subscribing", type: :feature do
     end
 
     context "arrived at form with referer" do
-      it "has a link to the referer" do
-        page.driver.add_header("Referer", "http://example.com", permanent: false)
+      it "has a link to the referer forced onto the gov.uk domain" do
+        page.driver.add_header("Referer", "http://example.com/some/page?query=string", permanent: false)
         visit new_subscription_path
-        expect(back_link_href).to eq("http://example.com/")
+        expect(back_link_href).to match(%r{gov.uk/some/page\?query=string$})
       end
     end
 


### PR DESCRIPTION
This commit forces the referer to be on gov.uk by taking the non domain parts of it and adding it onto the relevant domain. This prevents referers from third-party domains showing up on the “back” link.

Trello: https://trello.com/c/BHKZj7jR/638-fix-referer-reflected-xss-vulnerability