### PR TITLE
Take title from API

### DIFF
--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -13,7 +13,7 @@ class UnsubscriptionsController < ApplicationController
 private
 
   def set_title
-    @title = params[:title].presence
+    @title = api.get_subscription(@id).dig("subscription", "subscriber_list", "title").presence
   end
 
   def set_id

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -1,5 +1,5 @@
 class UnsubscriptionsController < ApplicationController
-  before_action :set_title, :set_id, :set_back_url, :set_from
+  before_action :set_id, :set_title, :set_back_url, :set_from
 
   def confirm; end
 

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -1,10 +1,10 @@
 class UnsubscriptionsController < ApplicationController
-  before_action :set_title, :set_uuid, :set_back_url, :set_from
+  before_action :set_title, :set_id, :set_back_url, :set_from
 
   def confirm; end
 
   def confirmed
-    api.unsubscribe(@uuid)
+    api.unsubscribe(@id)
   rescue GdsApi::HTTPNotFound
     # The user has already unsubscribed.
     nil
@@ -16,8 +16,8 @@ private
     @title = params[:title].presence
   end
 
-  def set_uuid
-    @uuid = params[:uuid].presence
+  def set_id
+    @id = params[:id].presence
   end
 
   def set_back_url

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -50,7 +50,7 @@
               <% end %>
               <br><a href="<%= update_frequency_path(id: subscription['id']) %>">Change how often you get updates</a>
             </p>
