### PR TITLE
Add extra information for subscription management

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -33,6 +33,14 @@
         <h3 class="govuk-heading-s">
           <%= subscription['subscriber_list']['title'] %>
         </h3>
+        <p class='govuk-body'>
+          <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
+        </p>
+        <% if subscription['subscriber_list']['description'].present? %>
+          <%= render "govuk_publishing_components/components/govspeak", {
+            content: raw(Kramdown::Document.new(subscription['subscriber_list']['description']).to_html)
+          } %>
+        <% end %>
         <p class="govuk-body">
           <%= I18n.t("frequencies.#{subscription['frequency']}.subscribed_summary") %>
           <br>

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -33,10 +33,12 @@ RSpec.describe SubscriptionsManagementController do
               "subscriber_list_id" => 1000,
               "frequency" => "daily",
               "id" => subscription_id,
+              "created_at" => "2019-09-16 02:08:08 01:00",
               "subscriber_list" => {
                 "id" => 1000,
                 "slug" => "some-thing",
-                "title" => "Some thing"
+                "title" => "Some thing",
+                "description" => "[You can view a copy of your results on GOV.UK.](https://www.gov.uk/get-ready-brexit-check/results?c%5B%5D=automotive)"
               }
             }
           ]
@@ -98,6 +100,10 @@ RSpec.describe SubscriptionsManagementController do
       it "renders the subscriber's subscriptions" do
         get :index, session: session_data
         expect(response.body).to include("Some thing")
+        expect(response.body).to include("Created on 16 September 2019 at 2:08am")
+        expect(response.body).to include(
+          "<p><a href=\"https://www.gov.uk/get-ready-brexit-check/results?c%5B%5D=automotive\">You can view a copy of your results on GOV.UK.</a></p>"
+        )
       end
     end
 


### PR DESCRIPTION
This commit adds some extra content to the subscription management page
for each subscription, the additions are as follows:

* The time the subscription was created
* The subscriber list's desciption if present for the associated
subscription

Finally, I'm not sure about including the govspeak gem for this one use
as we need it to convert the subscriber_list description - markdown link
in this case to a html link and the actual class I'm using doesn't make
much sense in this context 'Govspeak::Document' as we aren't using a
document.

Related PR:
https://github.com/alphagov/email-alert-api/pull/977

Trello:
https://trello.com/c/FGYU4NlN/92-differentiate-between-your-get-ready-for-brexit-results-in-subscription-management