### PR TITLE
Update to version 21.15.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails", "6.0.2"
 
 gem "gds-api-adapters", "~> 63.0"
 gem "govuk_app_config", "~> 2.0"
-gem "govuk_publishing_components", "~> 21.14.0"
+gem "govuk_publishing_components", "~> 21.15.0"
 gem "jwt", "~> 2.2"
 gem "plek", "~> 3.0"
 gem "sass-rails", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_publishing_components (21.14.0)
+    govuk_publishing_components (21.15.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -310,7 +310,7 @@ DEPENDENCIES
   capybara (~> 3.2)
   gds-api-adapters (~> 63.0)
   govuk_app_config (~> 2.0)
-  govuk_publishing_components (~> 21.14.0)
+  govuk_publishing_components (~> 21.15.0)
   govuk_schemas
   jwt (~> 2.2)
   plek (~> 3.0)


### PR DESCRIPTION
21.15.0
Allow textarea to be described by an element outside the component (#1225)
Add guidance_id to contextual guidance component (#1225)
Update cookie banner component from an opt-out to an opt-in approach (#1227)