-            <p><a href="<%= confirm_unsubscribe_path(uuid: subscription['id'], title: subscription['subscriber_list']['title'], from: 'subscription-management') %>">Unsubscribe</a></p>
+            <p><a href="<%= confirm_unsubscribe_path(id: subscription['id'], from: 'subscription-management') %>">Unsubscribe</a></p>
           <% end %>
           <%= render 'govuk_component/govspeak', {
             content: subscription_info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do
   post '/email-signup' => 'taxonomy_signups#create'
 
   scope '/email' do
-    get '/unsubscribe/:uuid' => 'unsubscriptions#confirm', as: :confirm_unsubscribe
-    post '/unsubscribe/:uuid' => 'unsubscriptions#confirmed', as: :unsubscribe
+    get '/unsubscribe/:id' => 'unsubscriptions#confirm', as: :confirm_unsubscribe
+    post '/unsubscribe/:id' => 'unsubscriptions#confirmed', as: :unsubscribe
 
     scope '/manage' do
       get '/' => 'subscriptions_management#index', as: :list_subscriptions

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe UnsubscriptionsController do
 
   render_views
 
-  let(:uuid) { "A-UUID" }
+  let(:id) { "A-UUID" }
   let(:title) { "A title" }
 
   before do
-    email_alert_api_unsubscribes_a_subscription(uuid)
+    email_alert_api_unsubscribes_a_subscription(id)
   end
 
-  describe "GET /email/unsubscribe/:uuid" do
+  describe "GET /email/unsubscribe/:id" do
     it "responds with a 200" do
-      get :confirm, params: { uuid: uuid, title: title }
+      get :confirm, params: { id: id, title: title }
 
       expect(response.status).to eq(200)
     end
@@ -27,26 +27,26 @@ RSpec.describe UnsubscriptionsController do
     end
 
     it "renders a form" do
-      get :confirm, params: { uuid: uuid, title: title }
+      get :confirm, params: { id: id, title: title }
 
-      expect(response.body).to include(%(action="/email/unsubscribe/#{uuid}"))
+      expect(response.body).to include(%(action="/email/unsubscribe/#{id}"))
     end
 
     it "renders the title on the page" do
-      get :confirm, params: { uuid: uuid, title: title }
+      get :confirm, params: { id: id, title: title }
 
       expect(response.body).to include("You won’t get any more updates about #{title}")
     end
 
     it "passes the title through to the 'confirmed' action" do
-      get :confirm, params: { uuid: uuid, title: title }
+      get :confirm, params: { id: id, title: title }
 
       expect(response.body).to include(%(value="#{title}"))
     end
 
     context "when no title is provided" do
       it "shows a different message" do
-        get :confirm, params: { uuid: uuid }
+        get :confirm, params: { id: id }
 
         expect(response.body).to include("You won’t get any more updates about this topic.")
       end
@@ -54,16 +54,16 @@ RSpec.describe UnsubscriptionsController do
 
     context "when a blank title is provided" do
       it "shows a different message" do
-        get :confirm, params: { uuid: uuid, title: " " }
+        get :confirm, params: { id: id, title: " " }
 
         expect(response.body).to include("You won’t get any more updates about this topic.")
       end
     end
   end
 
-  describe "POST /email/unsubscribe/:uuid" do
+  describe "POST /email/unsubscribe/:id" do
     it "responds with a 200" do
-      post :confirmed, params: { uuid: uuid, title: title }
+      post :confirmed, params: { id: id, title: title }
 
       expect(response.status).to eq(200)
     end
@@ -75,24 +75,24 @@ RSpec.describe UnsubscriptionsController do
     end
 
     it "renders a confirmation page" do
-      post :confirmed, params: { uuid: uuid, title: title }
+      post :confirmed, params: { id: id, title: title }
 
       expect(response.body).to include("You won’t get any more updates about #{title}")
     end
 
     it "sends an unsubscribe request to email-alert-api" do
-      post :confirmed, params: { uuid: uuid, title: title }
+      post :confirmed, params: { id: id, title: title }
 
-      assert_unsubscribed(uuid)
+      assert_unsubscribed(id)
     end
 
     context "when the user has already unsubscribed" do
       before do
-        email_alert_api_has_no_subscription_for_uuid(uuid)
+        email_alert_api_has_no_subscription_for_uuid(id)
       end
 
       it "renders the same confirmation page" do
-        post :confirmed, params: { uuid: uuid, title: title }
+        post :confirmed, params: { id: id, title: title }
 
         expect(response.body).to include("You won’t get any more updates about #{title}")
       end
@@ -100,7 +100,7 @@ RSpec.describe UnsubscriptionsController do
 
     context "when no title is provided" do
       it "shows a different message" do
-        post :confirmed, params: { uuid: uuid }
+        post :confirmed, params: { id: id }
 
         expect(response.body).to include("You won’t get any more updates about this topic.")
       end
@@ -108,7 +108,7 @@ RSpec.describe UnsubscriptionsController do
 
     context "when a blank title is provided" do
       it "shows a different message" do
-        post :confirmed, params: { uuid: uuid, title: " " }
+        post :confirmed, params: { id: id, title: " " }
 
         expect(response.body).to include("You won’t get any more updates about this topic.")
       end

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -7,81 +7,66 @@ RSpec.describe UnsubscriptionsController do
   render_views
 
   let(:id) { "A-UUID" }
-  let(:title) { "A title" }
+  let(:title) { "title" }
 
   before do
+    email_alert_api_has_subscription(id, "immediately", title: title)
     email_alert_api_unsubscribes_a_subscription(id)
   end
 
   describe "GET /email/unsubscribe/:id" do
     it "responds with a 200" do
-      get :confirm, params: { id: id, title: title }
+      get :confirm, params: { id: id }
 
       expect(response.status).to eq(200)
     end
 
     it "sets the Cache-Control header to 'private, no-cache'" do
-      get :confirm, params: { uuid: uuid, title: title }
+      get :confirm, params: { id: id }
 
       expect(response.headers["Cache-Control"]).to eq("private, no-cache")
     end
 
     it "renders a form" do
-      get :confirm, params: { id: id, title: title }
+      get :confirm, params: { id: id }
 
       expect(response.body).to include(%(action="/email/unsubscribe/#{id}"))
     end
 
     it "renders the title on the page" do
-      get :confirm, params: { id: id, title: title }
+      get :confirm, params: { id: id }
 
       expect(response.body).to include("You won’t get any more updates about #{title}")
     end
 
     it "passes the title through to the 'confirmed' action" do
-      get :confirm, params: { id: id, title: title }
+      get :confirm, params: { id: id }
 
       expect(response.body).to include(%(value="#{title}"))
-    end
-
-    context "when no title is provided" do
-      it "shows a different message" do
-        get :confirm, params: { id: id }
-
-        expect(response.body).to include("You won’t get any more updates about this topic.")
-      end
-    end
-
-    context "when a blank title is provided" do
-      it "shows a different message" do
-        get :confirm, params: { id: id, title: " " }
-
-        expect(response.body).to include("You won’t get any more updates about this topic.")
-      end
     end
   end
 
   describe "POST /email/unsubscribe/:id" do
     it "responds with a 200" do
-      post :confirmed, params: { id: id, title: title }
+      post :confirmed, params: { id: id }
 
       expect(response.status).to eq(200)
     end
 
     it "sets the Cache-Control header to 'private, no-cache'" do
-      post :confirmed, params: { uuid: uuid, title: title }
+      post :confirmed, params: { id: id }
 
       expect(response.headers["Cache-Control"]).to eq("private, no-cache")
     end
 
     it "renders a confirmation page" do
-      post :confirmed, params: { id: id, title: title }
+      post :confirmed, params: { id: id }
 
       expect(response.body).to include("You won’t get any more updates about #{title}")
     end
 
     it "sends an unsubscribe request to email-alert-api" do
-      post :confirmed, params: { id: id, title: title }
+      post :confirmed, params: { id: id }
 
       assert_unsubscribed(id)
     end
@@ -92,25 +77,9 @@ RSpec.describe UnsubscriptionsController do
       end
 
       it "renders the same confirmation page" do
-        post :confirmed, params: { id: id, title: title }
-
-        expect(response.body).to include("You won’t get any more updates about #{title}")
-      end
-    end
-
-    context "when no title is provided" do
-      it "shows a different message" do
         post :confirmed, params: { id: id }
 
-        expect(response.body).to include("You won’t get any more updates about this topic.")
-      end
-    end
-
-    context "when a blank title is provided" do
-      it "shows a different message" do
-        post :confirmed, params: { id: id, title: " " }
-
-        expect(response.body).to include("You won’t get any more updates about this topic.")
+        expect(response.body).to include("You won’t get any more updates about #{title}")
       end
     end
   end


### PR DESCRIPTION
This takes the title from the `email-alert-api` rather than from a URL query parameter meaning that it will always be representative of the subscription.

[Trello Card](https://trello.com/c/tQznyVfV/704-remove-the-need-to-specify-a-subscriber-list-name-on-the-unsubscribe-page)