### PR TITLE
Enable Brakeman

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ library("govuk")
 node {
   govuk.buildProject(
     sassLint: false,
-    rubyLintDiff: false
+    rubyLintDiff: false,
+    brakeman: true,
   )
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "5d437b79cadf3c7bcdd77273a7cfa2dd8e893179191484e5e9a751cdf53c6163",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/taxonomy_signups_controller.rb",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(TaxonomySignup.new(EmailAlertFrontend.services(:content_store).content_item(taxon_path).to_h).subscription_management_url)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "TaxonomySignupsController",
+        "method": "create"
+      },
+      "user_input": "TaxonomySignup.new(EmailAlertFrontend.services(:content_store).content_item(taxon_path).to_h).subscription_management_url",
+      "confidence": "High",
+      "note": "This URL comes from the Content Store and we trust all the data in the Content Store."
+    }
+  ],
+  "updated": "2018-08-02 08:34:22 +0100",
+  "brakeman_version": "4.3.1"
+}


### PR DESCRIPTION
This will allow us to check for security vulnerabilities in our apps.

I've had to ignore a warning in this repository, and there is a justification in the commit message.

[Trello Card](https://trello.com/c/JyrOAef3/363-fix-sql-injection-vulnerabilities-in-govuk-applications)