### PR TITLE
Tweak wording on unsubscribe confirmation page

### DIFF
--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -5,9 +5,9 @@
 <%= render 'govuk_component/title', title: "Are you sure you want to unsubscribe?" %>
 <% lead_paragraph_text = capture do %>
  <% if @title %>
-You won't get any more updates about <%= @title %>.
+You won’t get any more updates about <%= @title %>.
  <% else %>
-You won't get any more updates about this topic.
+You won’t get any more updates about this topic.
  <% end %>
 <% end %>
 <%= form_tag(action: :confirmed) do %>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "You have successfully unsubscribed" %>
 <%= render 'govuk_component/title', title: @title %>
 <% if @title %>
- <p>You have successfully unsubscribed from <%= @title %>.</p>
+ <p>You won’t get any more updates about <%= @title %>.</p>
 <% else %>
- <p>You have successfully unsubscribed.</p>
+ <p>You won’t get any more updates about this topic.</p>
 <% end %>

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe UnsubscriptionsController do
     it "renders the title on the page" do
       get :confirm, params: { uuid: uuid, title: title }
 
-      expect(response.body).to include("You won&#39;t get any more updates about #{title}")
+      expect(response.body).to include("You won’t get any more updates about #{title}")
     end
 
     it "passes the title through to the 'confirmed' action" do
@@ -48,7 +48,7 @@ RSpec.describe UnsubscriptionsController do
       it "shows a different message" do
         get :confirm, params: { uuid: uuid }
 
-        expect(response.body).to include("You won&#39;t get any more updates about this topic.")
+        expect(response.body).to include("You won’t get any more updates about this topic.")
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe UnsubscriptionsController do
       it "shows a different message" do
         get :confirm, params: { uuid: uuid, title: " " }
 
-        expect(response.body).to include("You won&#39;t get any more updates about this topic.")
+        expect(response.body).to include("You won’t get any more updates about this topic.")
       end
     end
   end
@@ -77,7 +77,7 @@ RSpec.describe UnsubscriptionsController do
     it "renders a confirmation page" do
       post :confirmed, params: { uuid: uuid, title: title }
 
-      expect(response.body).to include("You have successfully unsubscribed from #{title}")
+      expect(response.body).to include("You won’t get any more updates about #{title}")
     end
 
     it "sends an unsubscribe request to email-alert-api" do
@@ -94,7 +94,7 @@ RSpec.describe UnsubscriptionsController do
       it "renders the same confirmation page" do
         post :confirmed, params: { uuid: uuid, title: title }
 
-        expect(response.body).to include("You have successfully unsubscribed from #{title}")
+        expect(response.body).to include("You won’t get any more updates about #{title}")
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe UnsubscriptionsController do
       it "shows a different message" do
         post :confirmed, params: { uuid: uuid }
 
-        expect(response.body).to include("You have successfully unsubscribed.")
+        expect(response.body).to include("You won’t get any more updates about this topic.")
       end
     end
 
@@ -110,7 +110,7 @@ RSpec.describe UnsubscriptionsController do
       it "shows a different message" do
         post :confirmed, params: { uuid: uuid, title: " " }
 
-        expect(response.body).to include("You have successfully unsubscribed.")
+        expect(response.body).to include("You won’t get any more updates about this topic.")
       end
     end
   end


### PR DESCRIPTION
This commit tweaks the wording on the unsubscribe confirmation page to match the page before it, and also to not repeat the same wording in both the title and paragraph.