### PR TITLE
Consistently use back buttons instead of breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,7 @@ gem 'gds-api-adapters', '~> 52.1'
 gem 'govuk_app_config', '~> 1.4'
 gem 'govuk_elements_rails', '~> 3.1'
 gem 'govuk_frontend_toolkit', '~> 7.4'
-gem 'govuk_navigation_helpers', '~> 9.2'
-gem 'govuk_publishing_components', '~> 5.5'
+gem 'govuk_publishing_components', '~> 5.6.0'
 gem 'plek', '~> 2.1'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,9 +144,10 @@ GEM
       activesupport (~> 5.1)
       gds-api-adapters (>= 43.0)
       govuk_ab_testing (~> 2.4)
-    govuk_publishing_components (5.5.6)
+    govuk_publishing_components (5.6.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
+      govuk_navigation_helpers (~> 9.2.1)
       rails (>= 5.0.0.1)
       rake
       rouge
@@ -356,8 +357,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.4)
   govuk_elements_rails (~> 3.1)
   govuk_frontend_toolkit (~> 7.4)
-  govuk_navigation_helpers (~> 9.2)
-  govuk_publishing_components (~> 5.5)
+  govuk_publishing_components (~> 5.6.0)
   launchy
   phantomjs (~> 2.1)
   plek (~> 2.1)

--- a/app/controllers/taxonomy_signups_controller.rb
+++ b/app/controllers/taxonomy_signups_controller.rb
@@ -4,13 +4,10 @@ class TaxonomySignupsController < ApplicationController
   before_action :load_taxon
   before_action :validate_taxon_document_type
 
-  def new
-    load_breadcrumbs
-  end
+  def new; end
 
   def confirm
     load_estimated_email_frequency
-    load_breadcrumbs
   end
 
   def create
@@ -55,13 +52,6 @@ private
       redirect_to '/'
       false
     end
-  end
-
-  def load_breadcrumbs
-    @breadcrumbs = GovukNavigationHelpers::NavigationHelper.new(@taxon)
-      .taxon_breadcrumbs[:breadcrumbs]
-    @breadcrumbs.last.merge!(is_current_page: false, url: @taxon['base_path'])
-    @breadcrumbs << { title: 'Get email alerts', is_current_page: true }
   end
 
   def load_estimated_email_frequency

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -8,8 +8,6 @@
   <%= stylesheet_link_tag "application-without-elements" %>
 <% end %>
 
-<%= render "govuk_component/breadcrumbs", breadcrumbs: @breadcrumbs %>
-
 <%= render "govuk_publishing_components/components/back_link", {
   href: @back_url,
 } %>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -8,8 +8,6 @@
   <%= stylesheet_link_tag "application-without-elements" %>
 <% end %>
 
-<%= render "govuk_component/breadcrumbs", breadcrumbs: @breadcrumbs %>
-
 <%= render "govuk_publishing_components/components/back_link", {
   href: @back_url,
 } %>

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -8,8 +8,6 @@
   <%= stylesheet_link_tag "application-without-elements" %>
 <% end %>
 
-<%= render "govuk_component/breadcrumbs", breadcrumbs: @breadcrumbs %>
-
 <%= render "govuk_publishing_components/components/back_link", {
   href: @back_url,
 } %>

--- a/app/views/taxonomy_signups/confirm.html.erb
+++ b/app/views/taxonomy_signups/confirm.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, @taxon['title'] %>
 
-<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
+<%= render "govuk_publishing_components/components/back_link", {
+  href: @taxon['base_path']
+} %>
 
 <div class='grid-row'>
 <div class='email-signup column-two-thirds'>

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -2,7 +2,10 @@
 <% content_for :head do %>
   <meta name="robots" content="noindex, nofollow">
 <% end %>
-<%= render 'govuk_component/breadcrumbs', breadcrumbs: @breadcrumbs %>
+
+<%= render "govuk_publishing_components/components/back_link", {
+  href: @taxon['base_path']
+} %>
 
 <div class='grid-row'>
 <div class='column-two-thirds'>


### PR DESCRIPTION
We're trying to standardise the way we do navigation with the contextual navigation breadcrumbs. This PR removes the breadcrumbs from the pages in favour of a consistent back-button.

## Before

![screen shot 2018-03-21 at 14 50 54](https://user-images.githubusercontent.com/233676/37716859-6793c232-2d17-11e8-8698-8621938812af.png)

![screen shot 2018-03-21 at 14 51 06](https://user-images.githubusercontent.com/233676/37716864-682b2672-2d17-11e8-83bd-bfbe7316f5dc.png)


## After

![screen shot 2018-03-21 at 14 51 09](https://user-images.githubusercontent.com/233676/37716865-68477890-2d17-11e8-97c8-94be261ed1ab.png)

![screen shot 2018-03-21 at 14 50 56](https://user-images.githubusercontent.com/233676/37716861-67f15cda-2d17-11e8-90b6-1110d79307ac.png)


cc @rubenarakelyan 