### PR TITLE
Remove default frequency param

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -60,7 +60,7 @@ private
   end
 
   def subscription_params
-    params.permit(:topic_id, :address, :frequency, :default_frequency)
+    params.permit(:topic_id, :address, :frequency)
   end
 
   def valid_frequency


### PR DESCRIPTION
Trello: https://trello.com/c/u6yXgl9h/314-remove-redundant-uses-of-defaultfrequency-parameter-on-email-signup-links

This PR relies on https://github.com/alphagov/finder-frontend/pull/1805 being merged and deployed first, so we are sure that no apps are making use of the default_frequency param.