### PR TITLE
Replace govspeak helper with classes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,10 +1,4 @@
 module ApplicationHelper
-  def govspeak
-    render "govuk_publishing_components/components/govspeak" do
-      yield
-    end
-  end
-
   def title(text, params = {})
     render 'govuk_publishing_components/components/title', { title: text }.merge(params)
   end

--- a/app/views/authentication/request_sign_in_token.html.erb
+++ b/app/views/authentication/request_sign_in_token.html.erb
@@ -4,9 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Manage your subscriptions</h1>
 
-    <%= govspeak do %>
-      <p>We’ve sent an email to <%= @address %>.</p>
-      <p>Check your inbox and click on the link to confirm your email address.</p>
-    <% end %>
+    <p class="govuk-body">We’ve sent an email to <%= @address %>.</p>
+    <p class="govuk-body">Check your inbox and click on the link to confirm your email address.</p>
   </div>
 </div>

--- a/app/views/authentication/sign_in.html.erb
+++ b/app/views/authentication/sign_in.html.erb
@@ -32,9 +32,7 @@
         value: @address,
       } %>
 
-      <%= govspeak do %>
-        <p>You’ll need to confirm your email address before you can manage your subscriptions.</p>
-      <% end %>
+      <p class="govuk-body">You’ll need to confirm your email address before you can manage your subscriptions.</p>
 
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Continue',

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -13,10 +13,8 @@
       title: "You’ve subscribed successfully"
     } %>
 
-    <%= govspeak do %>
-      <p>
-        <%= I18n.t("frequencies.#{@frequency}.subscribed_to_topic", title: @title) %>
-      </p>
-    <% end %>
+    <p class="govuk-body">
+      <%= I18n.t("frequencies.#{@frequency}.subscribed_to_topic", title: @title) %>
+    </p>
   </div>
 </div>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -23,15 +23,13 @@
 
     <h1 class="govuk-heading-l">Enter your email address</h1>
 
-    <%= govspeak do %>
-      <p>
-        You’re subscribing to get email notifications about: <br/>
-        ‘<strong><%= @title %></strong>’.
-      </p>
-      <p>
-        <%= I18n.t("frequencies.#{@frequency}.subscribing_to_topic") %>
-      </p>
-    <% end %>
+    <p class="govuk-body">
+      You’re subscribing to get email notifications about: <br/>
+      ‘<strong><%= @title %></strong>’.
+    </p>
+    <p class="govuk-body">
+      <%= I18n.t("frequencies.#{@frequency}.subscribing_to_topic") %>
+    </p>
 
     <%= form_tag create_subscription_path, method: :post, class: "checklist-email-signup" do %>
       <%= hidden_field_tag :topic_id, @topic_id %>
@@ -58,8 +56,12 @@
       } %>
     <%- end -%>
 
-    <%= govspeak do %>
-      <p>We won’t share your email address with anyone. Read our <a href="https://www.gov.uk/help/privacy-policy" target="_blank">privacy policy (opens in new tab)</a>.</p>
-    <% end %>
+    <p class="govuk-body">
+      We won’t share your email address with anyone. Read our
+      <%= link_to "privacy policy (opens in a new tab)",
+                  "/help/privacy-policy",
+                  target: "_blank",
+                  class: "govuk-link" %>.
+    </p>
   </div>
 </div>

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -10,9 +10,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Are you sure you want to unsubscribe from everything?</h1>
 
-    <%= govspeak do %>
-      <p>You won’t get any more automated emails from GOV.UK.</p>
-    <% end %>
+    <p class="govuk-body">You won’t get any more automated emails from GOV.UK.</p>
 
     <%= form_tag(action: :confirmed_unsubscribe_all) do %>
       <%= hidden_field_tag(:from, @from) %>
@@ -26,8 +24,8 @@
         },
       } %>
     <% end %>
-    <%= govspeak do %>
-      <p><%= link_to "Cancel", @back_url %></p>
-    <% end %>
+    <p class="govuk-body">
+      <%= link_to "Cancel", @back_url, class: %w[govuk-link govuk-link--no-visited-state] %>
+    </p>
   </div>
 </div>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -13,36 +13,47 @@
     <h2 class="govuk-heading-m">
       <%= "Subscriptions for #{@subscriber['address']}" %>
     </h2>
-    <%= govspeak do %>
-      <p><%= link_to "Change email address", update_address_path %></p>
-    <% end %>
+    <p class="govuk-body">
+      <%= link_to "Change email address",
+                  update_address_path,
+                  class: %w[govuk-link govuk-link--no-visited-state] %>
+    </p>
 
     <hr class="govuk-section-break govuk-section-break--l">
 
     <% if @subscriptions.empty? %>
-      <%= govspeak do %>
-        <p>
-          You aren’t subscribed to any topics on GOV.UK.
-          <a href="/help/update-email-notifications#how-to-subscribe">Find out how to subscribe</a>.
-        </p>
-      <% end %>
+      <p class="govuk-body">
+        You aren’t subscribed to any topics on GOV.UK.
+        <%= link_to "Find out how to subscribe",
+                    "/help/update-email-notifications#how-to-subscribe",
+                    class: "govuk-link" %>.
+      </p>
     <% else %>
       <% @subscriptions.each do |_key, subscription| %>
         <h3 class="govuk-heading-s">
           <%= subscription['subscriber_list']['title'] %>
         </h3>
