### PR TITLE
Clarify which JS requires come from govuk_frontend_toolkit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,9 @@
-//=require govuk_publishing_components/components/error-summary
+// from govuk_frontend_toolkit and not delivered by static as part of
+// header-footer-only on deployed environments
 //=require govuk/show-hide-content.js
+//
+// from govuk_publishing_components
+//=require govuk_publishing_components/components/error-summary
 ;(function () {
   $('.js-hidden-submit').removeClass('js-hidden-submit')
   $('.no-js-panel').removeClass('no-js-panel')


### PR DESCRIPTION
For: https://trello.com/c/AK6V1hHg/103-sort-out-govuktoolkit-use-in-frontend-apps-to-avoid-object-object-in-ga

In general we don't want to require all of the JS from
govuk_frontend_toolkit, because in deployed environments we'd end up
duplicating a lot of the JS that we load in from static.  However,
depending on which static layout we use we don't actually get all of
govuk_frontend_toolkit's JS, and we might want to rely on parts that
aren't delivered by static.  In these cases it's fine to require those
files, but we should be clear about what we can and can't require to
avoid someone changing the require to `//= require govuk_toolkit` in
the future.

To that end we drop a comment at the top of `application.js` around
the existing requires explaining that they are parts of
govuk_frontend_toolkit that are not included by the `header-footer-only`
template we use.