### PR TITLE
Add feature tests for managing subscriptions

### DIFF
--- a/spec/features/change_email_address_spec.rb
+++ b/spec/features/change_email_address_spec.rb
@@ -1,0 +1,52 @@
+RSpec.feature "Change email address after receiving confirmation link" do
+  include GdsApi::TestHelpers::EmailAlertApi
+  include TokenHelper
+
+  scenario do
+    given_i_am_a_subscriber
+    when_i_visit_the_manage_my_subscriptions_page
+    and_i_click_to_change_my_email_address
+    and_i_enter_a_new_email_address
+    then_i_can_see_that_my_email_address_has_been_changed
+  end
+
+  def given_i_am_a_subscriber
+    @current_email_address = "test@test.com"
+    @subscriber_id = SecureRandom.uuid
+  end
+
+  def when_i_visit_the_manage_my_subscriptions_page
+    stub_email_alert_api_has_subscriber_subscriptions(
+      @subscriber_id,
+      @current_email_address,
+      nil,
+      subscriptions: [],
+    )
+
+    token = jwt_token(data: {
+      "address" => @current_email_address,
+      "subscriber_id" => @subscriber_id,
+    })
+
+    visit process_sign_in_token_path(token: token)
+  end
+
+  def and_i_click_to_change_my_email_address
+    click_on "Change email address"
+  end
+
+  def and_i_enter_a_new_email_address
+    @new_email_address = "another@email.com"
+    @request = stub_email_alert_api_has_updated_subscriber(@subscriber_id, @new_email_address)
+
+    fill_in "What’s your new email address?", with: @new_email_address
+    click_on "Save"
+  end
+
+  def then_i_can_see_that_my_email_address_has_been_changed
+    expect(@request).to have_been_requested
+    expect(page).to have_content(
+      "Your email address has been changed to #{@new_email_address}",
+    )
+  end
+end

--- a/spec/features/change_email_frequency_spec.rb
+++ b/spec/features/change_email_frequency_spec.rb
@@ -1,0 +1,80 @@
+RSpec.feature "Change email frequency after receiving confirmation link" do
+  include GdsApi::TestHelpers::EmailAlertApi
+  include TokenHelper
+
+  scenario do
+    given_i_have_a_subscription
+    when_i_visit_the_manage_my_subscriptions_page
+    then_i_can_see_i_am_subscribed_to_daily_updates
+    when_i_click_to_change_how_often_i_get_updates
+    and_i_select_once_a_week
+    then_i_can_see_that_i_am_subscribed_to_weekly_updates
+  end
+
+  def given_i_have_a_subscription
+    @address = "test@test.com"
+    @subscriber_id = SecureRandom.uuid
+    @subscription_id = SecureRandom.uuid
+    @subscription_title = "Something to subscribe to"
+
+    stub_email_alert_api_has_subscriber_subscriptions(
+      @subscriber_id, @address, nil, subscriptions: [subscription]
+    ).then
+     .to_return(status: 200,
+                body: subscriber_subscriptions_response_with_weekly_frequency)
+  end
+
+  def when_i_visit_the_manage_my_subscriptions_page
+    token = jwt_token(data: {
+      "address" => @address,
+      "subscriber_id" => @subscriber_id,
+    })
+
+    visit process_sign_in_token_path(token: token)
+  end
+
+  def then_i_can_see_i_am_subscribed_to_daily_updates
+    expect(page).to have_content("You chose to get daily updates")
+  end
+
+  def when_i_click_to_change_how_often_i_get_updates
+    click_on "Change how often you get updates"
+  end
+
+  def and_i_select_once_a_week
+    @request = stub_email_alert_api_has_updated_subscription(@subscription_id, "weekly")
+
+    choose "Once a week"
+    click_on "Save"
+  end
+
+  def then_i_can_see_that_i_am_subscribed_to_weekly_updates
+    expect(@request).to have_been_requested
+    expect(page).to have_content(
+      "You’ll now get updates about ‘#{@subscription_title}’ weekly",
+    )
+  end
+
+private
+
+  def subscription
+    {
+      "id" => @subscription_id,
+      "created_at" => Time.zone.now,
+      "frequency" => "daily",
+      "subscriber_list" => {
+        "title" => @subscription_title,
+      },
+    }
+  end
+
+  def subscriber_subscriptions_response_with_weekly_frequency
+    {
+      "subscriber" => {
+        "id" => @subscriber_id,
+        "address" => @address,
+      },
+      "subscriptions" => [subscription.merge("frequency" => "weekly")],
+    }.to_json
+  end
+end

