### PR TITLE
Fix and protect against missing translations

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -25,7 +25,7 @@ class SubscriptionsManagementController < ApplicationController
     subscription_title = @subscriptions[id]["subscriber_list"]["title"]
 
     frequency_text = if new_frequency == "immediately"
-                       I18n.t("frequencies.immediately.short_desc").downcase
+                       I18n.t!("frequencies.immediately").downcase
                      else
                        new_frequency
                      end

--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -1,10 +1,10 @@
 module FrequenciesHelper
   def valid_frequencies
-    I18n.t("frequencies").map { |frequency, _config| frequency.to_s }
+    t("frequencies").map { |frequency, _config| frequency.to_s }
   end
 
   def frequencies(options)
-    I18n.t("frequencies").map { |frequency, desc|
+    t("frequencies").map { |frequency, desc|
       {
         value: frequency,
         text: desc,

--- a/app/views/subscriptions/complete.html.erb
+++ b/app/views/subscriptions/complete.html.erb
@@ -8,7 +8,7 @@
     } %>
 
     <p class="govuk-body">
-      <%= I18n.t("subscriptions.complete.summary.#{@frequency}", title: @title) %>
+      <%= t("subscriptions.complete.summary.#{@frequency}", title: @title) %>
     </p>
   </div>
 </div>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -28,7 +28,7 @@
       ‘<strong><%= @title %></strong>’.
     </p>
     <p class="govuk-body">
-      <%= I18n.t("subscriptions.new_address.summary.#{@frequency}") %>
+      <%= t("subscriptions.new_address.summary.#{@frequency}") %>
     </p>
 
     <%= form_tag create_subscription_path, method: :post, class: "checklist-email-signup" do %>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -42,7 +42,7 @@
           } %>
         <% end %>
         <p class="govuk-body">
-          <%= I18n.t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
+          <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
           <br>
           <%= link_to "Change how often you get updates",
                       update_frequency_path(id: subscription['id']),


### PR DESCRIPTION
This fixes a broken translations and switches to using I18n methods
that throw exceptions instead of silently failing, so we can catch
similar failures before they get deployed.