### PR TITLE
Remove references to GovDelivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A consistent frontend for displaying email alert signup pages.
 ## Nomenclature
 
 - Email Alert Signup: a page displaying the title of what the User is signing up to
-- Tags: A key and array value pair which when are used by the [Email Alert API](https://github.com/alphagov/email-alert-api) to forward the user onto the govdelivery signup URL
+- Tags: A key and array value pair which when are used by the [Email Alert API](https://github.com/alphagov/email-alert-api) to forward the user onto the signup URL
 
 ## Dependences
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,4 @@ Rails.application.routes.draw do
       get '/complete' => 'subscriptions#complete', as: :subscription
     end
   end
-
-  if Rails.env.test?
-    get '/govdelivery-redirect', to: proc { [200, {}, ['']] }
-  end
 end

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -24,7 +24,7 @@ When(/^I sign up to the email alerts$/) do
   }
 
   @subscriber_list = {
-    'subscription_url' => '/govdelivery-redirect',
+    'subscription_url' => '/email/subscriptions/new?topic_id=employment-policy',
   }
 
   allow(@mock_email_alert_api).to receive(:find_or_create_subscriber_list)
@@ -37,7 +37,7 @@ end
 Then(/^my subscription should be registered$/) do
   expect(@mock_email_alert_api).to have_received(:find_or_create_subscriber_list)
     .with(@subscription_params)
-  expect(current_path).to eq '/govdelivery-redirect'
+  expect(page).to have_current_path('/email/subscriptions/new?topic_id=employment-policy')
 end
 
 Given(/^a government email alert page exists$/) do

--- a/features/step_definitions/taxonomy_email_alert_steps.rb
+++ b/features/step_definitions/taxonomy_email_alert_steps.rb
@@ -72,7 +72,7 @@ When(/^i confirm$/) do
   }
 
   @subscriber_list = {
-    'subscription_url' => '/govdelivery-redirect',
+    'subscription_url' => "/email/subscriptions/new?topic_id=#{@taxon[:title].parameterize}",
   }
 
   allow(@mock_email_alert_api).to receive(:find_or_create_subscriber_list)
@@ -87,7 +87,7 @@ Then(/^my subscription is created$/) do
     .with(@subscription_params)
 end
 
-Then(/^i am redirected to manage my subscriptions off of govuk$/) do
-  expect(current_path).to eq '/govdelivery-redirect'
+Then(/^i am redirected to manage my subscriptions$/) do
+  expect(page).to have_current_path("/email/subscriptions/new?topic_id=#{@taxon[:title].parameterize}")
 end
 # rubocop:enable Metrics/BlockLength

--- a/features/taxonomy_email_alerts.feature
+++ b/features/taxonomy_email_alerts.feature
@@ -11,4 +11,4 @@ Feature: Email alert signup
     Then i see a confirmation page
     When i confirm
     Then my subscription is created
-    And i am redirected to manage my subscriptions off of govuk
+    And i am redirected to manage my subscriptions

--- a/spec/models/taxonomy_signup_spec.rb
+++ b/spec/models/taxonomy_signup_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TaxonomySignup do
         .and_return(mock_email_alert_api)
       allow(mock_email_alert_api)
         .to receive(:find_or_create_subscriber_list)
-        .and_return('subscriber_list' => { 'subscription_url' => '/govdelivery' })
+        .and_return('subscriber_list' => { 'subscription_url' => '/something' })
     end
 
     it 'asks email-alert-api to find or create a subscriber list' do
@@ -31,7 +31,7 @@ RSpec.describe TaxonomySignup do
       signup = TaxonomySignup.new(fake_taxon)
 
       expect(signup.save).to be
-      expect(signup.subscription_management_url).to eq '/govdelivery'
+      expect(signup.subscription_management_url).to eq '/something'
     end
 
     context 'when no taxon present' do


### PR DESCRIPTION
This commit removes references to GovDelivery in the tests.