--- a/spec/features/manage_subscriptions_confirmation_email_spec.rb
+++ b/spec/features/manage_subscriptions_confirmation_email_spec.rb
@@ -1,0 +1,33 @@
+RSpec.feature "Receive confirmation email when managing subscriptions" do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  scenario do
+    given_i_have_an_email_address
+    when_i_visit_the_manage_my_subscriptions_page
+    and_i_enter_my_email_address
+    then_i_can_see_a_confirmation_email_has_been_sent_to_me
+  end
+
+  def given_i_have_an_email_address
+    @email_address = "test@test.com"
+  end
+
+  def when_i_visit_the_manage_my_subscriptions_page
+    visit sign_in_path
+  end
+
+  def and_i_enter_my_email_address
+    subscriber_id = SecureRandom.uuid
+    @request = stub_email_alert_api_sends_subscriber_verification_email(
+      subscriber_id, @email_address
+    )
+
+    fill_in "What’s your email address?", with: @email_address
+    click_on "Continue"
+  end
+
+  def then_i_can_see_a_confirmation_email_has_been_sent_to_me
+    expect(@request).to have_been_requested
+    expect(page).to have_content("We’ve sent an email to #{@email_address}")
+  end
+end

--- a/spec/features/unsubscribe_all_spec.rb
+++ b/spec/features/unsubscribe_all_spec.rb
@@ -1,0 +1,57 @@
+RSpec.feature "Bulk unsubscribe after receiving confirmation link" do
+  include GdsApi::TestHelpers::EmailAlertApi
+  include TokenHelper
+
+  scenario do
+    given_i_have_multiple_subscriptions
+    when_i_visit_the_manage_my_subscriptions_page
+    and_i_click_on_unsubscribe_from_everything
+    and_i_confirm_to_unsubscribe
+    then_i_can_see_i_have_been_unsubscribed
+  end
+
+  def given_i_have_multiple_subscriptions
+    @address = "test@test.com"
+    @subscriber_id = SecureRandom.uuid
+    stub_email_alert_api_has_subscriber_subscriptions(
+      @subscriber_id,
+      @address,
+      nil,
+      subscriptions: [subscription, subscription],
+    )
+  end
+
+  def when_i_visit_the_manage_my_subscriptions_page
+    token = jwt_token(data: {
+      "address" => @address,
+      "subscriber_id" => @subscriber_id,
+    })
+    visit process_sign_in_token_path(token: token)
+  end
+
+  def and_i_click_on_unsubscribe_from_everything
+    click_on "Unsubscribe from everything"
+  end
+
+  def and_i_confirm_to_unsubscribe
+    @request = stub_email_alert_api_unsubscribes_a_subscriber(@subscriber_id)
+    click_on "Unsubscribe"
+  end
+
+  def then_i_can_see_i_have_been_unsubscribed
+    expect(@request).to have_been_requested
+    expect(page).to have_content("You have been unsubscribed from all your subscriptions")
+  end
+
+private
+
+  def subscription
+    {
+      "id" => SecureRandom.uuid,
+      "created_at" => Time.zone.now,
+      "subscriber_list" => {
+        "id" => SecureRandom.uuid,
+      },
+    }
+  end
+end

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -1,0 +1,38 @@
+RSpec.feature "Unsubscribe after receiving confirmation link" do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  scenario do
+    given_i_have_a_subscription
+    when_i_visit_the_unsubscribe_page
+    and_i_click_on_unsubscribe
+    then_i_see_that_i_am_unsubscribed
+  end
+
+  def given_i_have_a_subscription
+    @subscriber_list_id = SecureRandom.uuid
+    @title = "A thing to subscribe to"
+    stub_email_alert_api_has_subscription(
+      @subscriber_list_id,
+      "immediately",
+      title: @title,
+    )
+  end
+
+  def when_i_visit_the_unsubscribe_page
+    visit confirm_unsubscribe_path(@subscriber_list_id)
+  end
+
+  def and_i_click_on_unsubscribe
+    @unsubscribe_request = stub_email_alert_api_unsubscribes_a_subscription(
+      @subscriber_list_id,
+    )
+    click_on "Unsubscribe"
+  end
+
+  def then_i_see_that_i_am_unsubscribed
+    expect(@unsubscribe_request).to have_been_requested
+    expect(page).to have_content(
+      "You won’t get any more updates about #{@title}.",
+    )
+  end
+end


### PR DESCRIPTION
https://trello.com/c/wb8hyN7U/308-double-opt-in-add-feature-tests-for-managing-subscriptions