### PR TITLE
Remove redundant gems causing test faults

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby File.read(".ruby-version").strip
 
 gem "rails", "5.2.3"
 
-gem "decent_exposure", "~> 3.0"
 gem "gds-api-adapters", "~> 61.0"
 gem "govuk_app_config", "~> 2.0"
 gem "govuk_publishing_components", "~> 21.13.0"
@@ -15,8 +14,6 @@ gem "slimmer", "~> 13.2"
 gem "uglifier", "~> 4.2"
 
 group :development, :test do
-  gem "better_errors"
-  gem "binding_of_caller"
   gem "pry-byebug"
   gem "rubocop-govuk"
 end
@@ -24,7 +21,6 @@ end
 group :test do
   gem "cucumber-rails", "~> 2.0", require: false
   gem "govuk_schemas"
-  gem "launchy"
   gem "rspec-rails", "~> 3.9"
   gem "timecop", "~> 0.9.1"
   gem "webmock", "~> 3.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,12 +47,6 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     backports (3.15.0)
-    better_errors (2.5.1)
-      coderay (>= 1.0.0)
-      erubi (>= 1.0.0)
-      rack (>= 0.9.0)
-    binding_of_caller (0.8.0)
-      debug_inspector (>= 0.0.1)
     builder (3.2.3)
     byebug (11.0.1)
     capybara (3.29.0)
@@ -90,9 +84,6 @@ GEM
       railties (>= 4.2, < 7)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    debug_inspector (0.0.3)
-    decent_exposure (3.0.2)
-      activesupport (>= 4.0)
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -141,8 +132,6 @@ GEM
     jwt (2.2.1)
     kgio (2.11.2)
     kramdown (2.1.0)
-    launchy (2.4.3)
-      addressable (~> 2.3)
     link_header (0.0.8)
     logstash-event (1.2.02)
     logstasher (1.3.0)
@@ -328,16 +317,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  better_errors
-  binding_of_caller
   cucumber-rails (~> 2.0)
-  decent_exposure (~> 3.0)
   gds-api-adapters (~> 61.0)
   govuk_app_config (~> 2.0)
   govuk_publishing_components (~> 21.13.0)
   govuk_schemas
   jwt (~> 2.2)
-  launchy
   plek (~> 3.0)
   pry-byebug
   rails (= 5.2.3)


### PR DESCRIPTION
https://trello.com/c/dIAlk2dp/278-double-opt-in-create-a-subscription-before-the-success-page

This removes a bunch of gems that appear to be unused. A couple of them
are also masking exceptions in tests, and should probably not have been
put in the 'dev/test' group in the first place.