### PR TITLE
Replace frequency_summary method with calls to I18n

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -25,7 +25,7 @@ class SubscriptionsManagementController < ApplicationController
     subscription_title = @subscriptions[id]['subscriber_list']['title']
 
     frequency_text = if new_frequency == 'immediately'
-                       frequency_summary(message: :short_desc, frequency: 'immediately').downcase
+                       I18n.t("frequencies.immediately.short_desc").downcase
                      else
                        new_frequency
                      end

--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -12,12 +12,4 @@ module FrequenciesHelper
       }
     }
   end
-
-  def frequency_summary(options)
-    frequency_conf = I18n.t('frequencies').select { |frequency, _config| frequency.to_s == options[:frequency] }
-    frequency_conf = frequency_conf[options[:frequency].to_sym]
-    message = frequency_conf[options[:message].to_sym]
-    message.sub!('@title', options[:title]) if options[:title]
-    message
-  end
 end

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -15,7 +15,7 @@
 
     <%= govspeak do %>
       <p>
-        <%= frequency_summary(message: :subscribed_to_topic, frequency: @frequency, title: @title) %>
+        <%= I18n.t("frequencies.#{@frequency}.subscribed_to_topic", title: @title) %>
       </p>
     <% end %>
   </div>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -29,7 +29,7 @@
         ‘<strong><%= @title %></strong>’.
       </p>
       <p>
-        <%= frequency_summary(message: :subscribing_to_topic, frequency: @frequency) %>
+        <%= I18n.t("frequencies.#{@frequency}.subscribing_to_topic") %>
       </p>
     <% end %>
 

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -33,7 +33,7 @@
         </h3>
         <%= govspeak do %>
           <p>
-            <% frequency_summary(message: :subscribed_summary, frequency: subscription['frequency']) %>
+            <%= I18n.t("frequencies.#{@frequency}.subscribed_summary") %>
             <br><a href="<%= update_frequency_path(id: subscription['id']) %>">Change how often you get updates</a>
           </p>
           <p><a href="<%= confirm_unsubscribe_path(id: subscription['id']) %>">Unsubscribe</a></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,15 +34,15 @@ en:
     immediately:
       short_desc: As soon as they happen
       subscribing_to_topic: "You’ll get an email every time a page is added or changed."
-      subscribed_to_topic: "You’ll get an email each time there’s an update to ‘@title’"
+      subscribed_to_topic: "You’ll get an email each time there’s an update to ‘%{title}’"
       subscribed_summary: "You chose to get updates as soon as they happen."
     daily:
       short_desc: No more than once a day
       subscribing_to_topic: "You'll get an email each day if a page is added or changed."
-      subscribed_to_topic: "You’ll get an email each day there’s been an update to ‘@title’"
+      subscribed_to_topic: "You’ll get an email each day there’s been an update to ‘%{title}’"
       subscribed_summary: "You chose to get daily updates."
     weekly:
       short_desc: No more than once a week
       subscribing_to_topic: "You'll get one email per week if a page is added or changed."
-      subscribed_to_topic: "You’ll get one email per week if there’s been an update to ‘@title’"
+      subscribed_to_topic: "You’ll get one email per week if there’s been an update to ‘%{title}’"
       subscribed_summary: "You chose to get weekly updates."


### PR DESCRIPTION
There was some weird behaviour going on where the incorrect title was sometimes being displayed.  This changes the way we're substituting the title in the I18n string and removes the `frequency_summary` method.

Trello card: https://trello.com/c/SMUHJdsO/121-fix-email-signup-confirmation-page