### PR TITLE
Add combine_mode parameter

### DIFF
--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -73,6 +73,8 @@ private
       subscription_params[:links] = subscriber_list['links'].to_h
     end
 
+    subscription_params[:combine_mode] = details['combine_mode']
+
     subscription_params.deep_stringify_keys
   end
 end

--- a/features/step_definitions/email_alert_steps.rb
+++ b/features/step_definitions/email_alert_steps.rb
@@ -17,6 +17,7 @@ end
 
 When(/^I sign up to the email alerts$/) do
   @subscription_params = {
+    'combine_mode' => nil,
     'title' => 'Employment policy',
     'tags' => @tags,
   }

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe EmailAlertSignup do
       it "sends the correct subscription params to the email alert api" do
         expect(api_client).to receive(:find_or_create_subscriber_list)
           .with(
+            "combine_mode" => nil,
             "title" => "Afghanistan travel advice",
             "links" => { "countries" => ["5a292f20-a9b6-46ea-b35f-584f8b3d7392"] },
             "document_type" => "travel_advice",
@@ -60,6 +61,7 @@ RSpec.describe EmailAlertSignup do
       it "sends the correct subscription params to the email alert api" do
         expect(api_client).to receive(:find_or_create_subscriber_list)
           .with(
+            "combine_mode" => nil,
             "title" => "Foreign travel advice",
             "document_type" => "travel_advice",
           )
@@ -76,6 +78,7 @@ RSpec.describe EmailAlertSignup do
       it "sends the correct subscription params to the email alert api" do
         expect(api_client).to receive(:find_or_create_subscriber_list)
           .with(
+            "combine_mode" => nil,
             "title" => "Employment policy",
             "tags" => { "policies" => %w(employment) }
           )
@@ -99,6 +102,28 @@ RSpec.describe EmailAlertSignup do
         expect(api_client).to receive(:find_or_create_subscriber_list)
           .with(hash_including("title" => "Some Title"))
           .and_return(mock_subscriber_list)
+
+        email_signup = EmailAlertSignup.new(signup_page)
+        email_signup.save
+      end
+    end
+
+    context "when the signup page has combine_mode set" do
+      let(:signup_content_item) do
+        travel_index_item["details"]["combine_mode"] = "or"
+        travel_index_item
+      end
+
+      let(:signup_page) { mock_response(signup_content_item) }
+
+      it "sends the combine_mode" do
+        expect(api_client).to receive(:find_or_create_subscriber_list)
+                                  .with(
+                                    "combine_mode" => "or",
+                                    "document_type" => "travel_advice",
+                                    "title" => "Foreign travel advice"
+                                  )
+                                  .and_return(mock_subscriber_list)
 
         email_signup = EmailAlertSignup.new(signup_page)
         email_signup.save


### PR DESCRIPTION
We should find_or_create_subscriber_lists taking into account
whether a finder signup content item has a combine_mode
specified. 

Strictly speaking, this probably isn't necessary for the time being as the affected controller here (AFAIK) is only used for [topic page signups](https://www.gov.uk/education) but it can't hurt in case these changes stick around for longer than we expect

Trello: https://trello.com/c/y6ZhETsr/130-implement-a-joined-subscriber-list-model-in-email-alert-api-recommended-%F0%9F%8D%90