### PR TITLE
Replace govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   TargetRubyVersion: 2.4
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem "uglifier", "~> 4.2"
 group :development, :test do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "govuk-lint"
   gem "pry-byebug"
+  gem "rubocop-govuk"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,11 +111,6 @@ GEM
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -256,6 +251,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -282,8 +281,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     slimmer (13.1.0)
@@ -336,7 +333,6 @@ DEPENDENCIES
   cucumber-rails (~> 2.0)
   decent_exposure (~> 3.0)
   gds-api-adapters (~> 61.0)
-  govuk-lint
   govuk_app_config (~> 2.0)
   govuk_publishing_components (~> 21.10.0)
   govuk_schemas
@@ -346,6 +342,7 @@ DEPENDENCIES
   pry-byebug
   rails (= 5.2.3)
   rspec-rails (~> 3.9)
+  rubocop-govuk
   sass-rails (~> 5.0)
   slimmer (~> 13.0)
   timecop (~> 0.9.1)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
 desc "Run govuk-lint with similar params to CI"
 task lint: :environment do
-  sh "govuk-lint-ruby --format clang Gemfile app config features lib spec"
+  sh "rubocop --format clang Gemfile app config features lib spec"
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk