### PR TITLE
Adds `govuk-!-margin-bottom-6` spacing to legend

### DIFF
--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -18,7 +18,7 @@
 
       <div class="form-group">
         <%= render "govuk_publishing_components/components/fieldset", {
-          legend_text: render("govuk_publishing_components/components/govspeak", content: %{<h2 class="app-legend-title">How often do you want to get updates?</h2>}.html_safe),
+          legend_text: render("govuk_publishing_components/components/govspeak", content: %{<h2 class="app-legend-title govuk-!-margin-bottom-6">How often do you want to get updates?</h2>}.html_safe),
         } do %>
           <%= render "govuk_publishing_components/components/radio", {
             name: "frequency",


### PR DESCRIPTION
## Before
<img width="735" alt="screen shot 2018-12-05 at 13 36 25" src="https://user-images.githubusercontent.com/4599889/49518492-add4fe00-f896-11e8-927d-a0f3c9afe1b4.png">

## After
<img width="832" alt="screen shot 2018-12-05 at 13 37 39" src="https://user-images.githubusercontent.com/4599889/49518506-b4fc0c00-f896-11e8-8f98-d824a311275b.png">
