### PR TITLE
Don't show taxons in the alpha phase

### DIFF
--- a/app/controllers/taxonomy_signups_controller.rb
+++ b/app/controllers/taxonomy_signups_controller.rb
@@ -2,6 +2,7 @@ class TaxonomySignupsController < ApplicationController
   protect_from_forgery except: [:create]
   before_action :require_taxon_param
   before_action :validate_taxon_document_type
+  helper_method :child_taxons
 
   def new; end
 
@@ -17,6 +18,12 @@ class TaxonomySignupsController < ApplicationController
     else
       redirect_to confirm_taxonomy_signup_path(topic: taxon_path)
     end
+  end
+
+  def child_taxons
+    taxon['links']
+      .fetch('child_taxons', [])
+      .reject { |taxon| taxon['phase'] == 'alpha' }
   end
 
 private

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -7,8 +7,6 @@
 <div class='grid-row'>
 <div class='column-two-thirds'>
 
-<% child_taxons = @taxon.dig('links', 'child_taxons') %>
-
 <% if child_taxons.present?%>
   <%= title "What do you want to get alerts about?", average_title_length: "long" %>
 


### PR DESCRIPTION
At least as children. This is to prevent taxons which are not ready
for people to sign up to from showing up.