### PR TITLE
Adds option for pre-selecting one of the frequency options

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -46,6 +46,7 @@ private
       .get_subscriber_list(slug: @topic_id)
       .to_h.fetch("subscriber_list")
     @frequency = subscription_params[:frequency]
+    @default_frequency = subscription_params[:default_frequency] || "immediately"
     @address = subscription_params[:address]
     @title = @subscriber_list["title"]
   end
@@ -56,7 +57,7 @@ private
   end
 
   def subscription_params
-    params.permit(:topic_id, :address, :frequency)
+    params.permit(:topic_id, :address, :frequency, :default_frequency)
   end
 
   def valid_frequency

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -23,15 +23,17 @@
             {
               value: "immediately",
               text: "As soon as they happen",
-              checked: true,
+              checked: (@default_frequency == "immediately"),
             },
             {
               value: "daily",
               text: "No more than once a day",
+              checked: (@default_frequency == "daily"),
             },
             {
               value: "weekly",
               text: "No more than once a week",
+              checked: (@default_frequency == "weekly"),
             }
           ]
         } %>

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe "subscribing", type: :feature do
     end
   end
 
+  feature "signing up for a subscription without default frequency parameter" do
+    it "should default to immediately" do
+      visit "/email/subscriptions/new?topic_id=#{topic_id}"
+      expect(find_field(name: "frequency", checked: true).value).to eq 'immediately'
+    end
+  end
+
+  feature "signing up for a subscription with a default frequency specified" do
+    it "should change the pre-selected option based on `default_frequency` parameter" do
+      visit "/email/subscriptions/new?topic_id=#{topic_id}&default_frequency=daily"
+      expect(find_field(name: "frequency", checked: true).value).to eq 'daily'
+    end
+  end
+
   feature "back link navigation" do
     let(:new_subscription_path) { "/email/subscriptions/new?topic_id=#{topic_id}" }
     let(:new_subscription_path_regex) do


### PR DESCRIPTION
Trello: https://trello.com/c/f7DWeg4q/

## What
Adds a `default_frequency` parameter to the email alert frontend:

- If omitted (as it will be by default), nothing changes - the "immediately" option is selected as normal.
- If specified, this will override the default select option, i.e. `default_frequency=weekly` would set the selected frequency to weekly.

## Why
We want to set the default selection to 'daily' for the Business Finder.