### PR TITLE
Don't show links to alpha taxons

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,8 @@ module ApplicationHelper
   def title(text, params = {})
     render 'govuk_publishing_components/components/title', { title: text }.merge(params)
   end
+
+  def live_taxon?(taxon)
+    taxon['phase'] == 'live'
+  end
 end

--- a/app/views/taxonomy_signups/new.html.erb
+++ b/app/views/taxonomy_signups/new.html.erb
@@ -1,9 +1,11 @@
 <% content_for :title, @taxon['title'] %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: @taxon['base_path']
-  } %>
+<% if live_taxon?(@taxon) %>
+  <% content_for :back_link do %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: @taxon['base_path']
+    } %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -59,9 +61,11 @@
 
   <% end %>
 
+  <% if live_taxon?(@taxon) %>
   <p class="govuk-body">
     <%= link_to 'Back to select a different topic', @taxon['base_path'], class: 'govuk-link' %>
   </p>
+  <% end %>
 
   </div>
 </div>

--- a/spec/features/taxonomy_alerts_spec.rb
+++ b/spec/features/taxonomy_alerts_spec.rb
@@ -13,4 +13,28 @@ RSpec.describe "Subscribing to the taxonomy", type: :feature do
       expect(page).to have_content document["title"]
     end
   end
+
+  it "shows navigation links for live taxons" do
+    document = GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |doc|
+      doc.merge('phase' => 'live')
+    end
+
+    content_store_has_item(document['base_path'], document)
+    visit "/email-signup?topic=#{document['base_path']}"
+
+    expect(page).to have_link "Back", href: document['base_path']
+    expect(page).to have_link "Back to select a different topic", href: document['base_path']
+  end
+
+  it "doesn't show links for non-live taxons" do
+    document = GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |doc|
+      doc.merge('phase' => 'alpha')
+    end
+
+    content_store_has_item(document['base_path'], document)
+    visit "/email-signup?topic=#{document['base_path']}"
+
+    expect(page).to_not have_link "Back", href: document['base_path']
+    expect(page).to_not have_link "Back to select a different topic", href: document['base_path']
+  end
 end


### PR DESCRIPTION
Alpha taxons are currently being used to provide single page email subscriptions
to support Brexit content.

Pages such as [Visit Europe after Brexit](https://www.gov.uk/email-signup/?topic=/government/visit-europe-after-brexit)
are sending people to 404 pages because the generated "Back" links go to
pages that don't exist because the taxon is in alpha stage.

This is not ideal, but we need to support this in the short term.