### PR TITLE
Remove grid class

### DIFF
--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -11,17 +11,15 @@
     <h1 class="govuk-heading-l"><%= t("subscriptions_management.update_address.heading") %></h1>
 
     <% if flash[:error] %>
-      <div class="column-two-thirds">
-        <%= render 'govuk_publishing_components/components/error_summary', {
-          title: t("subscriptions_management.update_address.error_title"),
-          items: [
-            {
-              text: t("subscriptions_management.update_address.error_description"),
-              href: '#email-address-input',
-            }
-          ]
-        } %>
-      </div>
+      <%= render 'govuk_publishing_components/components/error_summary', {
+        title: t("subscriptions_management.update_address.error_title"),
+        items: [
+          {
+            text: t("subscriptions_management.update_address.error_description"),
+            href: '#email-address-input',
+          }
+        ]
+      } %>
     <% end %>
 
     <p class="govuk-body"><%= t("subscriptions_management.update_address.current_email", address: @address) %></p>


### PR DESCRIPTION
- this appears to be the only element in all of GOV.UK still using the 'column-two-thirds' class from static, despite being surrounded by the newer govuk-grid-column classes
- I assume this was missed during the last update
- removing as it's already inside a two-thirds column and this class is going to be removed