### PR TITLE
Extract translations for subscriptions management and subscriber authentication

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -27,7 +27,9 @@ class SubscriptionsManagementController < ApplicationController
                        new_frequency
                      end
 
-    flash[:success] = "You’ll now get updates about ‘#{subscription_title}’ #{frequency_text}"
+    flash[:success] = t("subscriptions_management.change_frequency.success",
+                        subscription_title: subscription_title,
+                        frequency: frequency_text)
 
     redirect_to list_subscriptions_path
   end
@@ -50,8 +52,8 @@ class SubscriptionsManagementController < ApplicationController
       id: authenticated_subscriber_id,
       new_address: new_address,
     )
-
-    flash[:success] = "Your email address has been changed to #{new_address}"
+    flash[:success] = t("subscriptions_management.update_address.success",
+                        address: new_address)
 
     redirect_to list_subscriptions_path
   rescue GdsApi::HTTPUnprocessableEntity
@@ -65,7 +67,7 @@ class SubscriptionsManagementController < ApplicationController
   def confirmed_unsubscribe_all
     begin
       email_alert_api.unsubscribe_subscriber(authenticated_subscriber_id)
-      flash[:success] = "You have been unsubscribed from all your subscriptions"
+      flash[:success] = t("subscriptions_management.confirmed_unsubscribe_all.success")
     rescue GdsApi::HTTPNotFound
       # The user has already unsubscribed.
       nil

--- a/app/views/subscriber_authentication/request_sign_in_token.html.erb
+++ b/app/views/subscriber_authentication/request_sign_in_token.html.erb
@@ -2,9 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Manage your subscriptions</h1>
+    <h1 class="govuk-heading-l"><%= t("subscriber_authentication.heading") %></h1>
 
-    <p class="govuk-body">We’ve sent an email to <%= @address %>.</p>
-    <p class="govuk-body">Check your inbox and click on the link to confirm your email address.</p>
+    <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.confirmation", address: @address) %></p>
+    <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.prompt") %></p>
   </div>
 </div>

--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -3,22 +3,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Manage your subscriptions</h1>
+    <h1 class="govuk-heading-l"><%= t("subscriber_authentication.heading") %></h1>
 
     <% if flash[:error_summary] == "email" %>
       <%= render 'govuk_publishing_components/components/error_summary', {
-        title: 'We weren’t able to sign you in',
+        title: t("subscriber_authentication.sign_in.email_error.title"),
         items: [
           {
-            text: 'There’s a problem with your email address',
+            text: t("subscriber_authentication.sign_in.email_error.description"),
             href: '#email-address-input',
           }
         ]
       } %>
     <% elsif flash[:error_summary] == "bad_token" %>
       <%= render 'govuk_publishing_components/components/error_summary', {
-        title: 'That link has expired',
-        description: 'Enter your email address again to change your subscription',
+        title: t("subscriber_authentication.sign_in.bad_token_error.title"),
+        description: t("subscriber_authentication.sign_in.bad_token_error.description"),
       } %>
     <% end %>
 
@@ -26,13 +26,13 @@
       <%= render 'govuk_publishing_components/components/input', {
         error_message: flash[:error],
         id: 'email-address-input',
-        label: { text: 'What’s your email address?' },
+        label: { text: t("subscriber_authentication.sign_in.email_input.label") },
         name: :address,
         type: 'email',
         value: @address,
       } %>
 
-      <p class="govuk-body">You’ll need to confirm your email address before you can manage your subscriptions.</p>
+      <p class="govuk-body"><%= t("subscriber_authentication.sign_in.description") %></p>
 
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Continue',

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Are you sure you want to unsubscribe from everything?' %>
+<% content_for :title, t("subscriptions_management.confirm_unsubscribe_all.heading") %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -8,9 +8,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Are you sure you want to unsubscribe from everything?</h1>
+    <h1 class="govuk-heading-l"><%= t("subscriptions_management.confirm_unsubscribe_all.heading") %></h1>
 
-    <p class="govuk-body">You won’t get any more automated emails from GOV.UK.</p>
+    <p class="govuk-body"><%= t("subscriptions_management.confirm_unsubscribe_all.description") %></p>
 
     <%= form_tag(action: :confirmed_unsubscribe_all) do %>
       <%= hidden_field_tag(:from, @from) %>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, 'Manage your subscriptions' %>
