### PR TITLE
Fix bug in 'Manage your subscriptions' page

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -33,7 +33,7 @@
         </h3>
         <%= govspeak do %>
           <p>
-            <%= I18n.t("frequencies.#{@frequency}.subscribed_summary") %>
+            <%= I18n.t("frequencies.#{subscription['frequency']}.subscribed_summary") %>
             <br><a href="<%= update_frequency_path(id: subscription['id']) %>">Change how often you get updates</a>
           </p>
           <p><a href="<%= confirm_unsubscribe_path(id: subscription['id']) %>">Unsubscribe</a></p>


### PR DESCRIPTION
The wrong value was being used to present the existing frequency, therefore an error was displayed to the user rather than the frequency.

Trello card: https://trello.com/c/Af6uXux3/123-bug-in-manage-your-subscriptions