### PR TITLE
Create a root development page

### DIFF
--- a/app/controllers/development_controller.rb
+++ b/app/controllers/development_controller.rb
@@ -1,0 +1,1 @@
+class DevelopmentController < ApplicationController; end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,0 +1,54 @@
+<% content_for :title, "Email Alert Frontend" %>
+
+<%= render "govuk_publishing_components/components/title", title: "Email Alert Frontend" %>
+
+<p class="govuk-body">
+  This page is intended to only be shown in development and on Heroku review
+  apps. It won't be shown on GOV.UK as there are no routes to it.
+</p>
+
+<p class="govuk-body">
+  <%= link_to "Email Alert Frontend",
+              "https://github.com/alphagov/email-alert-frontend",
+              class: "govuk-link" %>
+  provides means to sign-up for GOV.UK mailing lists and manage
+  subscriptions.
+</p>
+
+<h2 class="govuk-heading-l">Component Guide</h2>
+
+<p class="govuk-body">
+  To see the available components, take a look at the
+  <%= link_to "Component Guide",
+              govuk_publishing_components.component_guide_path,
+              class: "govuk-link" %>
+</p>
+
+<h2 class="govuk-heading-l">Example sign-up pages</h2>
+
+<p class="govuk-body">
+  Note: these links depend on the appropriate pages being published to the
+  <%= link_to "Content store",
+              "https://github.com/alphagov/content-store",
+              class: "govuk-link" %>
+  that is being used and to proceed with any sign-up requires an
+  instance of
+  <%= link_to "Email Alert API",
+              "https://github.com/alphagov/email-alert-api",
+              class: "govuk-link" %>
+  to be available.
+</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>
+    <%= link_to "Foreign Travel Advice",
+                "/foreign-travel-advice/email-signup",
+                class: "govuk-link" %>
+  </li>
+  <li>
+    <%= link_to "Government Digital Service",
+                new_content_item_signup_path(link: "/government/organisations/government-digital-service"),
+                class: "govuk-link" %>
+  </li>
+</ul>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 
+  root to: "development#index"
+
   get '/*base_path' => 'email_alert_signups#new', as: :email_alert_signup, constraints: { base_path: %r|.*/email-signup| }
   post '/*base_path' => 'email_alert_signups#create', as: :email_alert_signups, constraints: { base_path: %r|.*/email-signup| }
 


### PR DESCRIPTION
Trello: https://trello.com/c/FGYU4NlN/92-differentiate-between-your-get-ready-for-brexit-results-in-subscription-management

This gives us something other than an error for when you view this
application in a development environment - and can stop govuk-docker
assuming that the application is unavailable when you run `govuk-docker
startup` as that expects a successful response.

How it looks:

![Screen Shot 2019-09-16 at 16 00 27](https://user-images.githubusercontent.com/282717/64969081-242d7480-d89b-11e9-938c-ae7105d10a83.png)
