### PR TITLE
[DO NOT MERGE] Remove legacy route to process sign in token

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,9 +37,6 @@ Rails.application.routes.draw do
 
     # DEPRECATED: legacy route in emails from GOV.UK
     get "/authenticate", to: redirect("/email/manage/authenticate")
-
-    # DEPRECATED: legacy route in emails from GOV.UK (delete 7 days after deploy)
-    get "/authenticate/process" => "subscriber_authentication#process_sign_in_token"
   end
 
   get "/healthcheck", to: GovukHealthcheck.rack_response


### PR DESCRIPTION
https://trello.com/c/dIAlk2dp/278-double-opt-in-create-a-subscription-before-the-success-page

Previously we scoped this route under '/manage'. This removes the
old route, which we kept for backwards compatibility. New auth emails
should now be using the scoped URL, and since after 7 days all the
emails containing the old URL are now expired, we think it's reasonable
to completely remove the old route.