### PR TITLE
Add ADR on session management

### DIFF
--- a/docs/arch/adr-001-sessions.md
+++ b/docs/arch/adr-001-sessions.md
@@ -1,11 +1,15 @@
 # Decision Record: Session management for Email Alert Frontend
 
+> NOTE
+> This ADR has been superseded by [ADR 002](adr-002-sessions.md).
+
 ## Introduction
 
 Frontend applications on GOV.UK have cookies stripped by Varnish. This renders the default CSRF protection offered by Rails useless and also raises an error if CSRF is not actively disabled for the application.
 
 ### CSRF and Authenticity Tokens
-An accepted way of securing against Cross Site Request Forgery in web applications is the inclusion of a hidden authenticity token in each form which might cause state to change (typically PUT, POST and DELETE actions). The role of the token is to ensure requests have come from pages served by the application and not malicious third party sites. The built in default CSRF protection in Rails requires session cookies.
+
+An accepted way of securing against Cross Site Request Forgery in web applications is the inclusion of a hidden authenticity token in each form which might cause state to change (typically PUT, POST and DELETE actions). The role of the token is to ensure requests have come from pages served by the application and not malicious third party sites. The built-in default CSRF protection in Rails requires session cookies.
 
 ### GOV.UK Varnish configuration
 
@@ -13,7 +17,7 @@ All GOV.UK frontend applications aside from Licensing have their cookies strippe
 
 ### Email Alert Frontend's responsibilities
 
-Email Alert Frontend is responsible for the front end journeys tha allow users to subscribe to and unsubscribe from emails. It communicates with Email Alert Api through GDS Api Adapters. Email Alert Api stores and retrieves the actual data relating to email subscriptions.
+Email Alert Frontend is responsible for the front end journeys that allow users to subscribe to and unsubscribe from emails. It communicates with Email Alert API through GDS API Adapters. Email Alert API stores and retrieves the actual data relating to email subscriptions.
 
 ## Current Decision
 
@@ -23,13 +27,10 @@ Disabling CSRF protection for the application as a whole was rejected because it
 
 ### Risk
 
-The main risk to newly developed functionality at the moment is that a malicious party could trick users into subscribing to or unsubscribing from content on GOV.UK. A further risk is that a malicious party could iterate through or craft specific UUIDs in an attempt to automate unsubscriptions.
+The main risk to newly-developed functionality at the moment is that a malicious party could trick users into subscribing to or unsubscribing from content on GOV.UK. A further risk is that a malicious party could iterate through or craft specific UUIDs in an attempt to automate unsubscriptions.
 
 ## Future
 
 It is likely that Email Alert Frontend will want to implement proper session management in a future piece of development when the full subscription management process is undertaken. At that point we should revisit this decision and if appropriate remove the code disabling CSRF protection.
 
-There are some potential issues with caching in that Fastly does not
-differentiate on session cookies which means users will see each other's
-content. This is something Tijmen brought up so it's worth chatting to him about
-it for more context.
+There are some potential issues with caching in that Fastly does not differentiate on session cookies which means users will see each other's content. This is something Tijmen brought up so it's worth chatting to him about it for more context.

--- a/docs/arch/adr-002-sessions.md
+++ b/docs/arch/adr-002-sessions.md
@@ -1,0 +1,20 @@
+# Decision Record: Session management for Email Alert Frontend
+
+> NOTE
+> This ADR supersedes by [ADR 001](adr-001-sessions.md).
+
+## Introduction
+
+As part of implementing subscription management, we have decided to enable sessions in Email Alert Frontend. This will allow users to move through the subscription management interface without having to pass large query string parameters between pages.
+
+## Technical implementation
+
+The Varnish configration for [`vcl_recv`](https://github.com/alphagov/govuk-puppet/blob/a6c51d887a6501f02766b7279127b60f02037a7f/modules/varnish/templates/default.vcl.erb#L83) and [`vcl_fetch`](https://github.com/alphagov/govuk-puppet/blob/a6c51d887a6501f02766b7279127b60f02037a7f/modules/varnish/templates/default.vcl.erb#L119) that strips all cookies except for those set by Licensing has been modified to allow cookies for all pages under `/email`. This will enable sessions to work once we start setting session data.
+
+# CSRF protection
+
+Email Alert Frontend has been updated to enable CSRF protection for controllers that render pages under `/email` since cookies are now set for these pages. This fixes some of the issues referred to in ADR 001.
+
+# Cache-Control headers
+
+Email Alert Frontend now explicitly sets the `Cache-Control` HTTP header to `private`. This signals to Fastly and our own Varnish caches that these pages should never be cached. This will prevent users from seeing other users' cached subscription data.


### PR DESCRIPTION
This commit adds ADR 002 on session management, which supersedes ADR 001 now that sessions and cookies have been enabled for all routes under `/email`.