### PR TITLE
Use govspeak component from gem

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,10 @@
 module ApplicationHelper
+  def govspeak
+    render "govuk_publishing_components/components/govspeak", rich_govspeak: true do
+      yield
+    end
+  end
+
   def title(text, params = {})
     render 'govuk_publishing_components/components/title', { title: text }.merge(params)
   end

--- a/app/views/authentication/request_sign_in_token.html.erb
+++ b/app/views/authentication/request_sign_in_token.html.erb
@@ -12,11 +12,9 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/govspeak', {
-      content: %{
-        <p>If you’re subscribed to emails from GOV.UK, we’ll send a link to #{@address}.</p>
-        <p>Use the link in the email to confirm your email address.</p>
-      }
-    } %>
+    <%= govspeak do %>
+      <p>If you’re subscribed to emails from GOV.UK, we’ll send a link to <%= @address %>.</p>
+      <p>Use the link in the email to confirm your email address.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/authentication/sign_in.html.erb
+++ b/app/views/authentication/sign_in.html.erb
@@ -46,11 +46,11 @@
         type: 'email',
         value: @address,
       } %>
-      <%= render 'govuk_component/govspeak', {
-        content: %{
-          <p>We’ll send you a link to confirm your email address.</p>
-        }
-      } %>
+
+      <%= govspeak do %>
+        <p>We’ll send you a link to confirm your email address.</p>
+      <% end %>
+
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Continue',
         margin_bottom: true,

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -20,8 +20,8 @@
       "weekly" => "You’ll get one email per week if there’s been an update to ‘#{@title}’.",
     } %>
 
-    <%= render "govuk_component/govspeak", {
-      content: "<p>#{frequency_variations[@frequency]}</p>"
-    } %>
+    <%= govspeak do %>
+      <p><%= frequency_variations[@frequency] %></p>
+    <% end %>
   </div>
 </div>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -30,18 +30,13 @@
       "weekly" => "You'll get one email per week if a page is added or changed.",
     } %>
 
-    <% subscription_info = capture do %>
+    <%= govspeak do %>
       <p>
         You’re subscribing to get email notifications about: <br/>
         ‘<strong><%= @title %></strong>’.
       </p>
       <p><%= frequency_variations[@frequency] %></p>
     <% end %>
-
-    <%= render "govuk_component/govspeak", {
-      content: subscription_info,
-      rich_govspeak: true
-    } %>
 
     <%= form_tag create_subscription_path, method: :post do %>
       <%= hidden_field_tag :topic_id, @topic_id %>
@@ -67,8 +62,9 @@
         },
       } %>
     <%- end -%>
-    <%= render "govuk_component/govspeak", {
-      content: '<p>We won’t share your email address with anyone. Read our <a href="https://www.gov.uk/help/privacy-policy" target="_blank">privacy policy (opens in new tab)</a>.</p>'
-    } %>
+
+    <%= govspeak do %>
+      <p>We won’t share your email address with anyone. Read our <a href="https://www.gov.uk/help/privacy-policy" target="_blank">privacy policy (opens in new tab)</a>.</p>
+    <% end %>
   </div>
 </div>

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -18,7 +18,7 @@
 
       <div class="form-group">
         <%= render "govuk_publishing_components/components/fieldset", {
-          legend_text: render("govuk_component/govspeak", content: %{<h2 class="app-legend-title">How often do you want to get updates?</h2>}),
+          legend_text: render("govuk_publishing_components/components/govspeak", content: %{<h2 class="app-legend-title">How often do you want to get updates?</h2>}.html_safe),
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "frequency",

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -16,9 +16,10 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/govspeak', {
-      content: %{<p>You won’t get any more automated emails from GOV.UK.</p>}
-    } %>
+    <%= govspeak do %>
+      <p>You won’t get any more automated emails from GOV.UK.</p>
+    <% end %>
+
     <%= form_tag(action: :confirmed_unsubscribe_all) do %>
       <%= hidden_field_tag(:from, @from) %>
       <%= render 'govuk_publishing_components/components/button', {
@@ -31,8 +32,8 @@
         },
       } %>
     <% end %>