-        <%= govspeak do %>
-          <p>
-            <%= I18n.t("frequencies.#{subscription['frequency']}.subscribed_summary") %>
-            <br><a href="<%= update_frequency_path(id: subscription['id']) %>">Change how often you get updates</a>
-          </p>
-          <p><a href="<%= confirm_unsubscribe_path(id: subscription['id']) %>">Unsubscribe</a></p>
-        <% end %>
+        <p class="govuk-body">
+          <%= I18n.t("frequencies.#{subscription['frequency']}.subscribed_summary") %>
+          <br>
+          <%= link_to "Change how often you get updates",
+                      update_frequency_path(id: subscription['id']),
+                      class: %w[govuk-link govuk-link--no-visited-state] %>
+        </p>
+        <p class="govuk-body">
+          <%= link_to "Unsubscribe",
+                      confirm_unsubscribe_path(id: subscription['id']),
+                      class: %w[govuk-link govuk-link--no-visited-state] %>
+        </p>
         <hr class="govuk-section-break govuk-section-break--m">
       <% end %>
 
       <% unsubscribe_all_text = capture do %>
-        <p class="govuk-body"><%= link_to "Unsubscribe from everything", confirm_unsubscribe_all_path %></p>
+        <p class="govuk-body">
+          <%= link_to "Unsubscribe from everything",
+                      confirm_unsubscribe_all_path,
+                      class: %w[govuk-link govuk-link--no-visited-state] %>
+        </p>
       <% end %>
 
       <%= render "govuk_publishing_components/components/inset_text", {

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -24,9 +24,7 @@
       </div>
     <% end %>
 
-    <%= govspeak do %>
-      <p>Your current email address is <%= @address %></p>
-    <% end %>
+    <p class="govuk-body">Your current email address is <%= @address %></p>
 
     <%= form_tag change_address_path, method: :post do %>
       <%= render 'govuk_publishing_components/components/input', {
@@ -38,12 +36,14 @@
         value: @new_address,
       } %>
       <% unless @new_address.nil? %>
-        <%= govspeak do %>
-          <p>If you want to transfer your subscription to <%= @new_address %>,
-            you’ll need to subscribe to the same topics again, using the new
-            email address. Or you can <a href="/contact/govuk">contact us</a>.
-          </p>
-        <% end %>
+        <p class="govuk-body">
+          If you want to transfer your subscription to <%= @new_address %>,
+          you’ll need to subscribe to the same topics again, using the new
+          email address. Or you can
+          <%= link_to "contact us",
+                      "/contact/govuk",
+                      class: %w[govuk-link govuk-link--no-visited-state] %>.
+        </p>
       <% end %>
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Save',
@@ -55,8 +55,10 @@
         },
       } %>
     <%- end -%>
-    <%= govspeak do %>
-      <p><%= link_to "Cancel", @back_url %></p>
-    <% end %>
+    <p class="govuk-body">
+      <%= link_to "Cancel",
+                  @back_url,
+                  class: %w[govuk-link govuk-link--no-visited-state] %>
+    </p>
   </div>
 </div>

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -31,9 +31,9 @@
             track_label: @current_frequency,
           }
         } %>
-    <%- end -%>
-    <%= govspeak do %>
-      <p><%= link_to "Cancel", @back_url %></p>
     <% end %>
+    <p class="govuk-body">
+      <%= link_to "Cancel", @back_url, class: %w[govuk-link govuk-link--no-visited-state] %>
+    </p>
   </div>
 </div>

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -12,12 +12,10 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Are you sure you want to unsubscribe?</h1>
 
-    <%= govspeak do %>
-      <% if @title %>
-        <p>You won’t get any more updates about <%= @title %>.</p>
-      <% else %>
-        <p>You won’t get any more updates about this topic.</p>
-      <% end %>
+    <% if @title %>
+      <p class="govuk-body">You won’t get any more updates about <%= @title %>.</p>
+    <% else %>
+      <p class="govuk-body">You won’t get any more updates about this topic.</p>
     <% end %>
 
     <%= form_tag(action: :confirmed) do %>
@@ -33,9 +31,11 @@
       } %>
     <% end %>
     <% if @authenticated_for_subscription %>
-      <%= govspeak do %>
-        <p><%= link_to "Cancel", list_subscriptions_path %></p>
-      <% end %>
+      <p class="govuk-body">
+        <%= link_to "Cancel",
+                    list_subscriptions_path,
+                    class: %w[govuk-link govuk-link--no-visited-state] %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
+++ b/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
@@ -16,12 +16,10 @@ content_for :title, page_title
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= page_title %></h1>
 
-    <%= govspeak do %>
-      <% if @title %>
-        <p>You won’t get any more updates about <%= @title %>.</p>
-      <% else %>
-        <p>You won’t get any more updates about this topic.</p>
-      <% end %>
+    <% if @title %>
+      <p class="govuk-body">You won’t get any more updates about <%= @title %>.</p>
+    <% else %>
+      <p class="govuk-body">You won’t get any more updates about this topic.</p>
     <% end %>
   </div>
 </div>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -1,26 +1,13 @@
 <% content_for :title, 'You’ve successfully unsubscribed' %>
 
-<% if @from_subscription_management %>
-  <% content_for :back_link do %>
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: @back_url
-    } %>
-  <% end %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">You’ve successfully unsubscribed</h1>
 
-    <%= govspeak do %>
-      <% if @title %>
-        <p>You won’t get any more updates about <%= @title %>.</p>
-      <% else %>
-        <p>You won’t get any more updates about this topic.</p>
-      <% end %>
-      <% if @from_subscription_management %>
-        <p><a href="<%= @back_url %>">Back to manage your subscriptions</a>.</p>
-      <% end %>
+    <% if @title %>
+      <p class="govuk-body">You won’t get any more updates about <%= @title %>.</p>
+    <% else %>
+      <p class="govuk-body">You won’t get any more updates about this topic.</p>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This application was making heavy use of the govspeak component as way
to style plain HTML. This led to confusion about whether this
application used govspeak/markdown and many cases where interface
controls had visited states that didn't quite make sense as they're
meanings may differ.

This change replaces these calls with plain classes.