### PR TITLE
Fix frontend after clean up

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,12 @@
   margin-bottom: $govuk-gutter-half;
   line-height: 1.5;
 }
+
+// TODO: remove these overwrites after the title component is updated to work
+// nicely with govuk-frontend layout
+.app-title {
+  .gem-c-title {
+    margin-top: $govuk-gutter-half;
+    margin-bottom: $govuk-gutter-half;
+  }
+}

--- a/app/views/email_alert_signups/new.html.erb
+++ b/app/views/email_alert_signups/new.html.erb
@@ -5,12 +5,12 @@
   <%= render 'govuk_publishing_components/components/government_navigation', active: email_alert_signup.government_content_section %>
 <% end %>
 
-<header>
+<header class="app-title">
   <%= title email_alert_signup.title, context: "Email alert subscription" %>
 </header>
 
 <%= form_for email_alert_signup, html: { class: "signup-form" } do |form| %>
-  <p><%= email_alert_signup.summary %></p>
+  <p class="govuk-body"><%= email_alert_signup.summary %></p>
 
   <%= render "govuk_publishing_components/components/button", {
     text: "Create subscription"

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= title 'Manage your subscriptions' %>
+    <h1 class="govuk-heading-l"> Manage your subscriptions</h1>
 
     <% if flash[:success] %>
       <%= render 'govuk_publishing_components/components/success_alert', {
@@ -47,7 +47,7 @@
         <hr class="govuk-section-break govuk-section-break--m">
       <% end %>
 
-      <%= unsubscribe_all_text = capture do %>
+      <% unsubscribe_all_text = capture do %>
         <p class="govuk-body"><%= link_to "Unsubscribe from everything", confirm_unsubscribe_all_path %></p>
       <% end %>
 

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -1,9 +1,11 @@
 <% content_for :title, 'Are you sure you want to unsubscribe?' %>
 
 <% if @authenticated_for_subscription %>
-  <%= render 'govuk_publishing_components/components/back_link', {
-    href: list_subscriptions_path,
-  } %>
+  <% content_for :back_link do %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: list_subscriptions_path
+    } %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
This PR fixes some bits after the major layout update in #383 as follows:
- Update email sign-up title spacing and add missing paragraph class (see captures below) - a page I didn't manage to test in local dev env
- Removes redundant output for the "Unsubscribe from everything" link
- Renders back link consistently across pages (the link was rendered in one view instead of being passed to the main layout)


### Before
![old-email-subscription](https://user-images.githubusercontent.com/788096/50596572-a6f0d980-0e9c-11e9-9441-b3c43f551c80.png)

### After
![new-email-subscription](https://user-images.githubusercontent.com/788096/50596584-ad7f5100-0e9c-11e9-8cd2-f047c162eba2.png)

---
[Trello card](https://trello.com/c/Lqs4a0p4)