### PR TITLE
Consolidate vocabs and create FrequenciesHelper

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,4 +1,5 @@
 class SubscriptionsController < ApplicationController
+  include FrequenciesHelper
   before_action :assign_attributes
   before_action :assign_back_url
 
@@ -61,8 +62,7 @@ private
   end
 
   def valid_frequency
-    frequencies = I18n.t('frequencies').map { |frequency, _config| frequency.to_s }
-    frequencies.include?(@frequency)
+    valid_frequencies.include?(@frequency)
   end
 
   def frequency_form_redirect

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -61,7 +61,8 @@ private
   end
 
   def valid_frequency
-    %w[immediately daily weekly].include?(@frequency)
+    frequencies = I18n.t('frequencies').map { |frequency, _config| frequency.to_s }
+    frequencies.include?(@frequency)
   end
 
   def frequency_form_redirect

--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -25,7 +25,7 @@ class SubscriptionsManagementController < ApplicationController
     subscription_title = @subscriptions[id]['subscriber_list']['title']
 
     frequency_text = if new_frequency == 'immediately'
-                       I18n.t('.immediately')[:short_desc].downcase
+                       frequency_summary(message: :short_desc, frequency: 'immediately').downcase
                      else
                        new_frequency
                      end

--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -25,7 +25,7 @@ class SubscriptionsManagementController < ApplicationController
     subscription_title = @subscriptions[id]['subscriber_list']['title']
 
     frequency_text = if new_frequency == 'immediately'
-                       "as soon as they happen"
+                       I18n.t('.immediately')[:short_desc].downcase
                      else
                        new_frequency
                      end

--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -1,4 +1,8 @@
 module FrequenciesHelper
+  def valid_frequencies
+    I18n.t('frequencies').map { |frequency, _config| frequency.to_s }
+  end
+
   def frequencies(options)
     I18n.t('frequencies').map { |frequency, config|
       {

--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -8,4 +8,12 @@ module FrequenciesHelper
       }
     }
   end
+
+  def frequency_summary(options)
+    frequency_conf = I18n.t('frequencies').select { |frequency, _config| frequency.to_s == options[:frequency] }
+    frequency_conf = frequency_conf[options[:frequency].to_sym]
+    message = frequency_conf[options[:message].to_sym]
+    message.sub!('@title', options[:title]) if options[:title]
+    message
+  end
 end

--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -1,0 +1,11 @@
+module FrequenciesHelper
+  def frequencies(options)
+    I18n.t('frequencies').map { |frequency, config|
+      {
+        value: frequency,
+        text: config[:short_desc],
+        checked: (options[:checked_frequency] == frequency.to_s),
+      }
+    }
+  end
+end

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -13,12 +13,10 @@
       title: "You’ve subscribed successfully"
     } %>
 
-    <% frequency_variations = t('frequencies').map { |frequency, config|
-        [frequency, config[:subscribed_to_topic].sub('@title', @title) ]
-    }.to_h %>
-
     <%= govspeak do %>
-      <p><%= frequency_variations[@frequency.to_sym] %></p>
+      <p>
+        <%= frequency_summary(message: :subscribed_to_topic, frequency: @frequency, title: @title) %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -13,14 +13,12 @@
       title: "You’ve subscribed successfully"
     } %>
 
-    <% frequency_variations = {
-      "immediately" => "You’ll get an email each time there’s an update to ‘#{@title}’",
-      "daily" => "You’ll get an email each day there’s been an update to ‘#{@title}’.",
-      "weekly" => "You’ll get one email per week if there’s been an update to ‘#{@title}’.",
-    } %>
+    <% frequency_variations = t('frequencies').map { |frequency, config|
+        [frequency, config[:subscribed_to_topic].sub('@title', @title) ]
+    }.to_h %>
 
     <%= govspeak do %>
-      <p><%= frequency_variations[@frequency] %></p>
+      <p><%= frequency_variations[@frequency.to_sym] %></p>
     <% end %>
   </div>
 </div>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -23,18 +23,16 @@
 
     <h1 class="govuk-heading-l">Enter your email address</h1>
 
-    <% frequency_variations = {
-      "immediately" => "You’ll get an email every time a page is added or changed.",
-      "daily" => "You'll get an email each day if a page is added or changed.",
-      "weekly" => "You'll get one email per week if a page is added or changed.",
-    } %>
+    <% frequency_variations = t('frequencies').map { |frequency, config|
+        [frequency, config[:subscribing_to_topic] ]
+    }.to_h %>
 
     <%= govspeak do %>
       <p>
         You’re subscribing to get email notifications about: <br/>
         ‘<strong><%= @title %></strong>’.
       </p>
-      <p><%= frequency_variations[@frequency] %></p>
+      <p><%= frequency_variations[@frequency.to_sym] %></p>
     <% end %>
 
     <%= form_tag create_subscription_path, method: :post do %>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -23,16 +23,14 @@
 
     <h1 class="govuk-heading-l">Enter your email address</h1>
 
-    <% frequency_variations = t('frequencies').map { |frequency, config|
-        [frequency, config[:subscribing_to_topic] ]
-    }.to_h %>
-
     <%= govspeak do %>
       <p>
         You’re subscribing to get email notifications about: <br/>
         ‘<strong><%= @title %></strong>’.
       </p>
