### PR TITLE
Add new opt-in subscribe feature

### DIFF
--- a/app/controllers/subscription_authentication_controller.rb
+++ b/app/controllers/subscription_authentication_controller.rb
@@ -1,0 +1,51 @@
+class SubscriptionAuthenticationController < ApplicationController
+  def authenticate
+    @topic_id = params.require(:topic_id)
+    @frequency = params.require(:frequency)
+
+    unless token_valid?
+      render :expired
+      return
+    end
+
+    address = token[:address]
+
+    subscriber_list_id = email_alert_api
+      .get_subscriber_list(slug: @topic_id)
+      .dig("subscriber_list", "id")
+
+    email_alert_api.subscribe(
+      subscriber_list_id: subscriber_list_id,
+      address: address,
+      frequency: @frequency,
+    )
+
+    redirect_to subscription_path(topic_id: @topic_id, frequency: @frequency)
+  end
+
+private
+
+  def token
+    @token ||= read_token
+  end
+
+  def token_valid?
+    return false unless token
+    token[:topic_id] == @topic_id
+  end
+
+  def read_token
+    payload, = JWT.decode(params.require(:token), secret, true, algorithm: "HS256")
+    payload.fetch("data").to_h.symbolize_keys
+  rescue JWT::DecodeError
+    nil
+  end
+
+  def secret
+    Rails.application.secrets.email_alert_auth_token
+  end
+
+  def email_alert_api
+    EmailAlertFrontend.services(:email_alert_api_with_no_caching)
+  end
+end

--- a/app/controllers/subscription_authentication_controller.rb
+++ b/app/controllers/subscription_authentication_controller.rb
@@ -1,10 +1,17 @@
 class SubscriptionAuthenticationController < ApplicationController
+  include FrequenciesHelper
+
   def authenticate
     @topic_id = params.require(:topic_id)
     @frequency = params.require(:frequency)
 
-    unless token.valid? && token.data[:topic_id] == @topic_id
+    unless token.valid?
       render :expired
+      return
+    end
+
+    unless valid_params?
+      head :unprocessable_entity
       return
     end
 
@@ -22,6 +29,11 @@ class SubscriptionAuthenticationController < ApplicationController
   end
 
 private
+
+  def valid_params?
+    token.data[:topic_id] == @topic_id &&
+      valid_frequencies.include?(@frequency)
+  end
 
   def token
     @token ||= AuthToken.new(params.require(:token))

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,0 +1,28 @@
+class AuthToken
+  def initialize(jwt_token)
+    @jwt_token = jwt_token
+  end
+
+  def valid?
+    data.present?
+  end
+
+  def data
+    @data ||= read_token
+  end
+
+private
+
+  attr_reader :jwt_token
+
+  def read_token
+    payload, = JWT.decode(jwt_token, secret, true, algorithm: "HS256")
+    payload.fetch("data").to_h.symbolize_keys
+  rescue JWT::DecodeError
+    nil
+  end
+
+  def secret
+    Rails.application.secrets.email_alert_auth_token
+  end
+end

--- a/app/views/subscription_authentication/expired.html.erb
+++ b/app/views/subscription_authentication/expired.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, t("subscription_authentication.title") %>
+<% content_for :meta_description, t("subscription_authentication.description") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= render "govuk_publishing_components/components/title", {
+      title: t("subscription_authentication.title")
+    } %>
+
+    <p class="govuk-body">
+      <%= t("subscription_authentication.description") %>
+    </p>
+  </div>
+</div>

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -1,11 +1,5 @@
 <% content_for :title, "Subscription created successfully" %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: @back_url
-  } %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,3 +46,6 @@ en:
       subscribing_to_topic: "You'll get one email per week if a page is added or changed."
       subscribed_to_topic: "You’ll get one email per week if there’s been an update to ‘%{title}’"
       subscribed_summary: "You chose to get weekly updates."
