### PR TITLE
Follow redirects for content item email signups

### DIFF
--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -1,14 +1,31 @@
 RSpec.describe ContentItemSignupsController do
   include GdsApi::TestHelpers::ContentStore
 
-  shared_examples "handles bad input data correctly" do
-    it "redirects to topic=/brexit if topic param is /government/brexit" do
-      get :new, params: { topic: "/government/brexit" }
+  describe "redirection" do
+    it "follows a redirect" do
+      content_store_has_item("/magical/broomsticks",
+                             document_type: "redirect",
+                             content_id: SecureRandom.uuid,
+                             redirects: [{ destination: "/cleaning/broomsticks" }])
+
+      get :new, params: { topic: "/magical/broomsticks" }
 
       expect(response).to have_http_status(:found)
-      expect(response.location).to eq "http://test.host/email-signup?topic=%2Fbrexit"
+      expect(response.location).to eq "http://test.host/email-signup?topic=%2Fcleaning%2Fbroomsticks"
     end
+    it "redirects to the homepage if there is no destination path" do
+      content_store_has_item("/magical/broomsticks",
+                             document_type: "redirect",
+                             content_id: SecureRandom.uuid)
 
+      get :new, params: { topic: "/magical/broomsticks" }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to eq "http://test.host/"
+    end
+  end
+
+  shared_examples "handles bad input data correctly" do
     it "redirects to root if topic param is missing" do
       make_request(bad_param: "/education/some-rando-item")
 


### PR DESCRIPTION
Sometimes taxa are moved and a redirect is set in place.  Email signup links to the moved taxons are often hardcoded in content and will have to be updated. Some may be missed resulting
in broken links.

Previously, the case of redirecting /government/brexit -> /brexit was handled
as a special hard coded case.

This PR makes makes this more general by following the redirects in
the content item.

trello: https://trello.com/c/zhg0rOFS/386-update-government-brexit-redirect-in-email-alert-frontend