-      <p><%= frequency_variations[@frequency.to_sym] %></p>
+      <p>
+        <%= frequency_summary(message: :subscribing_to_topic, frequency: @frequency) %>
+      </p>
     <% end %>
 
     <%= form_tag create_subscription_path, method: :post do %>

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -19,23 +19,13 @@
       } do %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "frequency",
-          items: [
+          items: t('frequencies').map { |frequency, config|
             {
-              value: "immediately",
-              text: "As soon as they happen",
-              checked: (@default_frequency == "immediately"),
-            },
-            {
-              value: "daily",
-              text: "No more than once a day",
-              checked: (@default_frequency == "daily"),
-            },
-            {
-              value: "weekly",
-              text: "No more than once a week",
-              checked: (@default_frequency == "weekly"),
+              value: frequency,
+              text: config[:short_desc],
+              checked: (@default_frequency == frequency.to_s),
             }
-          ]
+          }
         } %>
       <% end %>
 

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -19,13 +19,7 @@
       } do %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "frequency",
-          items: t('frequencies').map { |frequency, config|
-            {
-              value: frequency,
-              text: config[:short_desc],
-              checked: (@default_frequency == frequency.to_s),
-            }
-          }
+          items: frequencies(:checked_frequency => @default_frequency)
         } %>
       <% end %>
 

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -33,13 +33,7 @@
         </h3>
         <%= govspeak do %>
           <p>
-            <% if subscription['frequency'] == "daily" %>
-              You chose to get daily updates.
-            <% elsif subscription['frequency'] == "weekly" %>
-              You chose to get weekly updates.
-            <% else %>
-              You chose to get updates as soon as they happen.
-            <% end %>
+            <% t('frequencies')[subscription['frequency'].to_sym][:subscribed_summary] %>
             <br><a href="<%= update_frequency_path(id: subscription['id']) %>">Change how often you get updates</a>
           </p>
           <p><a href="<%= confirm_unsubscribe_path(id: subscription['id']) %>">Unsubscribe</a></p>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -33,7 +33,7 @@
         </h3>
         <%= govspeak do %>
           <p>
-            <% t('frequencies')[subscription['frequency'].to_sym][:subscribed_summary] %>
+            <% frequency_summary(message: :subscribed_summary, frequency: subscription['frequency']) %>
             <br><a href="<%= update_frequency_path(id: subscription['id']) %>">Change how often you get updates</a>
           </p>
           <p><a href="<%= confirm_unsubscribe_path(id: subscription['id']) %>">Unsubscribe</a></p>

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -17,23 +17,13 @@
         } do %>
           <%= render 'govuk_publishing_components/components/radio', {
             name: 'new_frequency',
-            items: [
+            items: t('frequencies').map { |frequency, config|
               {
-                value: 'immediately',
-                text: 'As soon as they happen',
-                checked: (@current_frequency == 'immediately'),
-              },
-              {
-                value: 'daily',
-                text: 'No more than once a day',
-                checked: (@current_frequency == 'daily'),
-              },
-              {
-                value: 'weekly',
-                text: 'No more than once a week',
-                checked: (@current_frequency == 'weekly'),
+                value: frequency,
+                text: config[:short_desc],
+                checked: (@current_frequency == frequency.to_s),
               }
-            ]
+            }
           } %>
         <% end %>
 

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -17,13 +17,7 @@
         } do %>
           <%= render 'govuk_publishing_components/components/radio', {
             name: 'new_frequency',
-            items: t('frequencies').map { |frequency, config|
-              {
-                value: frequency,
-                text: config[:short_desc],
-                checked: (@current_frequency == frequency.to_s),
-              }
-            }
+            items: frequencies(:checked_frequency => @current_frequency)
           } %>
         <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,19 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  frequencies:
+    immediately:
+      short_desc: As soon as they happen
+      subscribing_to_topic: "You’ll get an email every time a page is added or changed."
+      subscribed_to_topic: "You’ll get an email each time there’s an update to ‘@title’"
+      subscribed_summary: "You chose to get updates as soon as they happen."
+    daily:
+      short_desc: No more than once a day
+      subscribing_to_topic: "You'll get an email each day if a page is added or changed."
+      subscribed_to_topic: "You’ll get an email each day there’s been an update to ‘@title’"
+      subscribed_summary: "You chose to get daily updates."
+    weekly:
+      short_desc: No more than once a week
+      subscribing_to_topic: "You'll get one email per week if a page is added or changed."
+      subscribed_to_topic: "You’ll get one email per week if there’s been an update to ‘@title’"
+      subscribed_summary: "You chose to get weekly updates."


### PR DESCRIPTION
Currently, there are lots of repeated strings throughout the repository, making it difficult to:

a) update the text of an option (e.g. "No more than once a day")
b) add a new frequency (e.g. fortnightly)

...as doing so would require touching multiple files and it is likely something will get missed.

This PR consolidates all of these 'magic strings' in one place - the so far unutilised `en.yml` file - and creates a `frequencies_helper.rb` file to make it easy for the view and controllers to query this information.

As well as being a general refactor PR, this PR paves the way for working on https://trello.com/c/Y1UoRnZ9, which is likely to lead to the text tweaks alluded to in a).