### PR TITLE
Add other document types to be permitted for signup

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -26,7 +26,7 @@ class ContentItemSignupsController < ApplicationController
 
 private
 
-  PERMITTED_CONTENT_ITEMS = %w(taxon organisation).freeze
+  PERMITTED_CONTENT_ITEMS = %w(taxon organisation ministerial_role person topical_event world_location).freeze
 
   def require_content_item_param
     unless valid_content_item_param?

--- a/app/models/content_item_subscriber_list.rb
+++ b/app/models/content_item_subscriber_list.rb
@@ -32,26 +32,64 @@ private
   def link_hash
     case content_item_type
     when 'taxon'
-      taxon_links
+      taxon_or_world_location_links
     when 'organisation'
       organisation_links
+    when 'person'
+      person_links
+    when 'ministerial_role'
+      ministerial_role_links
+    when 'topical_event'
+      topical_event_links
+    when 'world_location'
+      world_location_links
     else
       message = "No link hash available for content items of type #{content_item_type}!"
       raise UnsupportedContentItemError, message
     end
   end
 
-  def taxon_links
+  def taxon_or_world_location_links
+    if content_item['base_path'].match(%r{^/world/(.*)})
+      {
+        'world_locations' => [content_item['content_id']]
+      }
+    else
+      {
+        # 'taxon_tree' is the key used in email-alert-service for
+        # notifications, so create a subscriber list with this key.
+        'taxon_tree' => [content_item['content_id']]
+      }
+    end
+  end
+
+  def world_location_links
     {
-      # 'taxon_tree' is the key used in email-alert-service for
-      # notifications, so create a subscriber list with this key.
-      'taxon_tree' => [content_item['content_id']]
+      'world_locations' => [content_item['content_id']]
     }
   end
 
   def organisation_links
     {
       'organisations' => [content_item['content_id']]
+    }
+  end
+
+  def topical_event_links
+    {
+      'topical_events' => [content_item['content_id']]
+    }
+  end
+
+  def person_links
+    {
+      'people' => [content_item['content_id']]
+    }
+  end
+
+  def ministerial_role_links
+    {
+      'roles' => [content_item['content_id']]
     }
   end
 

--- a/app/models/email_volume/weekly_email_volume.rb
+++ b/app/models/email_volume/weekly_email_volume.rb
@@ -5,7 +5,7 @@ module EmailVolume
     end
 
     def estimate
-      volume_estimator.estimate
+      volume_estimator&.estimate
     end
 
   private
@@ -18,9 +18,6 @@ module EmailVolume
         TaxonWeeklyEmailVolume.new(@content_item)
       when 'organisation'
         OrganisationWeeklyEmailVolume.new(@content_item)
-      else
-        error_message = "Volume estimate not possible for content items of type #{content_item_type}!"
-        raise ContentItemNotEstimatableError, error_message
       end
     end
 

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -15,9 +15,11 @@
       You'll get alerts when the government publishes or changes anything on GOV.UK about: <%= @content_item['title'] %>.
     </p>
 
-    <p class="govuk-body">
-      This might be between <%= estimated_email_frequency %> updates a week.
-    </p>
+    <% if estimated_email_frequency %>
+      <p class="govuk-body">
+        This might be between <%= estimated_email_frequency %> updates a week.
+      </p>
+    <% end %>
 
     <p class="govuk-body">
       You can choose to receive email alerts:

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: @content_item['base_path']
+    href: :back
   } %>
 <% end %>
 
@@ -19,7 +19,7 @@
       <p class="govuk-body">
         This might be between <%= estimated_email_frequency %> updates a week.
       </p>
-    <% end %>
+  <% end %>
 
     <p class="govuk-body">
       You can choose to receive email alerts:
@@ -43,10 +43,6 @@
       <%= hidden_field_tag 'link', @content_item['base_path'] %>
       <%= submit_tag('Sign up now', class: 'govuk-button') %>
     <% end %>
-
-    <p class="govuk-body">
-      <%= link_to 'Back', :back %>
-    </p>
 
   </div>
 </div>

--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -61,11 +61,5 @@
 
   <% end %>
 
-  <% if live_content_item?(@content_item) %>
-  <p class="govuk-body">
-    <%= link_to 'Back to select a different topic', @content_item['base_path'], class: 'govuk-link' %>
-  </p>
-  <% end %>
-
   </div>
 </div>

--- a/spec/features/taxonomy_alerts_spec.rb
+++ b/spec/features/taxonomy_alerts_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe "Subscribing to the taxonomy", type: :feature do
     visit "/email-signup?topic=#{document['base_path']}"
 
     expect(page).to have_link "Back", href: document['base_path']
-    expect(page).to have_link "Back to select a different topic", href: document['base_path']
   end
 
   it "doesn't show links for non-live taxons" do
@@ -35,6 +34,5 @@ RSpec.describe "Subscribing to the taxonomy", type: :feature do
     visit "/email-signup?topic=#{document['base_path']}"
 
     expect(page).to_not have_link "Back", href: document['base_path']
-    expect(page).to_not have_link "Back to select a different topic", href: document['base_path']
   end
 end

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe ContentItemSubscriberList do
       instance_double(EmailAlertFrontend.services(:email_alert_api).class)
     end
 