-    <%= render 'govuk_component/govspeak', {
-      content: %{<p><a href="#{@back_url}">Cancel</a></p>}
-    } %>
+    <%= govspeak do %>
+      <p><%= link_to "Cancel", @back_url %></p>
+    <% end %>
   </div>
 </div>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -20,18 +20,22 @@
       text: "Subscriptions for #{@subscriber['address']}",
       heading_level: 2
     } %>
-    <%= render 'govuk_component/govspeak', {
-      content: %{<p><a href="#{update_address_path}">Change email address</a></p>}
-    } %>
+
+    <%= govspeak do %>
+      <p><%= link_to "Change email address", update_address_path %></p>
+    <% end %>
   </div>
 </div>
 
 <div class="grid-row">
   <div class="column-two-thirds add-title-margin">
     <% if @subscriptions.empty? %>
-      <%= render 'govuk_component/govspeak', {
-        content: %{<p>You aren’t subscribed to any topics on GOV.UK. <a href="/help/update-email-notifications#how-to-subscribe">Find out how to subscribe</a>.</p>}
-      } %>
+      <%= govspeak do %>
+        <p>
+          You aren’t subscribed to any topics on GOV.UK.
+          <a href="/help/update-email-notifications#how-to-subscribe">Find out how to subscribe</a>.
+        </p>
+      <% end %>
     <% else %>
       <% @subscriptions.each do |_key, subscription| %>
         <div class="responsive-bottom-margin">
@@ -39,7 +43,7 @@
             text: subscription['subscriber_list']['title'],
             heading_level: 3
           } %>
-          <% subscription_info = capture do %>
+          <%= govspeak do %>
             <p>
               <% if subscription['frequency'] == "daily" %>
                 You chose to get daily updates.
@@ -52,14 +56,14 @@
             </p>
             <p><a href="<%= confirm_unsubscribe_path(id: subscription['id']) %>">Unsubscribe</a></p>
           <% end %>
-          <%= render 'govuk_component/govspeak', {
-            content: subscription_info
-          } %>
         </div>
       <% end %>
-      <%= render 'govuk_component/govspeak', {
-        content: %{<div class="info-notice"><p><a href="#{confirm_unsubscribe_all_path}">Unsubscribe from everything</a></p></div>}
-      } %>
+
+      <%= govspeak do %>
+        <div class="info-notice">
+          <p><%= link_to "Unsubscribe from everything", confirm_unsubscribe_all_path %></p>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -32,9 +32,10 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <%= render 'govuk_component/govspeak', {
-      content: %{<p>Your current email address is #{@address}</p>}
-    } %>
+    <%= govspeak do %>
+      <p>Your current email address is <%= @address %></p>
+    <% end %>
+
     <%= form_tag change_address_path, method: :post do %>
       <%= render 'govuk_publishing_components/components/input', {
         error_message: flash[:error],
@@ -45,9 +46,12 @@
         value: @new_address,
       } %>
       <% unless @new_address.nil? %>
-        <%= render 'govuk_component/govspeak', {
-          content: %{<p>If you want to transfer your subscription to #{@new_address}, you’ll need to subscribe to the same topics again, using the new email address. Or you can <a href="/contact/govuk">contact us</a>.</p>}
-        } %>
+        <%= govspeak do %>
+          <p>If you want to transfer your subscription to <%= @new_address %>,
+            you’ll need to subscribe to the same topics again, using the new
+            email address. Or you can <a href="/contact/govuk">contact us</a>.
+          </p>
+        <% end %>
       <% end %>
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Save',
@@ -59,8 +63,8 @@
         },
       } %>
     <%- end -%>
