### PR TITLE
Handle JWT::VerificationError in AuthenticationController

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -52,7 +52,7 @@ private
     subscriber_id = data.fetch('subscriber_id')
     redirect = data.fetch('redirect')
     [subscriber_id, redirect]
-  rescue JWT::ExpiredSignature, KeyError
+  rescue JWT::ExpiredSignature, JWT::VerificationError, KeyError
     []
   end
 


### PR DESCRIPTION
This is happening quite a lot on staging, presumably as the secret is
different, the tokens coming through from the traffic replay are
indeed invalid.