### PR TITLE
Use title component from the gem

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def title(text, params = {})
+    render 'govuk_publishing_components/components/title', { title: text }.merge(params)
+  end
 end

--- a/app/views/authentication/request_sign_in_token.html.erb
+++ b/app/views/authentication/request_sign_in_token.html.erb
@@ -6,7 +6,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'Manage your subscriptions' %>
+    <%= title 'Manage your subscriptions' %>
   </div>
 </div>
 

--- a/app/views/authentication/sign_in.html.erb
+++ b/app/views/authentication/sign_in.html.erb
@@ -6,7 +6,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'Manage your subscriptions' %>
+    <%= title 'Manage your subscriptions' %>
   </div>
 </div>
 

--- a/app/views/email_alert_signups/new.html.erb
+++ b/app/views/email_alert_signups/new.html.erb
@@ -6,10 +6,7 @@
 <% end %>
 
 <header>
-  <%= render partial: 'govuk_component/title', locals: {
-    title: email_alert_signup.title,
-    context: "Email alert subscription"
-  } %>
+  <%= title email_alert_signup.title, context: "Email alert subscription" %>
 </header>
 
 <%= form_for email_alert_signup, html: { class: "signup-form" } do |form| %>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -22,9 +22,7 @@
       } %>
     <% end %>
 
-    <%= render partial: "govuk_component/title", locals: {
-      title: "Enter your email address",
-    } %>
+    <%= title "Enter your email address" %>
 
     <% frequency_variations = {
       "immediately" => "You’ll get an email every time a page is added or changed.",

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -11,9 +11,7 @@
 <div class="grid-row">
   <div class="column-two-thirds">
 
-    <%= render partial: "govuk_component/title", locals: {
-      title: "Get emails when pages are added or updated",
-    } %>
+    <%= title "Get emails when pages are added or updated" %>
 
     <%= form_tag subscription_frequency_path, method: :post do %>
       <%= hidden_field_tag :topic_id, @topic_id %>

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -10,7 +10,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'Are you sure you want to unsubscribe from everything?' %>
+    <%= title 'Are you sure you want to unsubscribe from everything?' %>
   </div>
 </div>
 

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'Manage your subscriptions' %>
+    <%= title 'Manage your subscriptions' %>
 
     <% if flash[:success] %>
       <div class="responsive-bottom-margin">

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -10,7 +10,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'Change your email address' %>
+    <%= title 'Change your email address' %>
   </div>
 </div>
 

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -10,7 +10,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'Manage your subscriptions' %>
+    <%= title 'Manage your subscriptions' %>
   </div>
 </div>
 

--- a/app/views/taxonomy_signups/confirm.html.erb
+++ b/app/views/taxonomy_signups/confirm.html.erb
@@ -7,10 +7,7 @@
 <div class='grid-row'>
 <div class='email-signup column-two-thirds'>
 
-  <%= render partial: 'govuk_component/title', locals: {
-    average_title_length: "long",
-    title: "What you'll get"
-  } %>
+  <%= title "What you'll get", average_title_length: "long" %>
 
   <p>
     You'll get alerts when the government publishes or changes anything on GOV.UK about: <%= @taxon['title'] %>.

--- a/app/views/taxonomy_signups/confirm.html.erb
+++ b/app/views/taxonomy_signups/confirm.html.erb
@@ -7,7 +7,7 @@
 <div class='grid-row'>
 <div class='email-signup column-two-thirds'>
 
-  <%= title "What you'll get", average_title_length: "long" %>
+  <%= title "What you’ll get", average_title_length: "long" %>
 
   <p>
     You'll get alerts when the government publishes or changes anything on GOV.UK about: <%= @taxon['title'] %>.

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -10,10 +10,7 @@
 <% child_taxons = @taxon.dig('links', 'child_taxons') %>
 
 <% if child_taxons.present?%>
-  <%= render partial: 'govuk_component/title', locals: {
-    average_title_length: "long",
-    title: "What do you want to get alerts about?"
-  } %>
+  <%= title "What do you want to get alerts about?", average_title_length: "long" %>
 
   <%= form_tag({action: "confirm"}, method: "get") do %>
     <fieldset>

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -12,7 +12,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'Are you sure you want to unsubscribe?' %>
+    <%= title 'Are you sure you want to unsubscribe?' %>
   </div>
 </div>
 

--- a/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
+++ b/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
@@ -16,7 +16,7 @@ content_for :title, page_title
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: page_title %>
+    <%= title page_title %>
   </div>
 </div>
 

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -12,7 +12,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/title', title: 'You’ve successfully unsubscribed' %>
+    <%= title 'You’ve successfully unsubscribed' %>
   </div>
 </div>
 

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -12,9 +12,7 @@ When(/^I access the email signup page$/) do
 end
 
 Then(/^I see the email signup page$/) do
-  within(shared_component_selector("title")) do
-    expect(page).to have_content("Employment")
-  end
+  expect(page).to have_content("Employment")
 end
 
 When(/^I sign up to the email alerts$/) do


### PR DESCRIPTION
The title component is moving from Static to the gem. This makes all pages use the gem-component using a helper, which cleans up the views a bit.

https://trello.com/c/EruCrkqO