### PR TITLE
Make wording for daily or weekly updates clearer

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,12 +37,12 @@ en:
       subscribed_to_topic: "You’ll get an email each time there’s an update to ‘%{title}’"
       subscribed_summary: "You chose to get updates as soon as they happen."
     daily:
-      short_desc: No more than once a day
+      short_desc: Once a day
       subscribing_to_topic: "You'll get an email each day if a page is added or changed."
       subscribed_to_topic: "You’ll get an email each day there’s been an update to ‘%{title}’"
       subscribed_summary: "You chose to get daily updates."
     weekly:
-      short_desc: No more than once a week
+      short_desc: Once a week
       subscribing_to_topic: "You'll get one email per week if a page is added or changed."
       subscribed_to_topic: "You’ll get one email per week if there’s been an update to ‘%{title}’"
       subscribed_summary: "You chose to get weekly updates."


### PR DESCRIPTION
Trello: https://trello.com/c/rgb9qLtB

## Motivation

User research showed some users were confused by what 'No more than once a day' and 'No more than once a week' subscription options meant.

This is a problem for all subscriptions across GOV.UK

The requested changes are here: https://docs.google.com/document/d/1yEMoTegE8Abm_ZF3tlhPErK_VduhnGk1l45Leak7vgo/edit

## Expected changes
### Before
![Screen Shot 2019-06-25 at 17 31 08](https://user-images.githubusercontent.com/5793815/60116211-84ff5200-976f-11e9-981f-e12b249fd629.png)

### After
![Screen Shot 2019-06-25 at 17 30 59](https://user-images.githubusercontent.com/5793815/60116205-816bcb00-976f-11e9-9cc9-cc6e18bd18f0.png)
