### PR TITLE
Fix component guide

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -18,4 +18,5 @@ Rails.application.config.assets.digest = true
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
 Rails.application.config.assets.precompile += %w(
   application-without-elements.css
+  print.css
 )

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,4 @@
+GovukPublishingComponents.configure do |c|
+  c.component_guide_title = "Email Alert Frontend Component Guide"
+  c.application_stylesheet = "application-without-elements"
+end


### PR DESCRIPTION
This adds the missing configuration file which sets up the title and
stylesheet for the component guide.

We are using the application-without-elements stylesheet as elements
includes resets which impacts on the component guide rendering.

Before:

![screen shot 2018-03-28 at 14 47 46](https://user-images.githubusercontent.com/282717/38033094-15957e50-3297-11e8-8c45-fd1f77d120df.png)

After:

![screen shot 2018-03-28 at 14 48 53](https://user-images.githubusercontent.com/282717/38033120-2b1c73d2-3297-11e8-83d5-ce716b83c000.png)
