### PR TITLE
Use button component from gem

### DIFF
--- a/app/views/authentication/sign_in.html.erb
+++ b/app/views/authentication/sign_in.html.erb
@@ -51,7 +51,7 @@
           <p>We’ll send you a link to confirm your email address.</p>
         }
       } %>
-      <%= render 'govuk_component/button', {
+      <%= render 'govuk_publishing_components/components/button', {
         text: 'Continue',
         margin_bottom: true,
         data_attributes: {

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -58,7 +58,7 @@
         value: @address,
       } %>
 
-      <%= render "govuk_component/button", {
+      <%= render "govuk_publishing_components/components/button", {
         text: "Subscribe",
         margin_bottom: true,
         data_attributes: {

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -44,7 +44,7 @@
       </div>
 
       <div class="form-group">
-        <%= render "govuk_component/button", {
+        <%= render "govuk_publishing_components/components/button", {
           text: "Next",
           margin_bottom: true,
           data_attributes: {

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -21,7 +21,7 @@
     } %>
     <%= form_tag(action: :confirmed_unsubscribe_all) do %>
       <%= hidden_field_tag(:from, @from) %>
-      <%= render 'govuk_component/button', {
+      <%= render 'govuk_publishing_components/components/button', {
         text: 'Unsubscribe',
         margin_bottom: true,
         data_attributes: {

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -49,7 +49,7 @@
           content: %{<p>If you want to transfer your subscription to #{@new_address}, you’ll need to subscribe to the same topics again, using the new email address. Or you can <a href="/contact/govuk">contact us</a>.</p>}
         } %>
       <% end %>
-      <%= render 'govuk_component/button', {
+      <%= render 'govuk_publishing_components/components/button', {
         text: 'Save',
         margin_bottom: true,
         data_attributes: {

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -45,7 +45,7 @@
         <% end %>
       </div>
       <div class="form-group">
-        <%= render 'govuk_component/button', {
+        <%= render 'govuk_publishing_components/components/button', {
           text: 'Save',
           margin_bottom: true,
           data_attributes: {

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -29,7 +29,7 @@
       content: paragraph_text
     } %>
     <%= form_tag(action: :confirmed) do %>
-      <%= render 'govuk_component/button', {
+      <%= render 'govuk_publishing_components/components/button', {
         text: 'Unsubscribe',
         margin_bottom: true,
         data_attributes: {


### PR DESCRIPTION
Button component recently moved from static to the components gem. This PR updates the use of the component in this app.

The version of the gem containing the button was already incremented in a previous PR.