+  subscription_authentication:
+    title: Your link has expired
+    description: The links we send only work for 7 days. This is to protect your personal data.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       post "/frequency" => "subscriptions#frequency", as: :subscription_frequency
       post "/create" => "subscriptions#create", as: :create_subscription
       get "/complete" => "subscriptions#complete", as: :subscription
+      get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
     end
 
     # DEPRECATED: legacy route in emails from GOV.UK

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe SubscriberAuthenticationController do
   include GdsApi::TestHelpers::EmailAlertApi
+  include TokenHelper
 
   let(:endpoint) { GdsApi::TestHelpers::EmailAlertApi::EMAIL_ALERT_API_ENDPOINT }
   let(:subscriber_id) { 1 }
@@ -73,58 +74,37 @@ RSpec.describe SubscriberAuthenticationController do
   end
 
   describe "GET /email/authenticate/process" do
-    let(:secret) { Rails.application.secrets.email_alert_auth_token }
-
-    let(:token_data) do
-      {
-        "data" => {
-          "subscriber_id" => subscriber_id,
-          "redirect" => "/email/manage",
-        },
-        "exp" => 5.minutes.from_now.to_i,
-        "iat" => Time.now.to_i,
-        "iss" => "https://www.gov.uk",
-      }
+    let(:token) do
+      jwt_token(data: {
+        "subscriber_id" => subscriber_id,
+        "redirect" => "/email/manage",
+      })
     end
-
-    let(:jwt_token) { JWT.encode(token_data, secret, "HS256") }
 
     context "when the page is requested" do
       it "sets the Cache-Control header to 'private, no-cache'" do
-        get :process_sign_in_token, params: { token: jwt_token }
+        get :process_sign_in_token, params: { token: token }
         expect(response.headers["Cache-Control"]).to eq("private, no-cache")
       end
     end
 
     context "when an expired token is provided" do
-      let(:expired_token_data) do
-        {
-          "data" => {
-            "subscriber_id" => subscriber_id,
-            "redirect" => "/email/manage",
-          },
-          "exp" => 5.minutes.ago.to_i,
-          "iat" => 10.minutes.ago.to_i,
-          "iss" => "https://www.gov.uk",
-        }
-      end
-
-      let(:expired_jwt_token) { JWT.encode(expired_token_data, secret, "HS256") }
+      let(:expired_token) { jwt_token(expiry: 5.minutes.ago) }
 
       it "redirects to sign in" do
-        get :process_sign_in_token, params: { token: expired_jwt_token }
+        get :process_sign_in_token, params: { token: expired_token }
         expect(response).to redirect_to(sign_in_path)
       end
 
       it "sets a bad_token flash" do
-        get :process_sign_in_token, params: { token: expired_jwt_token }
+        get :process_sign_in_token, params: { token: expired_token }
         expect(flash[:error_summary]).to eq("bad_token")
       end
     end
 
     context "when a valid token is provided" do
       it "redirects to the subscription management page" do
-        get :process_sign_in_token, params: { token: jwt_token }
+        get :process_sign_in_token, params: { token: token }
         expect(response).to redirect_to(list_subscriptions_path)
       end
     end

