### PR TITLE
Extract string constants out of controllers

### DIFF
--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -1,14 +1,11 @@
 class SubscriberAuthenticationController < ApplicationController
-  MISSING_EMAIL_ERROR = "Please enter your email address.".freeze
-  INVALID_EMAIL_ERROR = "This doesn’t look like a valid email address – check you’ve entered it correctly.".freeze
-
   def sign_in
     @address = params[:address]
   end
 
   def request_sign_in_token
     unless params[:address].present?
-      flash.now[:error] = MISSING_EMAIL_ERROR
+      flash.now[:error] = t("subscriber_authentication.sign_in.missing_email")
       flash.now[:error_summary] = "email"
       return render :sign_in
     end
@@ -20,7 +17,7 @@ class SubscriberAuthenticationController < ApplicationController
       destination: process_sign_in_token_path,
     )
   rescue GdsApi::HTTPUnprocessableEntity
-    flash.now[:error] = INVALID_EMAIL_ERROR
+    flash.now[:error] = t("subscriber_authentication.sign_in.invalid_email")
     flash.now[:error_summary] = "email"
     render :sign_in
   rescue GdsApi::HTTPNotFound

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,10 +3,6 @@ class SubscriptionsController < ApplicationController
   before_action :assign_attributes
   before_action :assign_back_url
 
-  MISSING_EMAIL_ERROR = "Please enter your email address.".freeze
-  INVALID_EMAIL_ERROR = "This doesn’t look like a valid email address – check you’ve entered it correctly.".freeze
-  MISSING_FREQUENCY_ERROR = "Select how often you want updates".freeze
-
   def new
     if @frequency.present?
       return frequency_form_redirect unless valid_frequency
@@ -26,7 +22,7 @@ class SubscriptionsController < ApplicationController
         frequency: @frequency,
       )
     else
-      flash.now[:error] = MISSING_FREQUENCY_ERROR
+      flash.now[:error] = t("subscriptions.new_frequency.missing_frequency")
       render :new_frequency
     end
   end
@@ -37,7 +33,11 @@ class SubscriptionsController < ApplicationController
     if @address.present? && subscribe
       redirect_to subscription_path(topic_id: @topic_id, frequency: @frequency)
     else
-      flash.now[:error] = @address.present? ? INVALID_EMAIL_ERROR : MISSING_EMAIL_ERROR
+      flash.now[:error] = if @address.present?
+                            t("subscriptions.new_address.invalid_email")
+                          else
+                            t("subscriptions.new_address.missing_email")
+                          end
 
       render :new_address
     end

--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -3,9 +3,6 @@ class SubscriptionsManagementController < ApplicationController
   before_action :get_subscription_details
   before_action :set_back_url
 
-  MISSING_EMAIL_ERROR = "Please enter your email address.".freeze
-  INVALID_EMAIL_ERROR = "That email address isn’t valid, or it’s already in use – check you’ve typed in your email address correctly.".freeze
-
   def index; end
 
   def update_frequency
@@ -43,7 +40,7 @@ class SubscriptionsManagementController < ApplicationController
     @address = @subscriber["address"]
 
     unless params[:new_address].present?
-      flash.now[:error] = MISSING_EMAIL_ERROR
+      flash.now[:error] = t("subscriptions_management.update_address.missing_email")
       return render :update_address
     end
 
@@ -59,7 +56,7 @@ class SubscriptionsManagementController < ApplicationController
     redirect_to list_subscriptions_path
   rescue GdsApi::HTTPUnprocessableEntity
     @new_address = new_address
-    flash.now[:error] = INVALID_EMAIL_ERROR
+    flash.now[:error] = t("subscriptions_management.update_address.invalid_email")
     render :update_address
   end
 

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -1,0 +1,5 @@
+en:
+  subscriber_authentication:
+    sign_in:
+      missing_email: "Please enter your email address."
+      invalid_email: "This doesn’t look like a valid email address – check you’ve entered it correctly."

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -3,9 +3,12 @@ en:
     new_frequency:
       general_problem: "There is a problem"
       required_question: "You must answer this question"
