### PR TITLE
Don't show empty descriptions for taxons

### DIFF
--- a/app/views/taxonomy_signups/_taxon.html.erb
+++ b/app/views/taxonomy_signups/_taxon.html.erb
@@ -15,7 +15,7 @@
 <div id='radio<%= taxon_index %>' class='form-block hidden-submit panel no-js-panel panel-border-narrow js-hidden' aria-hidden="true">
   <% if is_parent %>
     <p> This will include alerts about all the topics below </p>
-  <% else %>
+  <% elsif taxon['description'].present? %>
     <p> This will include: <%= taxon['description'] %> </p>
   <% end %>
 

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -37,7 +37,9 @@
 
   <div>
     <p>You are signing up for email alerts about: <%= @taxon['title']%></p>
-    <p>This will include: <%= @taxon['description']%></p>
+    <% if @taxon['description'].present? %>
+      <p>This will include: <%= @taxon['description'] %></p>
+    <% end %>
 
     <%= link_to 'Select', confirm_taxonomy_signup_path(topic: @taxon['base_path']), class: 'button' %>
   </div>


### PR DESCRIPTION
Many topic pages don't have descriptions, so don't assume that they
do.