### PR TITLE
Drop support for JWT tokens

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -19,23 +19,12 @@ private
   attr_reader :token
 
   def read_token
-    read_message_encryptor_token || read_jwt_token
-  end
-
-  def read_message_encryptor_token
     len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
     key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
     crypt = ActiveSupport::MessageEncryptor.new(key, OPTIONS)
     decrypted_data = crypt.decrypt_and_verify(token)
     decrypted_data&.symbolize_keys
   rescue ActiveSupport::MessageEncryptor::InvalidMessage
-    nil
-  end
-
-  def read_jwt_token
-    payload, = JWT.decode(token, secret, true, algorithm: "HS256")
-    payload.fetch("data").to_h.symbolize_keys
-  rescue JWT::DecodeError
     nil
   end
 

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SubscriberAuthenticationController do
 
   describe "GET /email/authenticate/process" do
     let(:token) do
-      jwt_token(data: {
+      encrypt_and_sign_token(data: {
         "subscriber_id" => subscriber_id,
         "redirect" => "/email/manage",
       })
@@ -89,7 +89,7 @@ RSpec.describe SubscriberAuthenticationController do
     end
 
     context "when an expired token is provided" do
-      let(:expired_token) { jwt_token(expiry: 5.minutes.ago) }
+      let(:expired_token) { encrypt_and_sign_token(expiry: 0) }
 
       it "redirects to sign in" do
         get :process_sign_in_token, params: { token: expired_token }

--- a/spec/features/change_email_address_spec.rb
+++ b/spec/features/change_email_address_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Change email address after receiving confirmation link" do
       subscriptions: [],
     )
 
-    token = jwt_token(data: {
+    token = encrypt_and_sign_token(data: {
       "address" => @current_email_address,
       "subscriber_id" => @subscriber_id,
     })

--- a/spec/features/change_email_frequency_spec.rb
+++ b/spec/features/change_email_frequency_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Change email frequency after receiving confirmation link" do
   end
 
   def when_i_visit_the_manage_my_subscriptions_page
-    token = jwt_token(data: {
+    token = encrypt_and_sign_token(data: {
       "address" => @address,
       "subscriber_id" => @subscriber_id,
     })

--- a/spec/features/unsubscribe_all_spec.rb
+++ b/spec/features/unsubscribe_all_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Bulk unsubscribe after receiving confirmation link" do
   end
 
   def when_i_visit_the_manage_my_subscriptions_page
-    token = jwt_token(data: {
+    token = encrypt_and_sign_token(data: {
       "address" => @address,
       "subscriber_id" => @subscriber_id,
     })

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -2,43 +2,24 @@ describe AuthToken do
   include TokenHelper
 
   describe "#data" do
-    context "JWT token (legacy)" do
-      it "returns the data hash when valid" do
-        token = AuthToken.new(jwt_token(data: { a: "b" }))
-        expect(token.data).to eq(a: "b")
-      end
-
-      it "returns nil after the expiry time" do
-        token = AuthToken.new(jwt_token(expiry: 1.year.ago))
-        expect(token.data).to be_nil
-      end
-
-      it "returns nil if the token is invalid" do
-        token = AuthToken.new("eyJhbGciOiJIUzI1NiJ9.eyJkYXRhIjp7ImEiOiJiIn0sImV4cCI6MTU3NjYwMzEzMCwiaWF0IjoxNTc2NjAyODMwLCJpc3MiOiJodHRwczovL3d3dy5nb3YudWsifQ.Y6CjmaHAu6RSkEHySYQhuINuYQwj9Kpb8Zs6PzlBVv9")
-        expect(token.data).to be_nil
-      end
+    it "returns the data hash when valid" do
+      token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }))
+      expect(token.data).to eq(a: "b")
     end
 
-    context "ActiveSupport token" do
-      it "returns the data hash when valid" do
-        token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }))
-        expect(token.data).to eq(a: "b")
-      end
+    it "returns nil after the expiry time" do
+      token = AuthToken.new(encrypt_and_sign_token(expiry: 0))
+      expect(token.data).to be_nil
+    end
 
-      it "returns nil after the expiry time" do
-        token = AuthToken.new(encrypt_and_sign_token(expiry: 0))
-        expect(token.data).to be_nil
-      end
+    it "returns nil if the token is malformed" do
+      token = AuthToken.new("foo")
+      expect(token.data).to be_nil
+    end
 
-      it "returns nil if the token is malformed" do
-        token = AuthToken.new("foo")
-        expect(token.data).to be_nil
-      end
-
-      it "returns nil if the token is invalid" do
-        token = AuthToken.new("1HmD8E9iHE7LWl6vT+dfRiKoxX9fU/BY--0MJPSBtYJqtox940--q/zvsHND7yFOeVsIdFbbIQ==")
-        expect(token.data).to be_nil
-      end
+    it "returns nil if the token is invalid" do
+      token = AuthToken.new("1HmD8E9iHE7LWl6vT+dfRiKoxX9fU/BY--0MJPSBtYJqtox940--q/zvsHND7yFOeVsIdFbbIQ==")
+      expect(token.data).to be_nil
     end
   end
 end

--- a/spec/support/token_helper.rb
+++ b/spec/support/token_helper.rb
@@ -6,16 +6,4 @@ module TokenHelper
     crypt = ActiveSupport::MessageEncryptor.new(key, AuthToken::OPTIONS)
     crypt.encrypt_and_sign(data, expires_in: expiry)
   end
-
-  def jwt_token(data: {}, expiry: 5.minutes.from_now)
-    token_data = {
-      "data" => data,
-      "exp" => expiry.to_i,
-      "iat" => Time.now.to_i,
-      "iss" => "https://www.gov.uk",
-    }
-
-    secret = Rails.application.secrets.email_alert_auth_token
-    JWT.encode(token_data, secret, "HS256")
-  end
 end


### PR DESCRIPTION
https://trello.com/c/FwB5bALg/336-double-opt-in-fix-data-leak

This removes support for auth tokens created using JWT. After a period
of dual running, we now expect users to only click links with the new
tokens created using Rails' MessageEncryptor.