--- a/spec/controllers/subscription_authentication_controller_spec.rb
+++ b/spec/controllers/subscription_authentication_controller_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe SubscriptionAuthenticationController do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  render_views
+
+  describe "GET authenticate" do
+    let(:secret) { Rails.application.secrets.email_alert_auth_token }
+    let(:address) { "someone@example.com" }
+    let(:topic_id) { SecureRandom.uuid }
+    let(:params) { { topic_id: topic_id, frequency: "immediately" } }
+
+    context "the token is valid" do
+      before do
+        stub_email_alert_api_has_subscriber_list_by_slug(
+          slug: topic_id,
+          returned_attributes: { id: 123 },
+        )
+
+        stub_email_alert_api_creates_a_subscription(
+          123,
+          address,
+          params[:frequency],
+          nil,
+        )
+      end
+
+      let(:token) { JWT.encode(token_data, secret, "HS256") }
+
+      it "redirects to the success page" do
+        get :authenticate, params: params.merge(token: token)
+        expect(response).to redirect_to(subscription_path(params))
+      end
+
+      it "sets the Cache-Control header to 'private, no-cache'" do
+        get :authenticate, params: params.merge(token: token)
+        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
+      end
+    end
+
+    context "the token is expired" do
+      let(:token) do
+        JWT.encode(
+          token_data.merge("exp" => 5.minutes.ago.to_i),
+          secret,
+          "HS256"
+        )
+      end
+
+      it "shows an error page" do
+        get :authenticate, params: params.merge(token: token)
+        expect(response.body).to include(I18n.t!("subscription_authentication.title"))
+      end
+    end
+
+    context "the token is incomplete" do
+      let(:token) do
+        JWT.encode(
+          token_data.merge("data" => {}),
+          secret,
+          "HS256"
+        )
+      end
+
+      it "shows an error page" do
+        get :authenticate, params: params.merge(token: token)
+        expect(response.body).to include(I18n.t!("subscription_authentication.title"))
+      end
+    end
+
+    context "the token is re-used" do
+      let(:token) { jwt_token(data: { "topic_id" => "another" }) }
+
+      it "shows an error page" do
+        get :authenticate, params: params.merge(token: token)
+        expect(response.body).to include(I18n.t!("subscription_authentication.title"))
+      end
+    end
+
+    context "the token is invalid" do
+      it "shows an error page" do
+        get :authenticate, params: params.merge(token: "foo")
+        expect(response.body).to include(I18n.t!("subscription_authentication.title"))
+      end
+    end
+  end
+end

--- a/spec/controllers/subscription_authentication_controller_spec.rb
+++ b/spec/controllers/subscription_authentication_controller_spec.rb
@@ -42,16 +42,7 @@ RSpec.describe SubscriptionAuthenticationController do
     context "the token is expired" do
       let(:token) { jwt_token(expiry: 5.minutes.ago) }
 
-      it "shows an error page" do
-        get :authenticate, params: params.merge(token: token)
-        expect(response.body).to include(I18n.t!("subscription_authentication.title"))
-      end
-    end
-
-    context "the token is incomplete" do
-      let(:token) { jwt_token(data: {}) }
-
-      it "shows an error page" do
+      it "shows an expired error page" do
         get :authenticate, params: params.merge(token: token)
         expect(response.body).to include(I18n.t!("subscription_authentication.title"))
       end
@@ -60,14 +51,25 @@ RSpec.describe SubscriptionAuthenticationController do
     context "the token is re-used" do
       let(:token) { jwt_token(data: { "topic_id" => "another" }) }
 
-      it "shows an error page" do
+      it "shows a general error page" do
         get :authenticate, params: params.merge(token: token)
-        expect(response.body).to include(I18n.t!("subscription_authentication.title"))
+        expect(response.status).to eq 422
+      end
+    end
+
+    context "the frequency is invalid" do
+      let(:token) do
+        jwt_token(data: { "topic_id" => topic_id, "address" => address })
+      end
+
+      it "shows a general error page" do
+        get :authenticate, params: params.merge(token: token, frequency: "foo")
+        expect(response.status).to eq 422
       end
     end
 
     context "the token is invalid" do
-      it "shows an error page" do
+      it "shows an expired error page" do
         get :authenticate, params: params.merge(token: "foo")
         expect(response.body).to include(I18n.t!("subscription_authentication.title"))
       end

