### PR TITLE
Set Cache-Control header and allow CSRF protection

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,6 +1,5 @@
 class SubscriptionsController < ApplicationController
-  protect_from_forgery except: %i[create frequency]
-
+  before_action :set_cache_control_header
   before_action :assign_attributes
   before_action :assign_back_url
 
@@ -40,6 +39,10 @@ class SubscriptionsController < ApplicationController
   def complete; end
 
 private
+
+  def set_cache_control_header
+    headers["Cache-Control"] = "private"
+  end
 
   def assign_attributes
     @topic_id = subscription_params.require(:topic_id)

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -1,5 +1,5 @@
 class UnsubscriptionsController < ApplicationController
-  protect_from_forgery except: [:confirmed]
+  before_action :set_cache_control_header
   before_action :set_title, :set_uuid
 
   def confirm; end
@@ -12,6 +12,10 @@ class UnsubscriptionsController < ApplicationController
   end
 
 private
+
+  def set_cache_control_header
+    headers["Cache-Control"] = "private"
+  end
 
   def set_title
     @title = params[:title].presence

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe SubscriptionsController do
         get :new, params: { topic_id: topic_id }
         expect(response).to have_http_status(:ok)
       end
+
+      it "sets the Cache-Control header to 'private'" do
+        get :new, params: { topic_id: topic_id }
+        expect(response.headers["Cache-Control"]).to eq("private")
+      end
     end
 
     context "when a topic and frequency are provided" do
@@ -90,6 +95,11 @@ RSpec.describe SubscriptionsController do
           topic_id: topic_id, frequency: frequency
         )
         expect(response).to redirect_to(destination)
+      end
+
+      it "sets the Cache-Control header to 'private'" do
+        post :frequency, params: { topic_id: topic_id, frequency: frequency }
+        expect(response.headers["Cache-Control"]).to eq("private")
       end
     end
   end
@@ -154,6 +164,11 @@ RSpec.describe SubscriptionsController do
       it "sends a request to email-alert-api" do
         post :create, params: params
         assert_subscribed(subscribable_id, address, frequency)
+      end
+
+      it "sets the Cache-Control header to 'private'" do
+        post :create, params: params
+        expect(response.headers["Cache-Control"]).to eq("private")
       end
     end
   end

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe UnsubscriptionsController do
       expect(response.status).to eq(200)
     end
 
+    it "sets the Cache-Control header to 'private'" do
+      get :confirm, params: { uuid: uuid, title: title }
+
+      expect(response.headers["Cache-Control"]).to eq("private")
+    end
+
     it "renders a form" do
       get :confirm, params: { uuid: uuid, title: title }
 
@@ -60,6 +66,12 @@ RSpec.describe UnsubscriptionsController do
       post :confirmed, params: { uuid: uuid, title: title }
 
       expect(response.status).to eq(200)
+    end
+
+    it "sets the Cache-Control header to 'private'" do
+      post :confirmed, params: { uuid: uuid, title: title }
+
+      expect(response.headers["Cache-Control"]).to eq("private")
     end
 
     it "renders a confirmation page" do


### PR DESCRIPTION
This commit sets the `Cache-Control` header for all controllers that serve pages under `/email` to “private” so they don’t get cached by the CDN. This is because cookies and sessions will be enabled soon and we don’t want specific users’ pages to be cached. It also enables CSRF protection now that cookies are enabled.

Depends on https://github.com/alphagov/govuk-puppet/pull/7402

Trello: https://trello.com/c/97eS4TdI/710-sort-out-sessions-for-email-alert-frontend