### PR TITLE
[DNM] Revert world location signups

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -27,7 +27,7 @@ class ContentItemSignupsController < ApplicationController
 
 private
 
-  PERMITTED_CONTENT_ITEMS = %w(taxon organisation ministerial_role person topical_event world_location).freeze
+  PERMITTED_CONTENT_ITEMS = %w(taxon organisation ministerial_role person topical_event).freeze
 
   def require_content_item_param
     unless valid_content_item_param?

--- a/app/models/content_item_subscriber_list.rb
+++ b/app/models/content_item_subscriber_list.rb
@@ -32,7 +32,7 @@ private
   def link_hash
     case content_item_type
     when "taxon"
-      taxon_or_world_location_links
+      taxon_links
     when "organisation"
       organisation_links
     when "person"
@@ -41,31 +41,17 @@ private
       ministerial_role_links
     when "topical_event"
       topical_event_links
-    when "world_location"
-      world_location_links
     else
       message = "No link hash available for content items of type #{content_item_type}!"
       raise UnsupportedContentItemError, message
     end
   end
 
-  def taxon_or_world_location_links
-    if content_item["base_path"].match(%r{^/world/(.*)})
-      {
-        "world_locations" => [content_item["content_id"]],
-      }
-    else
-      {
-        # 'taxon_tree' is the key used in email-alert-service for
-        # notifications, so create a subscriber list with this key.
-        "taxon_tree" => [content_item["content_id"]],
-      }
-    end
-  end
-
-  def world_location_links
+  def taxon_links
     {
-      "world_locations" => [content_item["content_id"]],
+      # 'taxon_tree' is the key used in email-alert-service for
+      # notifications, so create a subscriber list with this key.
+      "taxon_tree" => [content_item["content_id"]],
     }
   end
 

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -37,21 +37,6 @@ RSpec.describe ContentItemSubscriberList do
       end
     end
 
-    context "given a taxon which is a world_location" do
-      it "asks email-alert-api to find or create a subscriber list" do
-        world_location = { "document_type" => "taxon", "title" => "Peters Island",
-                           "content_id" => "world-id", "base_path" => "/world/peter-island" }
-
-        signup = described_class.new(world_location)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Peters Island", "links" => { "world_locations" => %w[world-id] })
-      end
-    end
-
     context "given an organisation" do
       organisation = { "document_type" => "organisation", "title" => "Org", "content_id" => "org-id" }
 
@@ -107,21 +92,6 @@ RSpec.describe ContentItemSubscriberList do
         expect(mock_email_alert_api)
           .to have_received(:find_or_create_subscriber_list)
           .with("title" => "Summit 2019", "links" => { "topical_events" => %w[summit-id] })
-      end
-    end
-
-    context "given a international delegation" do
-      international_delegation = { "document_type" => "world_location",
-                                   "title" => "Nato Delegation", "content_id" => "delegation-id" }
-
-      it "asks email-alert-api to find or create a subscriber list" do
-        signup = described_class.new(international_delegation)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Nato Delegation", "links" => { "world_locations" => %w[delegation-id] })
       end
     end
   end


### PR DESCRIPTION
Originally this PR -> https://github.com/alphagov/email-alert-frontend/pull/546 was merged
which enabled more document types to signup via email-alert-frontend...
great! But as it turns out this broke email signups for new users
signing up to world locations (taxon and news) as taxon world location
were now using the links key world_locations which didn't match to any
content-changes coming in as they were expecting taxon_tree and news
world locations broke because the content-id being saved in the
subscriber list was the taxon world location instead of the one known
about in whitehall (news).

This PR reverts this change so all world location email signups should
now work as expected going forward.

Related to:
https://github.com/alphagov/whitehall/pull/5464

Trello:
https://trello.com/c/lkD6aJ9v/1568-fix-world-locations-email-signup-bug