### PR TITLE
Make it clear that the email is to manage subscriptions

### DIFF
--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -2,7 +2,7 @@ en:
   subscriber_authentication:
     heading: Manage your subscriptions
     sign_in:
-      description: You’ll need to confirm your email address before you can manage your subscriptions.  There may be a delay of up to 15 minutes before you receive the confirmation email.
+      description: We'll send you an email with a link in to manage your subscriptions.  There may be a delay of up to 15 minutes before you receive this email.
       email_input:
         label: What’s your email address?
       missing_email: "Please enter your email address."
@@ -15,4 +15,4 @@ en:
         description: Enter your email address again to change your subscription
     request_sign_in_token:
       confirmation: "We’ve sent an email to %{address}."
-      prompt: Check your inbox and click on the link to confirm your email address.
+      prompt: Check your inbox and click on the link to manage your subscriptions.

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -2,7 +2,7 @@ en:
   subscriber_authentication:
     heading: Manage your subscriptions
     sign_in:
-      description: We'll send you an email with a link in to manage your subscriptions.  There may be a delay of up to 15 minutes before you receive this email.
+      description: We’ll send you an email with a link in to manage your subscriptions.  There may be a delay of up to 15 minutes before you receive this email.
       email_input:
         label: What’s your email address?
       missing_email: "Please enter your email address."


### PR DESCRIPTION
We have some evidence that people are confused by having to "confirm" their email address when they already had to do that to sign up in the first place.