### PR TITLE
Update govuk_publishing_components to v21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,22 +5,20 @@ ruby File.read(".ruby-version").strip
 gem "rails", "5.2.3"
 
 gem "decent_exposure", "~> 3.0"
+gem "gds-api-adapters", "~> 60.1"
+gem "govuk_app_config", "~> 2.0"
+gem "govuk_publishing_components", "~> 21.0.0"
 gem "jwt", "~> 2.2"
+gem "plek", "~> 3.0"
 gem "sass-rails", "~> 5.0"
 gem "slimmer", "~> 13.0"
 gem "uglifier", "~> 4.1"
 
-gem "gds-api-adapters", "~> 60.1"
-gem "govuk_app_config", "~> 2.0"
-gem "govuk_publishing_components", "~> 17.21"
-gem "plek", "~> 3.0"
-
 group :development, :test do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "pry-byebug"
-
   gem "govuk-lint"
+  gem "pry-byebug"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,8 @@ GEM
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
     builder (3.2.3)
-    byebug (11.0.0)
-    capybara (3.28.0)
+    byebug (11.0.1)
+    capybara (3.29.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -121,13 +121,9 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (8.2.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
-    govuk_publishing_components (17.21.0)
+    govuk_publishing_components (21.0.0)
       gds-api-adapters
       govuk_app_config
-      govuk_frontend_toolkit
       kramdown
       plek
       rails (>= 5.0.0.1)
@@ -143,7 +139,7 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
-    json (2.1.0)
+    json (2.2.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.2.1)
@@ -171,12 +167,12 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.12.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    nio4r (2.4.0)
+    nio4r (2.5.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     null_logger (0.0.1)
@@ -212,7 +208,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.1.0)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.3)
       actionpack (= 5.2.3)
@@ -234,13 +230,13 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.7.0)
-    rspec-core (3.8.0)
+    rouge (3.11.0)
+    rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-rails (3.8.2)
@@ -251,7 +247,7 @@ GEM
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+    rspec-support (3.8.2)
     rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -271,15 +267,14 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
+    sass-rails (5.1.0)
+      railties (>= 5.2.0)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.1)
+    sassc (2.2.1)
       ffi (~> 1.9)
-      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -289,7 +284,7 @@ GEM
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
-    sentry-raven (2.11.0)
+    sentry-raven (2.11.2)
       faraday (>= 0.7.6, < 1.0)
     slimmer (13.1.0)
       activesupport
@@ -309,7 +304,7 @@ GEM
     statsd-ruby (1.4.0)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -343,7 +338,7 @@ DEPENDENCIES
   gds-api-adapters (~> 60.1)
   govuk-lint
   govuk_app_config (~> 2.0)
-  govuk_publishing_components (~> 17.21)
+  govuk_publishing_components (~> 21.0.0)
   govuk_schemas
   jwt (~> 2.2)
   launchy
@@ -361,4 +356,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,17 +1,17 @@
+$govuk-use-legacy-palette: true;
+$govuk-typography-use-rem: false;
+
 @import "govuk_publishing_components/all_components";
 
 .app-email-option {
-  @include core-24;
-  margin-top: $govuk-gutter-half;
-  margin-bottom: $govuk-gutter-half;
-  line-height: 1.5;
+  @include govuk-font(24, $line-height: 1.5);
+  margin-top: govuk-spacing(3);
+  margin-bottom: govuk-spacing(3);
 }
 
-// TODO: remove these overwrites after the title component is updated to work
-// nicely with govuk-frontend layout
-.app-title {
-  .gem-c-title {
-    margin-top: $govuk-gutter-half;
-    margin-bottom: $govuk-gutter-half;
+.govuk-link,
+.govuk-back-link {
+  &:focus {
+    @include govuk-template-link-focus-override;
   }
 }

--- a/app/assets/stylesheets/mixins/_govuk-template-link-focus-override.scss
+++ b/app/assets/stylesheets/mixins/_govuk-template-link-focus-override.scss
@@ -1,0 +1,9 @@
+// TODO: Remove when appropriate
+// govuk_template overrides the styles set by
+// govuk-frontend 3.0.0. This mixin is intended as a temporary fix
+// to ensure focus styles are as expected in apps using govuk_template
+
+@mixin govuk-template-link-focus-override {
+  @include govuk-focused-text;
+  color: govuk-colour("black") !important;
+}


### PR DESCRIPTION
https://trello.com/c/MRsMdjkS/72-update-email-alert-frontend-to-govukpublishingcomponents-v20-with-compatibility-mode-on

- Update gem to version 21
- Remove redundant CSS
- Switch to using design system mixins
- Add a temporary mixin to override styles from govuk-template

Due to dependencies you can't follow a full user journey through locally or on heroku so I've pushed the branch to integration. 

No screenshots as the visual differences are minimal except for the focus states.

Example starting points:

https://www.integration.publishing.service.gov.uk/email/subscriptions/new?topic_id=rail-accident-investigation-branch-raib-reports-with-the-following-railway-type-light-rail-2

https://www.integration.publishing.service.gov.uk/email-signup/confirm?link=%2Fgovernment%2Forganisations%2Fgovernment-digital-service

https://www.integration.publishing.service.gov.uk/email-signup?link=%2Fgovernment%2Forganisations%2Fgovernment-digital-service