+<% content_for :title, t("subscriptions_management.heading") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"> Manage your subscriptions</h1>
+    <h1 class="govuk-heading-l"><%= t("subscriptions_management.heading") %></h1>
 
     <% if flash[:success] %>
       <%= render 'govuk_publishing_components/components/success_alert', {

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Change your email address' %>
+<% content_for :title, t("subscriptions_management.update_address.heading") %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -8,15 +8,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Change your email address</h1>
+    <h1 class="govuk-heading-l"><%= t("subscriptions_management.update_address.heading") %></h1>
 
     <% if flash[:error] %>
       <div class="column-two-thirds">
         <%= render 'govuk_publishing_components/components/error_summary', {
-          title: 'We weren’t able to change your email address',
+          title: t("subscriptions_management.update_address.error_title"),
           items: [
             {
-              text: 'There’s a problem with your email address',
+              text: t("subscriptions_management.update_address.error_description"),
               href: '#email-address-input',
             }
           ]
@@ -24,22 +24,20 @@
       </div>
     <% end %>
 
-    <p class="govuk-body">Your current email address is <%= @address %></p>
+    <p class="govuk-body"><%= t("subscriptions_management.update_address.current_email", address: @address) %></p>
 
     <%= form_tag change_address_path, method: :post do %>
       <%= render 'govuk_publishing_components/components/input', {
         error_message: flash[:error],
         id: 'email-address-input',
-        label: { text: 'What’s your new email address?' },
+        label: { text: t("subscriptions_management.update_address.new_email_label") },
         name: :new_address,
         type: 'email',
         value: @new_address,
       } %>
       <% unless @new_address.nil? %>
         <p class="govuk-body">
-          If you want to transfer your subscription to <%= @new_address %>,
-          you’ll need to subscribe to the same topics again, using the new
-          email address. Or you can
+          <%= t("subscriptions_management.update_address.description", address: @new_address) %>
           <%= link_to "contact us",
                       "/contact/govuk",
                       class: %w[govuk-link govuk-link--no-visited-state] %>.

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Manage your subscriptions' %>
+<% content_for :title, t("subscriptions_management.heading") %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Manage your subscriptions</h1>
+    <h1 class="govuk-heading-l"><%= t("subscriptions_management.heading") %></h1>
 
     <%= form_tag change_frequency_path, method: :post do %>
       <%= hidden_field_tag :id, @subscription_id %>

--- a/app/views/unsubscriptions/_confirmation.html.erb
+++ b/app/views/unsubscriptions/_confirmation.html.erb
@@ -1,0 +1,5 @@
+<% if @title %>
+  <p class="govuk-body"><%= t("unsubscriptions.confirmation.with_title", title: @title) %></p>
+<% else %>
+  <p class="govuk-body"><%= t("unsubscriptions.confirmation.without_title") %></p>
+<% end %>

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Are you sure you want to unsubscribe?' %>
+<% content_for :title, t("unsubscriptions.title.confirm") %>
 
 <% if @authenticated_for_subscription %>
   <% content_for :back_link do %>
@@ -10,13 +10,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Are you sure you want to unsubscribe?</h1>
+    <h1 class="govuk-heading-l"><%= t("unsubscriptions.title.confirm") %></h1>
 
-    <% if @title %>
-      <p class="govuk-body">You won’t get any more updates about <%= @title %>.</p>
-    <% else %>
-      <p class="govuk-body">You won’t get any more updates about this topic.</p>
-    <% end %>
+    <%= render "confirmation" %>
 
     <%= form_tag(action: :confirmed) do %>
       <%= render 'govuk_publishing_components/components/button', {

--- a/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
+++ b/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
@@ -1,5 +1,5 @@
 <%
-page_title = "You’ve already unsubscribed"
+page_title = t("unsubscriptions.title.confirm_already_unsubscribed")
 page_title += " from #{@title}" if @title
 content_for :title, page_title
 %>
@@ -16,10 +16,6 @@ content_for :title, page_title
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l"><%= page_title %></h1>
 
-    <% if @title %>
-      <p class="govuk-body">You won’t get any more updates about <%= @title %>.</p>
-    <% else %>
-      <p class="govuk-body">You won’t get any more updates about this topic.</p>
-    <% end %>
+    <%= render "confirmation" %>
   </div>
 </div>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -1,13 +1,9 @@
-<% content_for :title, 'You’ve successfully unsubscribed' %>
+<% content_for :title, t("unsubscriptions.title.confirmed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">You’ve successfully unsubscribed</h1>
+    <h1 class="govuk-heading-l"><%= t("unsubscriptions.title.confirmed") %></h1>
 
-    <% if @title %>
-      <p class="govuk-body">You won’t get any more updates about <%= @title %>.</p>
-    <% else %>
-      <p class="govuk-body">You won’t get any more updates about this topic.</p>
-    <% end %>
+    <%= render "confirmation" %>
   </div>
 </div>

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -1,5 +1,18 @@
 en:
   subscriber_authentication:
+    heading: Manage your subscriptions
     sign_in:
+      description: You’ll need to confirm your email address before you can manage your subscriptions.
+      email_input:
+        label: What’s your email address?
       missing_email: "Please enter your email address."
       invalid_email: "This doesn’t look like a valid email address – check you’ve entered it correctly."
+      email_error:
+        title: We weren’t able to sign you in
+        description: There’s a problem with your email address
+      bad_token_error:
+        title: That link has expired
+        description: Enter your email address again to change your subscription
+    request_sign_in_token:
+      confirmation: "We’ve sent an email to %{address}."
+      prompt: Check your inbox and click on the link to confirm your email address.

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -1,10 +1,28 @@
 en:
   subscriptions_management:
+    heading: Manage your subscriptions
     index:
       subscription:
         immediately: "You chose to get updates as soon as they happen."
         daily: "You chose to get daily updates."
         weekly: "You chose to get weekly updates."
     update_address:
+      heading: Change your email address
+      current_email: "Your current email address is %{address}"
+      description: |
+        If you want to transfer your subscription to %{address},
+        you’ll need to subscribe to the same topics again, using the new
+        email address. Or you can
+      new_email_label: What’s your new email address?
+      error_title: We weren’t able to change your email address
+      error_description: There’s a problem with your email address
       missing_email: Please enter your email address.
       invalid_email: "That email address isn’t valid, or it’s already in use – check you’ve typed in your email address correctly."
+      success: "Your email address has been changed to %{address}"
+    change_frequency:
+      success: "You’ll now get updates about ‘%{subscription_title}’ %{frequency}"
+    confirm_unsubscribe_all:
+      heading: Are you sure you want to unsubscribe from everything?
+      description: You won’t get any more automated emails from GOV.UK.
+    confirmed_unsubscribe_all:
+      success: You have been unsubscribed from all your subscriptions

--- a/config/locales/unsubscriptions.yml
+++ b/config/locales/unsubscriptions.yml
@@ -1,0 +1,9 @@
+en:
+  unsubscriptions:
+    title:
+      confirm_already_unsubscribed: You’ve already unsubscribed
+      confirm: Are you sure you want to unsubscribe?
+      confirmed: You’ve successfully unsubscribed
+    confirmation:
+      with_title: You won’t get any more updates about %{title}.
+      without_title: You won’t get any more updates about this topic.

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -165,7 +165,9 @@ RSpec.describe SubscriptionsManagementController do
 
       it "renders an error message" do
         post :change_address, params: { new_address: new_address }, session: session_data
-        expect(response.body).to include(I18n.t!("subscriptions_management.update_address.missing_email"))
+        expect(response.body).to include(
+          I18n.t!("subscriptions_management.update_address.missing_email"),
+        )
       end
 
       it "renders a form" do
@@ -183,7 +185,9 @@ RSpec.describe SubscriptionsManagementController do
 
       it "renders an error message" do
         post :change_address, params: { new_address: new_address }, session: session_data
-        expect(response.body).to include(I18n.t!("subscriptions_management.update_address.invalid_email"))
+        expect(response.body).to include(
+          I18n.t!("subscriptions_management.update_address.invalid_email"),
+        )
       end
 
       it "renders a form" do
@@ -209,7 +213,9 @@ RSpec.describe SubscriptionsManagementController do
 
       it "renders a message" do
         get :confirm_unsubscribe_all, session: session_data
-        expect(response.body).to include("You won’t get any more automated emails from GOV.UK.")
+        expect(response.body).to include(
+          I18n.t!("subscriptions_management.confirm_unsubscribe_all.description"),
+        )
       end
     end
 

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe UnsubscriptionsController do
     it "renders the title on the page" do
       get :confirm, params: { id: id }
 
-      expect(response.body).to include("You won’t get any more updates about #{title}")
+      expect(response.body).to include(
+        I18n.t!("unsubscriptions.confirmation.with_title", title: title),
+      )
     end
 
     context "when the subscription has already ended" do
@@ -147,7 +149,9 @@ RSpec.describe UnsubscriptionsController do
     it "renders a confirmation page" do
       post :confirmed, params: { id: id }
 
-      expect(response.body).to include("You won’t get any more updates about #{title}")
+      expect(response.body).to include(
+        I18n.t!("unsubscriptions.confirmation.with_title", title: title),
+      )
     end
 
     it "sends an unsubscribe request to email-alert-api" do
@@ -164,7 +168,9 @@ RSpec.describe UnsubscriptionsController do
       it "renders a page informing them the subscription has already ended" do
         post :confirmed, params: { id: id }
 
-        expect(response.body).to include("You won’t get any more updates about #{title}")
+        expect(response.body).to include(
+          I18n.t!("unsubscriptions.confirmation.with_title", title: title),
+        )
       end
     end
 

--- a/spec/features/change_email_address_spec.rb
+++ b/spec/features/change_email_address_spec.rb
@@ -39,14 +39,15 @@ RSpec.feature "Change email address after receiving confirmation link" do
     @new_email_address = "another@email.com"
     @request = stub_email_alert_api_has_updated_subscriber(@subscriber_id, @new_email_address)
 
-    fill_in "What’s your new email address?", with: @new_email_address
+    fill_in I18n.t!("subscriptions_management.update_address.new_email_label"), with: @new_email_address
     click_on "Save"
   end
 
   def then_i_can_see_that_my_email_address_has_been_changed
     expect(@request).to have_been_requested
     expect(page).to have_content(
-      "Your email address has been changed to #{@new_email_address}",
+      I18n.t!("subscriptions_management.update_address.success",
+              address: @new_email_address),
     )
   end
 end

--- a/spec/features/change_email_frequency_spec.rb
+++ b/spec/features/change_email_frequency_spec.rb
@@ -34,7 +34,9 @@ RSpec.feature "Change email frequency after receiving confirmation link" do
   end
 
   def then_i_can_see_i_am_subscribed_to_daily_updates
-    expect(page).to have_content("You chose to get daily updates")
+    expect(page).to have_content(
+      I18n.t!("subscriptions_management.index.subscription.daily"),
+    )
   end
 
   def when_i_click_to_change_how_often_i_get_updates
@@ -51,7 +53,9 @@ RSpec.feature "Change email frequency after receiving confirmation link" do
   def then_i_can_see_that_i_am_subscribed_to_weekly_updates
     expect(@request).to have_been_requested
     expect(page).to have_content(
-      "You’ll now get updates about ‘#{@subscription_title}’ weekly",
+      I18n.t!("subscriptions_management.change_frequency.success",
+              subscription_title: @subscription_title,
+              frequency: "weekly"),
     )
   end
 

--- a/spec/features/manage_subscriptions_confirmation_email_spec.rb
+++ b/spec/features/manage_subscriptions_confirmation_email_spec.rb
@@ -22,12 +22,16 @@ RSpec.feature "Receive confirmation email when managing subscriptions" do
       subscriber_id, @email_address
     )
 
-    fill_in "What’s your email address?", with: @email_address
+    fill_in I18n.t!("subscriber_authentication.sign_in.email_input.label"),
+            with: @email_address
     click_on "Continue"
   end
 
   def then_i_can_see_a_confirmation_email_has_been_sent_to_me
     expect(@request).to have_been_requested
-    expect(page).to have_content("We’ve sent an email to #{@email_address}")
+    expect(page).to have_content(
+      I18n.t!("subscriber_authentication.request_sign_in_token.confirmation",
+              address: @email_address),
+    )
   end
 end

--- a/spec/features/unsubscribe_all_spec.rb
+++ b/spec/features/unsubscribe_all_spec.rb
@@ -40,7 +40,9 @@ RSpec.feature "Bulk unsubscribe after receiving confirmation link" do
 
   def then_i_can_see_i_have_been_unsubscribed
     expect(@request).to have_been_requested
-    expect(page).to have_content("You have been unsubscribed from all your subscriptions")
+    expect(page).to have_content(
+      I18n.t("subscriptions_management.confirmed_unsubscribe_all.success"),
+    )
   end
 
 private

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Unsubscribe after receiving confirmation link" do
   def then_i_see_that_i_am_unsubscribed
     expect(@unsubscribe_request).to have_been_requested
     expect(page).to have_content(
-      "You won’t get any more updates about #{@title}.",
+      I18n.t!("unsubscriptions.confirmation.with_title", title: @title),
     )
   end
 end


### PR DESCRIPTION
For https://trello.com/c/wb8hyN7U/308-double-opt-in-add-feature-tests-for-managing-subscriptions