### PR TITLE
Remove poltergeist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ group :test do
   gem 'cucumber-rails', '~> 1.6', require: false
   gem 'launchy'
   gem 'phantomjs', '~> 2.1'
-  gem 'poltergeist', require: false
   gem 'rspec-rails', '~> 3.8'
   gem 'timecop', '~> 0.9.1'
   gem 'webmock', '~> 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
-    cliver (0.3.2)
     coderay (1.1.2)
     commander (4.4.6)
       highline (~> 1.7.2)
@@ -203,10 +202,6 @@ GEM
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)
-    poltergeist (1.17.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -365,7 +360,6 @@ DEPENDENCIES
   launchy
   phantomjs (~> 2.1)
   plek (~> 2.1)
-  poltergeist
   pry-byebug
   rails (= 5.2.1)
   rspec-rails (~> 3.8)

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe "subscribing", type: :feature do
     context "arrived at form without referer" do
       it "links to govuk website root" do
         visit new_subscription_path
-        page.save_screenshot('screenshot.png')
         expect(back_link_href).to match(%r{gov.uk$})
       end
     end

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "subscribing", type: :feature do
 
     context "arrived at form with referer" do
       it "has a link to the referer forced onto the gov.uk domain" do
-        page.driver.add_header("Referer", "http://example.com/some/page?query=string", permanent: false)
+        page.driver.header("Referer", "http://example.com/some/page?query=string")
         visit new_subscription_path
         expect(back_link_href).to match(%r{gov.uk/some/page\?query=string$})
       end
@@ -66,7 +66,7 @@ RSpec.describe "subscribing", type: :feature do
       it "links to govuk website root" do
         visit new_subscription_path
         page.save_screenshot('screenshot.png')
-        expect(back_link_href).to match(%r{gov.uk/$})
+        expect(back_link_href).to match(%r{gov.uk$})
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,12 +6,6 @@ require 'rspec/rails'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require 'capybara/poltergeist'
-require 'phantomjs/poltergeist'
-
-Capybara.default_driver = :poltergeist
-Capybara.javascript_driver = :poltergeist
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
https://trello.com/c/0QzuQFMb/415-epic-switch-app-test-suites-from-poltergeist-to-headless-chrome-using-govuktest

Removes poltergeist which is no longer actively maintained.
The test suite doesn't need a JS driver so I've modified to work with `Capybara::RackTest`