### PR TITLE
Stop search engines from indexing any of the pages

### DIFF
--- a/app/views/authentication/request_sign_in_token.html.erb
+++ b/app/views/authentication/request_sign_in_token.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Manage your subscriptions' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/authentication/sign_in.html.erb
+++ b/app/views/authentication/sign_in.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Manage your subscriptions' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
       <%= stylesheet_link_tag "application" %>
     <% end %>
     <%= yield :head %>
+    <meta name="robots" content="noindex, nofollow">
   </head>
   <body>
     <div id="wrapper">

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, "Subscription created successfully" %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag "application-without-elements" %>
 <% end %>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, "Enter your email address" %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag "application-without-elements" %>
 <% end %>

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, "Get emails when pages are added or updated" %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag "application-without-elements" %>
 <% end %>

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Are you sure you want to unsubscribe from everything?' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Manage your subscriptions' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Change your email address' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Manage your subscriptions' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -1,7 +1,4 @@
 <% content_for :title, @taxon['title'] %>
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
 
 <%= render "govuk_publishing_components/components/back_link", {
   href: @taxon['base_path']

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Are you sure you want to unsubscribe?' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
+++ b/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
@@ -4,10 +4,6 @@ page_title += " from #{@title}" if @title
 content_for :title, page_title
 %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'You’ve successfully unsubscribed' %>
 
-<% content_for :head do %>
-  <meta name="robots" content="noindex, nofollow">
-<% end %>
-
 <% content_for :head_css do %>
   <%= stylesheet_link_tag 'application-without-elements' %>
 <% end %>


### PR DESCRIPTION
This currently is set up for all pages except the email signup (https://github.com/alphagov/email-alert-frontend/blob/master/app/views/ email_alert_signups/new.html.erb). This is probably an oversight.

cc @rubenarakelyan 

https://trello.com/c/vmMXWtP7