### PR TITLE
Set rubyLintDiff to false in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,8 @@
 library("govuk")
 
 node {
-  govuk.buildProject(sassLint: false)
+  govuk.buildProject(
+    sassLint: false,
+    rubyLintDiff: false
+  )
 }


### PR DESCRIPTION
To ensure that the entire codebase is checked by the linter.