### PR TITLE
Add explanatory text to the 'Manage your subscriptions' page

### DIFF
--- a/app/views/authentication/request_sign_in_token.html.erb
+++ b/app/views/authentication/request_sign_in_token.html.erb
@@ -5,8 +5,8 @@
     <h1 class="govuk-heading-l">Manage your subscriptions</h1>
 
     <%= govspeak do %>
-      <p>If you’re subscribed to emails from GOV.UK, we’ll send a link to <%= @address %>.</p>
-      <p>Use the link in the email to confirm your email address.</p>
+      <p>We’ve sent an email to <%= @address %>.</p>
+      <p>Check your inbox and click on the link to confirm your email address.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/authentication/sign_in.html.erb
+++ b/app/views/authentication/sign_in.html.erb
@@ -33,7 +33,7 @@
       } %>
 
       <%= govspeak do %>
-        <p>We’ll send you a link to confirm your email address.</p>
+        <p>You’ll need to confirm your email address before you can manage your subscriptions.</p>
       <% end %>
 
       <%= render 'govuk_publishing_components/components/button', {

--- a/spec/controllers/authentication_controller_spec.rb
+++ b/spec/controllers/authentication_controller_spec.rb
@@ -96,14 +96,14 @@ RSpec.describe AuthenticationController do
 
       it "renders a message" do
         post :request_sign_in_token, params: { address: subscriber_address }
-        expect(response.body).to include("If you’re subscribed to emails from GOV.UK, we’ll send a link to #{subscriber_address}")
+        expect(response.body).to include("We’ve sent an email to #{subscriber_address}")
       end
     end
 
     context "when a valid address is provided and the subscriber exists" do
       it "renders a message" do
         post :request_sign_in_token, params: { address: subscriber_address }
-        expect(response.body).to include("If you’re subscribed to emails from GOV.UK, we’ll send a link to #{subscriber_address}")
+        expect(response.body).to include("We’ve sent an email to #{subscriber_address}")
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/RO9xS4wS
Related to: https://github.com/alphagov/email-alert-api/pull/885

## Motivation

From our research we know that the 'Manage your subscriptions' page is causing confusion for users trying to change their email frequency.

We should clarify the content design of this page to make clear why the user is being asked to confirm their email address, and that this will enable them to change their email frequency.

## Expected changes

![Screen Shot 2019-06-10 at 14 28 07](https://user-images.githubusercontent.com/5793815/59198717-50df3b00-8b8c-11e9-8780-3c4d0197d0c1.png)

![Screen Shot 2019-06-10 at 14 27 21](https://user-images.githubusercontent.com/5793815/59199016-e37fda00-8b8c-11e9-82be-7d1771974ce5.png)

