### PR TITLE
Rescue 403 errors from content store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
+  rescue_from GdsApi::HTTPForbidden, with: :forbidden
   rescue_from GdsApi::HTTPGone, with: :gone
 
   if ENV["BASIC_AUTH_USERNAME"]
@@ -26,6 +27,10 @@ private
 
   def error_not_found
     render status: :not_found, plain: "404 not found"
+  end
+
+  def forbidden
+    render status: :forbidden, plain: "403 forbidden"
   end
 
   def gone

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe ContentItemSignupsController do
       expect(response.location).to eq "http://test.host/"
     end
 
+    it "returns a 403 when the user is not authorised" do
+      base_path = "/#{SecureRandom.hex}"
+      url = content_store_endpoint + "/content#{base_path}"
+      stub_request(:get, url).to_return(status: 403, headers: {})
+
+      get :new, params: { topic: base_path }
+
+      expect(response.status).to eq 403
+    end
+
     it "errors if no taxon found" do
       content_store_does_not_have_item("/education/some-rando-item")
       make_request(topic: "/education/some-rando-item")


### PR DESCRIPTION
Trello: https://trello.com/c/MPyM3tCK
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed and why?
At the moment email-alert-frontend is throwing a 500, when it receives an error code it doesn't recognise
from content-store. That means that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a 403, the user will be properly routed
to signon and asked to login if there is any form of access limiting on the content item (e.g. hosted on draft
stack, access limited to organisation)