### PR TITLE
Redirect /government/brexit topic to /brexit

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -29,6 +29,11 @@ private
   PERMITTED_CONTENT_ITEMS = %w(taxon organisation ministerial_role person topical_event world_location).freeze
 
   def require_content_item_param
+    if content_item_path.to_s == '/government/brexit'
+      redirect_to new_content_item_signup_path(topic: '/brexit')
+      return false
+    end
+
     unless valid_content_item_param?
       redirect_to '/'
       false

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe ContentItemSignupsController do
   include GdsApi::TestHelpers::ContentStore
 
   shared_examples 'handles bad input data correctly' do
+    it "redirects to topic=/brexit if topic param is /government/brexit" do
+      get :new, params: { topic: '/government/brexit' }
+
+      expect(response.status).to eq 302
+      expect(response.location).to eq 'http://test.host/email-signup?topic=%2Fbrexit'
+    end
+
     it 'redirects to root if topic param is missing' do
       make_request(bad_param: '/education/some-rando-item')
 


### PR DESCRIPTION
This taxon has been changed, but there are 500+ links to the email
signup page on GOV.UK (and possibly elsewhere online), so just
redirect the old URL for now.

This redirect should be removed when the content is updated.

---

https://govuk.zendesk.com/agent/tickets/3785368