### PR TITLE
[Don't merge] Don't use internal_name of taxons

### DIFF
--- a/app/models/taxonomy_signup.rb
+++ b/app/models/taxonomy_signup.rb
@@ -22,16 +22,12 @@ private
 
   def subscription_params
     {
-      'title' => title,
+      'title' => taxon['title'],
       'links' => {
         # 'taxon_tree' is the key used in email-alert-service for
         # notifications, so create a subscriber list with this key.
         'taxon_tree' => [taxon['content_id']]
       }
     }
-  end
-
-  def title
-    taxon['details'] && taxon['details']['internal_name'] || taxon['title']
   end
 end

--- a/spec/models/taxonomy_signup_spec.rb
+++ b/spec/models/taxonomy_signup_spec.rb
@@ -43,29 +43,5 @@ RSpec.describe TaxonomySignup do
         expect(signup.subscription_management_url).to eq nil
       end
     end
-
-    context 'when the taxon has an internal_name' do
-      let(:fake_taxon) {
-        {
-          'title' => 'Birth, death and marriage abroad',
-          'content_id' => 'foo-id',
-          'details' => {
-            'internal_name' => 'Birth, death and marriage abroad (India)'
-          }
-        }
-      }
-
-      it 'creates the subscription using the internal name' do
-        signup = TaxonomySignup.new(fake_taxon)
-
-        expect(signup.save).to be
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with(
-            'title' => 'Birth, death and marriage abroad (India)',
-            'links' => { 'taxon_tree' => ['foo-id'] }
-          )
-      end
-    end
   end
 end


### PR DESCRIPTION
The internal_name is not meant for public consumption, it's used in content tagger to give more context to the taxonomists.

This makes it so the subscriptions are created with just the title.

The internal_name was introduced in https://github.com/alphagov/email-alert-frontend/commit/78fdf94e64f61c1f86bb91fc4aadfc5ff602aa65.

The reasoning behind it is that the titles needed to be unique in the system, something that was enforced by GovDelivery. Because we're no longer using GovDelivery, we should be able to remove the uniqueness constraint. 

A PR on email-alert-api is forthcoming, don't merge until that is deployed.