### PR TITLE
Change email_alert_api to use new adapter method

### DIFF
--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -15,7 +15,7 @@ class SubscriberAuthenticationController < ApplicationController
 
     @address = params.require(:address)
 
-    email_alert_api.create_auth_token(
+    email_alert_api.send_subscriber_verification_email(
       address: @address,
       destination: process_sign_in_token_path,
     )


### PR DESCRIPTION
Trello: https://trello.com/c/9FmE3rPn/281-double-opt-in-create-api-adapter-to-send-double-opt-in-email

---

Should await merge and publication of this [branch on gds-api-adaptors](https://github.com/alphagov/gds-api-adapters/pull/963/files).

After which this PR should increment the version of that gem.

---

A part of the refactor work to improve double opt in across GOV.uk