### PR TITLE
Support setting asset_host in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  config.asset_host = ENV['GOVUK_ASSET_ROOT'] if ENV['GOVUK_ASSET_ROOT'].present?
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 


### PR DESCRIPTION
This means that Email Alert Frontend assets work when using the
development environment, a real host for assets.