### PR TITLE
Remove mention of default frequency

### DIFF
--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -26,7 +26,7 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li>instantly (default)</li>
+      <li>instantly</li>
       <li>once a day, with all updates made that day</li>
       <li>once a week, with all updates made that week</li>
     </ul>


### PR DESCRIPTION
The email signup page currently says that the default frequency is "instant" emails. Following https://github.com/alphagov/email-alert-frontend/pull/624, this is no longer the case.