### PR TITLE
Add default frequency options for topic ids

### DIFF
--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -12,4 +12,12 @@ module FrequenciesHelper
       }
     }
   end
+
+  def frequency_options(topic_id)
+    options = {}
+    if topic_id == "coronavirus-covid-19-uk-government-response"
+      options[:checked_frequency] = "daily"
+    end
+    options
+  end
 end

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -33,7 +33,7 @@
       } do %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "frequency",
-          items: frequencies,
+          items: frequencies(frequency_options(@topic_id)),
         } %>
       <% end %>
 

--- a/spec/helpers/frequencies_helper_spec.rb
+++ b/spec/helpers/frequencies_helper_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe FrequenciesHelper do
+  describe "#frequency_options" do
+    it "returns empty options without a topic_id" do
+      options = frequency_options(nil)
+      expect(options).to eq({})
+    end
+
+    it "returns empty options non listed topic_id" do
+      options = frequency_options("not-listed-topic-id")
+      expect(options).to eq({})
+    end
+
+    it "returns default options for a listed topic_id" do
+      options = frequency_options("coronavirus-covid-19-uk-government-response")
+      expect(options).to eq({ checked_frequency: "daily" })
+    end
+  end
+
+  describe "#frequencies" do
+    it "returns default frequencies without options" do
+      expect(frequencies).to eq([
+        {
+          value: :immediately,
+          text: "As soon as they happen",
+          checked: false,
+        },
+        {
+          value: :daily,
+          text: "Once a day",
+          checked: false,
+        },
+        {
+          value: :weekly,
+          text: "Once a week",
+          checked: false,
+        },
+      ])
+    end
+
+    it "returns default frequencies with options" do
+      expect(frequencies({ checked_frequency: "daily" })).to eq([
+        {
+          value: :immediately,
+          text: "As soon as they happen",
+          checked: false,
+        },
+        {
+          value: :daily,
+          text: "Once a day",
+          checked: true,
+        },
+        {
+          value: :weekly,
+          text: "Once a week",
+          checked: false,
+        },
+      ])
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to set default frequency options for particular topic ids. Also adds the default checked option of daily for the `coronavirus-covid-19-uk-government-response` topic id

![Screenshot_2020-03-20 Get emails when pages are added or updated - GOV UK](https://user-images.githubusercontent.com/3694062/77152398-d08d2500-6a8f-11ea-98be-10e2748f8f36.png)
