### PR TITLE
Support encrypted tokens (with JWT fallback)

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,6 +1,9 @@
 class AuthToken
-  def initialize(jwt_token)
-    @jwt_token = jwt_token
+  CIPHER = "aes-256-gcm".freeze
+  OPTIONS = { cipher: CIPHER, serializer: JSON }.freeze
+
+  def initialize(token)
+    @token = token
   end
 
   def valid?
@@ -13,10 +16,24 @@ class AuthToken
 
 private
 
-  attr_reader :jwt_token
+  attr_reader :token
 
   def read_token
-    payload, = JWT.decode(jwt_token, secret, true, algorithm: "HS256")
+    read_message_encryptor_token || read_jwt_token
+  end
+
+  def read_message_encryptor_token
+    len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
+    key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
+    crypt = ActiveSupport::MessageEncryptor.new(key, OPTIONS)
+    decrypted_data = crypt.decrypt_and_verify(token)
+    decrypted_data&.symbolize_keys
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    nil
+  end
+
+  def read_jwt_token
+    payload, = JWT.decode(token, secret, true, algorithm: "HS256")
     payload.fetch("data").to_h.symbolize_keys
   rescue JWT::DecodeError
     nil

--- a/spec/controllers/subscription_authentication_controller_spec.rb
+++ b/spec/controllers/subscription_authentication_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SubscriptionAuthenticationController do
       end
 
       let(:token) do
-        jwt_token(data: { "topic_id" => topic_id, "address" => address })
+        encrypt_and_sign_token(data: { "topic_id" => topic_id, "address" => address })
       end
 
       it "redirects to the success page" do
@@ -40,7 +40,7 @@ RSpec.describe SubscriptionAuthenticationController do
     end
 
     context "the token is expired" do
-      let(:token) { jwt_token(expiry: 5.minutes.ago) }
+      let(:token) { encrypt_and_sign_token(expiry: 0) }
 
       it "shows an expired error page" do
         get :authenticate, params: params.merge(token: token)
@@ -49,7 +49,7 @@ RSpec.describe SubscriptionAuthenticationController do
     end
 
     context "the token is re-used" do
-      let(:token) { jwt_token(data: { "topic_id" => "another" }) }
+      let(:token) { encrypt_and_sign_token(data: { "topic_id" => "another" }) }
 
       it "shows a general error page" do
         get :authenticate, params: params.merge(token: token)
@@ -59,7 +59,7 @@ RSpec.describe SubscriptionAuthenticationController do
 
     context "the frequency is invalid" do
       let(:token) do
-        jwt_token(data: { "topic_id" => topic_id, "address" => address })
+        encrypt_and_sign_token(data: { "topic_id" => topic_id, "address" => address })
       end
 
       it "shows a general error page" do

--- a/spec/features/subscribe_opt_in_spec.rb
+++ b/spec/features/subscribe_opt_in_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Subscribe opt-in" do
   def when_i_click_on_the_confirmation_link
     @title = "Test Subscriber List"
 
-    token = jwt_token(data: {
+    token = encrypt_and_sign_token(data: {
       "address" => @address,
       "topic_id" => @topic_id,
     })

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -1,0 +1,44 @@
+describe AuthToken do
+  include TokenHelper
+
+  describe "#data" do
+    context "JWT token (legacy)" do
+      it "returns the data hash when valid" do
+        token = AuthToken.new(jwt_token(data: { a: "b" }))
+        expect(token.data).to eq(a: "b")
+      end
+
+      it "returns nil after the expiry time" do
+        token = AuthToken.new(jwt_token(expiry: 1.year.ago))
+        expect(token.data).to be_nil
+      end
+
+      it "returns nil if the token is invalid" do
+        token = AuthToken.new("eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImEiOiJiIn0sImV4cCI6MTU3NjYwMzEzMCwiaWF0IjoxNTc2NjAyODMwLCJpc3MiOiJodHRwczovL3d3dy5nb3YudWsifQ.Y6CjmaHAu6RSkEHySYQhuINuYQwj9Kpb8Zs6PzlBVv9")
+        expect(token.data).to be_nil
+      end
+    end
+
+    context "ActiveSupport token" do
+      it "returns the data hash when valid" do
+        token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }))
+        expect(token.data).to eq(a: "b")
+      end
+
+      it "returns nil after the expiry time" do
+        token = AuthToken.new(encrypt_and_sign_token(expiry: 0))
+        expect(token.data).to be_nil
+      end
+
+      it "returns nil if the token is malformed" do
+        token = AuthToken.new("foo")
+        expect(token.data).to be_nil
+      end
+
+      it "returns nil if the token is invalid" do
+        token = AuthToken.new("1HmD8E9iHE7LWl6vT+dfRiKoxX9fU/BY--0MJPSBtYJqtox940--q/zvsHND7yFOeVsIdFbbIQ==")
+        expect(token.data).to be_nil
+      end
+    end
+  end
+end

--- a/spec/support/token_helper.rb
+++ b/spec/support/token_helper.rb
@@ -1,4 +1,12 @@
 module TokenHelper
+  def encrypt_and_sign_token(data: {}, expiry: 5.minutes)
+    len = ActiveSupport::MessageEncryptor.key_len(AuthToken::CIPHER)
+    secret = Rails.application.secrets.email_alert_auth_token
+    key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
+    crypt = ActiveSupport::MessageEncryptor.new(key, AuthToken::OPTIONS)
+    crypt.encrypt_and_sign(data, expires_in: expiry)
+  end
+
   def jwt_token(data: {}, expiry: 5.minutes.from_now)
     token_data = {
       "data" => data,


### PR DESCRIPTION
https://trello.com/c/FwB5bALg/336-double-opt-in-fix-data-leak

Previously we supported verification of a subscriber via the signature
of a JWT token, for which the payload isn't encrypted. This adds support
for an encrypted+signed token using ActiveSupport's MessageVerifier.

We expect to switch all tokens to use this new mechanism and remove
support for JWT tokens after about a week from deployment, since the
tokens would be invalid anyway after that time.

Since the associated secret is only intended for this purpose, we use a
fixed, empty salt ("") when generating a key of the appropriate length
for the MessageVerifier.