### PR TITLE
Smarter unsubscribe logic: match old subscriptions with new ones

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', '~> 5.0'
 gem 'slimmer', '~> 13.0'
 gem 'uglifier', '~> 4.1'
 
-gem 'gds-api-adapters', '~> 59.2'
+gem 'gds-api-adapters', '~> 59.4'
 gem 'govuk_app_config', '~> 1.16'
 gem 'govuk_publishing_components', '~> 16.16'
 gem 'plek', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
-    gds-api-adapters (59.2.1)
+    gds-api-adapters (59.4.0)
       addressable
       link_header
       null_logger
@@ -330,7 +330,7 @@ DEPENDENCIES
   binding_of_caller
   cucumber-rails (~> 1.7)
   decent_exposure (~> 3.0)
-  gds-api-adapters (~> 59.2)
+  gds-api-adapters (~> 59.4)
   govuk-lint
   govuk_app_config (~> 1.16)
   govuk_publishing_components (~> 16.16)

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -2,7 +2,15 @@ class UnsubscriptionsController < ApplicationController
   before_action :set_attributes
 
   def confirm
-    return render :confirm_already_unsubscribed if subscription_ended?
+    if subscription_ended?(@latest_subscription)
+      render :confirm_already_unsubscribed
+    elsif subscription_is_latest?
+      render :confirm
+    elsif old_subscription_has_same_frequency_as_latest?
+      redirect_to_unsubscribe_latest
+    else
+      redirect_to_manage_subscriptions
+    end
   end
 
   def confirmed
@@ -28,13 +36,30 @@ private
 
   def set_attributes
     @id = params.require(:id)
-    @subscription = api.get_subscription(@id)
-    @title = @subscription.dig("subscription", "subscriber_list", "title").presence
-    @authenticated_for_subscription = check_authenticated(@subscription)
+    @original_subscription = api.get_subscription(@id)
+    @latest_subscription = api.get_latest_matching_subscription(@id)
+    @title = @latest_subscription.dig("subscription", "subscriber_list", "title").presence
+    @authenticated_for_subscription = check_authenticated(@latest_subscription)
   end
 
-  def subscription_ended?
-    @subscription.dig("subscription", "ended_at").present?
+  def subscription_is_latest?
+    id(@original_subscription) == id(@latest_subscription)
+  end
+
+  def old_subscription_has_same_frequency_as_latest?
+    frequency(@latest_subscription) == frequency(@original_subscription)
+  end
+
+  def subscription_ended?(subscription)
+    subscription.dig("subscription", "ended_at").present?
+  end
+
+  def id(subscription)
+    subscription.dig("subscription", "id")
+  end
+
+  def frequency(subscription)
+    subscription.dig("subscription", "frequency")
   end
 
   def check_authenticated(subscription)
@@ -48,5 +73,18 @@ private
 
   def api
     EmailAlertFrontend.services(:email_alert_api)
+  end
+
+  def redirect_to_unsubscribe_latest
+    redirect_to "/email/unsubscribe/#{id(@latest_subscription)}"
+  end
+
+  def redirect_to_manage_subscriptions
+    # Whilst it would be nice to direct to 'https://www.gov.uk/email/manage' instead
+    # (and treat the user as authenticated), this would open a security hole whereby
+    # if user A forwards an email to user B, then subsequently changes their
+    # frequency, user B could click on the old unsubscribe link and view user A's
+    # subscriptions. So DON'T change this line:
+    redirect_to '/email/authenticate'
   end
 end

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -56,6 +56,60 @@ RSpec.describe UnsubscriptionsController do
       end
     end
 
+    context "when the user has unsubscribed and resubscribed, then clicked 'Unsubscribe' from their previous subscription" do
+      let(:original_subscription_id) { SecureRandom.uuid }
+      let(:latest_subscription_id) { SecureRandom.uuid }
+
+      before do
+        email_alert_api_has_subscriptions([
+          {
+            id: original_subscription_id,
+            frequency: "immediately",
+            ended: true,
+          },
+          {
+            id: latest_subscription_id,
+            frequency: "immediately",
+            ended: false,
+          }
+        ])
+      end
+
+      it "redirects to the latest subscription" do
+        get :confirm, params: { id: original_subscription_id }
+
+        expect(response.status).to eq(302)
+        expect(response.headers['Location']).to end_with("/email/unsubscribe/#{latest_subscription_id}")
+      end
+    end
+
+    context "when the user has changed their frequency, then clicked 'Unsubscribe' from their previous subscription" do
+      let(:original_subscription_id) { SecureRandom.uuid }
+      let(:latest_subscription_id) { SecureRandom.uuid }
+
+      before do
+        email_alert_api_has_subscriptions([
+          {
+            id: original_subscription_id,
+            frequency: "immediately",
+            ended: true,
+          },
+          {
+            id: latest_subscription_id,
+            frequency: "daily",
+            ended: false,
+          },
+        ])
+      end
+
+      it "redirects the user to manage their subscriptions" do
+        get :confirm, params: { id: original_subscription_id }
+
+        expect(response.status).to eq(302)
+        expect(response.headers['Location']).to end_with("/email/authenticate")
+      end
+    end
+
     context "when a user is authenticated" do
       let(:session) do
         { "authentication" => { "subscriber_id" => 1 } }


### PR DESCRIPTION
Trello card: https://trello.com/c/VlnvU2Dl

## What & Why

- Updates the `UnsubscriptionController` to follow this logic:
  - If their latest subscription has ended already, show the "You're already unsubscribed" page.
  - Else if this is their latest subscription, render a "Are you sure you want to unsubscribe?" page.
  - Else, if this is not their latest subscription, but its frequency matches that of their latest subscription, then we can act on the user's intention and unsubscribe them.
  - Finally, if this is an old subscription and its frequency is different to that of their latest subscription, we cannot act on their instruction to unsubscribe as it may not be what the user intended. Instead we redirect them to manage their subscription manually.
- Updates version of `gds-api-adapter`, as we need the `get_latest_matching_subscription` query added in 59.4.
- Writes some integration tests.

## Note

I don't believe any tests or application code is required around authentication vs non-authentication. The actual unsubscription isn't being affected here - just the page that asks whether or not you confirm you want to unsubscribe. Clicking 'confirm' creates a POST method that _does_ rely on authentication.