--- a/spec/features/subscribe_opt_in_spec.rb
+++ b/spec/features/subscribe_opt_in_spec.rb
@@ -1,0 +1,60 @@
+RSpec.feature "Subscribe opt-in" do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  scenario do
+    given_i_am_subscribing_to_a_list
+    when_i_click_on_the_confirmation_link
+    then_i_see_i_am_subscribed
+  end
+
+  def given_i_am_subscribing_to_a_list
+    @topic_id = SecureRandom.uuid
+    @subscriber_list_id = SecureRandom.uuid
+    @frequency = "immediately"
+    @address = "test@example.com"
+  end
+
+  def when_i_click_on_the_confirmation_link
+    token_data = {
+      "data" => {
+        "address" => @address,
+        "topic_id" => @topic_id,
+      },
+      "exp" => 5.minutes.from_now.to_i,
+      "iat" => Time.now.to_i,
+      "iss" => "https://www.gov.uk",
+    }
+
+    secret = Rails.application.secrets.email_alert_auth_token
+    token = JWT.encode(token_data, secret, "HS256")
+    @title = "Test Subscriber List"
+
+    stub_email_alert_api_has_subscriber_list_by_slug(
+      slug: @topic_id,
+      returned_attributes: {
+        id: @subscriber_list_id,
+        title: @title,
+      },
+    )
+
+    @request = stub_email_alert_api_creates_a_subscription(
+      @subscriber_list_id,
+      @address,
+      @frequency,
+      nil,
+    )
+
+    visit confirm_subscription_path(
+      token: token,
+      topic_id: @topic_id,
+      frequency: @frequency,
+    )
+  end
+
+  def then_i_see_i_am_subscribed
+    expect(@request).to have_been_requested
+    expect(page).to have_content("You’ve subscribed successfully")
+    description = I18n.t!("frequencies.#{@frequency}.subscribed_to_topic", title: @title)
+    expect(page).to have_content(description)
+  end
+end

--- a/spec/features/subscribe_opt_in_spec.rb
+++ b/spec/features/subscribe_opt_in_spec.rb
@@ -1,5 +1,6 @@
 RSpec.feature "Subscribe opt-in" do
   include GdsApi::TestHelpers::EmailAlertApi
+  include TokenHelper
 
   scenario do
     given_i_am_subscribing_to_a_list
@@ -15,19 +16,12 @@ RSpec.feature "Subscribe opt-in" do
   end
 
   def when_i_click_on_the_confirmation_link
-    token_data = {
-      "data" => {
-        "address" => @address,
-        "topic_id" => @topic_id,
-      },
-      "exp" => 5.minutes.from_now.to_i,
-      "iat" => Time.now.to_i,
-      "iss" => "https://www.gov.uk",
-    }
-
-    secret = Rails.application.secrets.email_alert_auth_token
-    token = JWT.encode(token_data, secret, "HS256")
     @title = "Test Subscriber List"
+
+    token = jwt_token(data: {
+      "address" => @address,
+      "topic_id" => @topic_id,
+    })
 
     stub_email_alert_api_has_subscriber_list_by_slug(
       slug: @topic_id,

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -54,7 +54,6 @@ RSpec.feature "Subscribe" do
     expect(@request).to have_been_requested
     expect(page).to have_content("You’ve subscribed successfully")
     expect(page).to have_content("Test Subscriber List")
-    expect(back_link_href).to include(new_subscription_path(topic_id: @topic_id))
   end
 
   def back_link_href

--- a/spec/support/token_helper.rb
+++ b/spec/support/token_helper.rb
@@ -1,0 +1,13 @@
+module TokenHelper
+  def jwt_token(data: {}, expiry: 5.minutes.from_now)
+    token_data = {
+      "data" => data,
+      "exp" => expiry.to_i,
+      "iat" => Time.now.to_i,
+      "iss" => "https://www.gov.uk",
+    }
+
+    secret = Rails.application.secrets.email_alert_auth_token
+    JWT.encode(token_data, secret, "HS256")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/dIAlk2dp/278-double-opt-in-create-a-subscription-before-the-success-page

This adds a new feature to create (or update) a subscription against a
validated JWT token. Since the address to subscribe to is encrypted within
the token, we can be sure the request represents genuine intent. As an
additional protection, we also validate the subscriber list matches the one
in the token, so that it can't be used out of context.