### PR TITLE
Make entire repository pass Rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('config/application', __dir__)
+require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
 

--- a/script/cucumber
+++ b/script/cucumber
@@ -4,7 +4,7 @@ vendored_cucumber_bin = Dir["#{File.dirname(__FILE__)}/../vendor/{gems,plugins}/
 if vendored_cucumber_bin
   load File.expand_path(vendored_cucumber_bin)
 else
-  require 'rubygems' unless ENV['NO_RUBYGEMS']
-  require 'cucumber'
+  require "rubygems" unless ENV["NO_RUBYGEMS"]
+  require "cucumber"
   load Cucumber::BINARY
 end


### PR DESCRIPTION
This is depended on by https://github.com/alphagov/govuk-jenkinslib/pull/66.