-    let(:fake_taxon) { { 'document_type' => 'taxon', 'title' => 'Foo', 'content_id' => 'foo-id' } }
-    let(:fake_organisation) { { 'document_type' => 'organisation', 'title' => 'Org', 'content_id' => 'org-id' } }
     before do
       allow(EmailAlertFrontend)
         .to receive(:services)
@@ -20,7 +18,10 @@ RSpec.describe ContentItemSubscriberList do
 
     context "given a taxon" do
       it 'asks email-alert-api to find or create a subscriber list' do
-        signup = described_class.new(fake_taxon)
+        taxon = { 'document_type' => 'taxon', 'title' => 'Foo',
+                  'content_id' => 'foo-id', 'base_path' => '/taxy/taxon' }
+
+        signup = described_class.new(taxon)
 
         expect(signup.has_content_item?).to be
         expect(signup.subscription_management_url).to eq '/something'
@@ -30,7 +31,7 @@ RSpec.describe ContentItemSubscriberList do
       end
     end
 
-    context 'when no taxon is present' do
+    context 'when no content item is present' do
       it 'does nothing' do
         signup = described_class.new(nil)
 
@@ -38,15 +39,91 @@ RSpec.describe ContentItemSubscriberList do
       end
     end
 
-    context "given an organisation" do
+    context "given a taxon which is a world_location" do
       it 'asks email-alert-api to find or create a subscriber list' do
-        signup = described_class.new(fake_organisation)
+        world_location = { 'document_type' => 'taxon', 'title' => 'Peters Island',
+                           'content_id' => 'world-id', 'base_path' => '/world/peter-island' }
+
+        signup = described_class.new(world_location)
+
+        expect(signup.has_content_item?).to be
+        expect(signup.subscription_management_url).to eq '/something'
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with('title' => 'Peters Island', 'links' => { 'world_locations' => %w[world-id] })
+      end
+    end
+
+    context "given an organisation" do
+      organisation = { 'document_type' => 'organisation', 'title' => 'Org', 'content_id' => 'org-id' }
+
+      it 'asks email-alert-api to find or create a subscriber list' do
+        signup = described_class.new(organisation)
 
         expect(signup.has_content_item?).to be
         expect(signup.subscription_management_url).to eq '/something'
         expect(mock_email_alert_api)
           .to have_received(:find_or_create_subscriber_list)
           .with('title' => 'Org', 'links' => { 'organisations' => %w[org-id] })
+      end
+    end
+
+    context "given a person" do
+      person = { 'document_type' => 'person', 'title' => 'Peter', 'content_id' => 'person-id' }
+
+      it 'asks email-alert-api to find or create a subscriber list' do
+        signup = described_class.new(person)
+
+        expect(signup.has_content_item?).to be
+        expect(signup.subscription_management_url).to eq '/something'
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with('title' => 'Peter', 'links' => { 'people' => %w[person-id] })
+      end
+    end
+
+    context "given a ministerial role" do
+      ministerial_role = { 'document_type' => 'ministerial_role',
+                           'title' => 'pm', 'content_id' => 'pm-id' }
+
+      it 'asks email-alert-api to find or create a subscriber list' do
+        signup = described_class.new(ministerial_role)
+
+        expect(signup.has_content_item?).to be
+        expect(signup.subscription_management_url).to eq '/something'
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with('title' => 'pm', 'links' => { 'roles' => %w[pm-id] })
+      end
+    end
+
+    context "given a topical event" do
+      topical_event = { 'document_type' => 'topical_event',
+                        'title' => 'Summit 2019', 'content_id' => 'summit-id' }
+
+      it 'asks email-alert-api to find or create a subscriber list' do
+        signup = described_class.new(topical_event)
+
+        expect(signup.has_content_item?).to be
+        expect(signup.subscription_management_url).to eq '/something'
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with('title' => 'Summit 2019', 'links' => { 'topical_events' => %w[summit-id] })
+      end
+    end
+
+    context "given a international delegation" do
+      international_delegation = { 'document_type' => 'world_location',
+                                   'title' => 'Nato Delegation', 'content_id' => 'delegation-id' }
+
+      it 'asks email-alert-api to find or create a subscriber list' do
+        signup = described_class.new(international_delegation)
+
+        expect(signup.has_content_item?).to be
+        expect(signup.subscription_management_url).to eq '/something'
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with('title' => 'Nato Delegation', 'links' => { 'world_locations' => %w[delegation-id] })
       end
     end
   end

--- a/spec/models/weekly_email_volume_spec.rb
+++ b/spec/models/weekly_email_volume_spec.rb
@@ -79,5 +79,12 @@ RSpec.describe EmailVolume::WeeklyEmailVolume do
         end
       end
     end
+
+    context 'given a person' do
+      it 'returns nil as no estimate for a person' do
+        person = { document_type: 'person', base_path: '/people/big-boris' }.deep_stringify_keys
+        expect(described_class.new(person).estimate).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit allows the following document types - ministerial_role,
person, topical_event and word_location to be initially signed up using
email-alert-frontend.

This is needed so when we retire the whitehall email signup pages we can
redirect here.

Trello:
https://trello.com/c/tgWUR1dx/25-switch-whitehalls-email-signup-pages-to-use-email-alert-frontends