### PR TITLE
Add note about email auth delay

### DIFF
--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -2,7 +2,7 @@ en:
   subscriber_authentication:
     heading: Manage your subscriptions
     sign_in:
-      description: You’ll need to confirm your email address before you can manage your subscriptions.
+      description: You’ll need to confirm your email address before you can manage your subscriptions.  There may be a delay of up to 15 minutes before you receive the confirmation email.
       email_input:
         label: What’s your email address?
       missing_email: "Please enter your email address."


### PR DESCRIPTION
We're thinking of adding a higher priority queue for these emails but, until that is done, just tell people that there's a delay.