### PR TITLE
Remove rich govspeak

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'gds-api-adapters', '~> 52.7'
 gem 'govuk_app_config', '~> 1.8'
 gem 'govuk_elements_rails', '~> 3.1'
 gem 'govuk_frontend_toolkit', '~> 7.6'
-gem 'govuk_publishing_components', '~> 9.9'
+gem 'govuk_publishing_components', '~> 9.10'
 gem 'plek', '~> 2.1'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,7 @@ GEM
     govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (9.9.1)
+    govuk_publishing_components (9.10.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -364,7 +364,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.8)
   govuk_elements_rails (~> 3.1)
   govuk_frontend_toolkit (~> 7.6)
-  govuk_publishing_components (~> 9.9)
+  govuk_publishing_components (~> 9.10)
   jwt (~> 2.1)
   launchy
   phantomjs (~> 2.1)
@@ -383,4 +383,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def govspeak
-    render "govuk_publishing_components/components/govspeak", rich_govspeak: true do
+    render "govuk_publishing_components/components/govspeak" do
       yield
     end
   end


### PR DESCRIPTION
https://trello.com/c/BUij6N3Y/361-turn-on-bold-for-whitehall

Rich govspeak (bold) will be enabled by default.

Depends on: https://github.com/alphagov/govuk_publishing_components/pull/463