### PR TITLE
Only show conditional if the description is present for a taxon

### DIFF
--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -32,7 +32,7 @@
         items: child_taxons.each.map { |taxon| {
           :value => taxon['base_path'],
           :text => taxon['title'],
-          :conditional => ('<p class="govuk-body">This will include: ' + taxon['description'] + '</p>').html_safe
+          :conditional => taxon['description'].present? ? ('<p class="govuk-body">This will include: ' + taxon['description'] + '</p>').html_safe : ''
         } }
       } %>
 


### PR DESCRIPTION
Some taxons don't have descriptions and they come through as nil, which means this line fails when it tries to concatenate the string. Later on in this file we have a `<% if @taxon['description'].present? %>` so I've replicated that in this line.