-    <%= render 'govuk_component/govspeak', {
-      content: %{<p><a href="#{@back_url}">Cancel</a></p>}
-    } %>
+    <%= govspeak do %>
+      <p><%= link_to "Cancel", @back_url %></p>
+    <% end %>
   </div>
 </div>

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -20,7 +20,7 @@
       <%= hidden_field_tag :id, @subscription_id %>
       <div class="form-group">
         <%= render 'govuk_publishing_components/components/fieldset', {
-          legend_text: render('govuk_component/govspeak', content: %{<h2 class="app-legend-title">How often do you want to get updates?</h2>}),
+          legend_text: render('govuk_publishing_components/components/govspeak', content: %{<h2 class="app-legend-title">How often do you want to get updates?</h2>}.html_safe),
         } do %>
           <%= render 'govuk_publishing_components/components/radio', {
             name: 'new_frequency',
@@ -57,8 +57,8 @@
         } %>
       </div>
     <%- end -%>
-    <%= render 'govuk_component/govspeak', {
-      content: %{<p><a href="#{@back_url}">Cancel</a></p>}
-    } %>
+    <%= govspeak do %>
+      <p><%= link_to "Cancel", @back_url %></p>
+    <% end %>
   </div>
 </div>

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -18,16 +18,14 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <% paragraph_text = capture do %>
+    <%= govspeak do %>
       <% if @title %>
         <p>You won’t get any more updates about <%= @title %>.</p>
       <% else %>
         <p>You won’t get any more updates about this topic.</p>
       <% end %>
     <% end %>
-    <%= render 'govuk_component/govspeak', {
-      content: paragraph_text
-    } %>
+
     <%= form_tag(action: :confirmed) do %>
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Unsubscribe',
@@ -41,9 +39,9 @@
       } %>
     <% end %>
     <% if @authenticated_for_subscription %>
-      <%= render 'govuk_component/govspeak', {
-        content: %{<p><a href="#{list_subscriptions_path}">Cancel</a></p>}
-      } %>
+      <%= govspeak do %>
+        <p><%= link_to "Cancel", list_subscriptions_path %></p>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
+++ b/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
@@ -22,15 +22,12 @@ content_for :title, page_title
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <% paragraph_text = capture do %>
+    <%= govspeak do %>
       <% if @title %>
         <p>You won’t get any more updates about <%= @title %>.</p>
       <% else %>
         <p>You won’t get any more updates about this topic.</p>
       <% end %>
     <% end %>
-    <%= render 'govuk_component/govspeak', {
-      content: paragraph_text
-    } %>
   </div>
 </div>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -18,7 +18,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <% paragraph_text = capture do %>
+    <%= govspeak do %>
       <% if @title %>
         <p>You won’t get any more updates about <%= @title %>.</p>
       <% else %>
@@ -28,8 +28,5 @@
         <p><a href="<%= @back_url %>">Back to manage your subscriptions</a>.</p>
       <% end %>
     <% end %>
-    <%= render 'govuk_component/govspeak', {
-      content: paragraph_text
-    } %>
   </div>
 </div>

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -63,10 +63,8 @@ RSpec.describe UnsubscriptionsController do
 
       it "shows a cancel button" do
         get :confirm, params: { id: id }, session: session
-        # Because of static components we can't do a `expect(body).to have_link`
-        expect(response.body).to include(
-          CGI.escapeHTML(%{<a href=\\"#{list_subscriptions_path}\\">Cancel</a>})
-        )
+
+        expect(response.body).to have_link("Cancel", href: list_subscriptions_path)
       end
     end
 


### PR DESCRIPTION
The Govspeak component has moved from Static to the gem. This switches this app to use the gem-based component.

To make the transition easier I've added a `govspeak` helper that takes a block. This cleans up the views a lot and makes it easier to read the HTML. It also makes sure that we're using Rails' HTML escaping mechanism by default, which is needed because the component will in the future no longer call `.html_safe` on the input (https://github.com/alphagov/govuk_publishing_components/pull/356). This fixes at least one (unexploitable) [XSS vulnerability in this app][1] (`@address` is add to the page unescaped).

[1]: https://github.com/alphagov/email-alert-frontend/blob/73dc8d4db0174b215fc61c42fa8ad992f2d8f6d2/app/views/authentication/request_sign_in_token.html.erb#L17

https://trello.com/c/uwcWXXNp