+      missing_frequency: "Select how often you want updates"
     new_address:
       general_problem: "We weren’t able to process your subscription"
       email_validation: "There’s a problem with your email address"
+      missing_email: "Please enter your email address."
+      invalid_email: "This doesn’t look like a valid email address – check you’ve entered it correctly."
       summary:
         immediately: "You’ll get an email every time a page is added or changed."
         daily: "You'll get an email each day if a page is added or changed."

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -5,3 +5,6 @@ en:
         immediately: "You chose to get updates as soon as they happen."
         daily: "You chose to get daily updates."
         weekly: "You chose to get weekly updates."
+    update_address:
+      missing_email: Please enter your email address.
+      invalid_email: "That email address isn’t valid, or it’s already in use – check you’ve typed in your email address correctly."

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SubscriberAuthenticationController do
 
       it "renders an error message" do
         post :request_sign_in_token, params: { address: subscriber_address }
-        expect(response.body).to include(SubscriberAuthenticationController::MISSING_EMAIL_ERROR)
+        expect(response.body).to include(I18n.t!("subscriber_authentication.sign_in.missing_email"))
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe SubscriberAuthenticationController do
 
       it "renders an error message" do
         post :request_sign_in_token, params: { address: subscriber_address }
-        expect(response.body).to include(SubscriberAuthenticationController::INVALID_EMAIL_ERROR)
+        expect(response.body).to include(I18n.t!("subscriber_authentication.sign_in.invalid_email"))
       end
     end
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe SubscriptionsController do
       it "renders an error" do
         post :frequency, params: { topic_id: topic_id }
 
-        expect(response.body).to include(described_class::MISSING_FREQUENCY_ERROR)
+        expect(response.body).to include(I18n.t!("subscriptions.new_frequency.missing_frequency"))
         expect(response).to have_http_status(:ok)
       end
     end
@@ -118,8 +118,7 @@ RSpec.describe SubscriptionsController do
 
       it "renders an error" do
         post :create, params: params
-        missing_email_error = Regexp.new(described_class::MISSING_EMAIL_ERROR)
-        expect(response.body).to match missing_email_error
+        expect(response.body).to include(I18n.t!("subscriptions.new_address.missing_email"))
         expect(response).to have_http_status(:ok)
       end
     end
@@ -137,8 +136,7 @@ RSpec.describe SubscriptionsController do
 
       it "renders an error" do
         post :create, params: params
-        invalid_email_error = Regexp.new(described_class::INVALID_EMAIL_ERROR)
-        expect(response.body).to match invalid_email_error
+        expect(response.body).to include(I18n.t!("subscriptions.new_address.invalid_email"))
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe SubscriptionsManagementController do
 
       it "renders an error message" do
         post :change_address, params: { new_address: new_address }, session: session_data
-        expect(response.body).to include(SubscriptionsManagementController::MISSING_EMAIL_ERROR)
+        expect(response.body).to include(I18n.t!("subscriptions_management.update_address.missing_email"))
       end
 
       it "renders a form" do
@@ -183,7 +183,7 @@ RSpec.describe SubscriptionsManagementController do
 
       it "renders an error message" do
         post :change_address, params: { new_address: new_address }, session: session_data
-        expect(response.body).to include(SubscriptionsManagementController::INVALID_EMAIL_ERROR)
+        expect(response.body).to include(I18n.t!("subscriptions_management.update_address.invalid_email"))
       end
 
       it "renders a form" do


### PR DESCRIPTION
https://trello.com/c/dBwLRlDm/283-double-opt-in-send-double-opt-in-email-before-creating-subscription

This moves all string constants in controllers into locale files, which
is where we should define this kind of non-programmatic data.