### PR TITLE
Skip 'options' page in email subscription journey if there are no options to choose from

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -11,6 +11,12 @@ class ContentItemSignupsController < ApplicationController
 
   def new
     @subscription = ContentItemSubscriptionPresenter.new(@content_item)
+
+    if @subscription.child_taxons.present?
+      render "new"
+    else
+      render "confirm"
+    end
   end
 
   def confirm; end

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -1,9 +1,11 @@
 <% content_for :title, @content_item['title'] %>
 
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: :back
-  } %>
+<% if live_content_item?(@content_item) %>
+  <% content_for :back_link do %>
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: :back
+    } %>
+  <% end %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -11,7 +11,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-  <% if @subscription.child_taxons.present?%>
     <h1 class="govuk-heading-l">What do you want to get alerts about?</h1>
 
     <%= form_tag({action: "confirm"}, method: "get") do %>
@@ -43,23 +42,5 @@
         margin_bottom: true
       } %>
     <% end %>
-
-  <% else %>
-
-    <h1 class="govuk-heading-l">Get email alerts</h1>
-
-    <p class="govuk-body">You are signing up for email alerts about: <%= @content_item['title']%></p>
-    <% if @content_item['description'].present? %>
-      <p class="govuk-body"><%= @subscription.description %></p>
-    <% end %>
-
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Select",
-      href: confirm_content_item_signup_path(link: @content_item['base_path']),
-      margin_bottom: true
-    } %>
-
-  <% end %>
-
   </div>
 </div>

--- a/spec/features/topic_signup_back_spec.rb
+++ b/spec/features/topic_signup_back_spec.rb
@@ -1,10 +1,9 @@
 RSpec.feature "Topic signup back" do
   include GovukContentSchemaExamples
 
-  scenario "live taxon" do
-    document = GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |doc|
-      doc.merge("phase" => "live")
-    end
+  scenario "live taxon with children" do
+    document = GovukSchemas::Example.find("taxon", example_name: "taxon_with_child_taxons")
+    document.merge!("phase" => "live")
 
     content_store_has_item(document["base_path"], document)
     visit "/email-signup?topic=#{document['base_path']}"
@@ -12,12 +11,39 @@ RSpec.feature "Topic signup back" do
     expect(page).to have_link "Back", href: document["base_path"]
   end
 
-  scenario "alpha taxon" do
-    document = GovukSchemas::RandomExample.for_schema(frontend_schema: "taxon") do |doc|
-      doc.merge("phase" => "alpha")
-    end
+  scenario "alpha taxon with children" do
+    document = GovukSchemas::Example.find("taxon", example_name: "taxon_with_child_taxons")
+    document.merge!("phase" => "alpha")
 
     content_store_has_item(document["base_path"], document)
+    visit "/email-signup?topic=#{document['base_path']}"
+
+    expect(page).to_not have_link "Back", href: document["base_path"]
+  end
+
+  scenario "live taxon without children" do
+    document = GovukSchemas::Example.find("taxon", example_name: "taxon")
+    document.merge!("phase" => "live")
+
+    content_store_has_item(document["base_path"], document)
+    content_store_has_item(
+      document["links"]["parent_taxons"].first["base_path"],
+      document["links"]["parent_taxons"].first,
+    )
+    visit "/email-signup?topic=#{document['base_path']}"
+
+    expect(page).to have_link "Back", href: "javascript:history.back()"
+  end
+
+  scenario "alpha taxon without children" do
+    document = GovukSchemas::Example.find("taxon", example_name: "taxon")
+    document.merge!("phase" => "alpha")
+
+    content_store_has_item(document["base_path"], document)
+    content_store_has_item(
+      document["links"]["parent_taxons"].first["base_path"],
+      document["links"]["parent_taxons"].first,
+    )
     visit "/email-signup?topic=#{document['base_path']}"
 
     expect(page).to_not have_link "Back", href: document["base_path"]


### PR DESCRIPTION
Trello: https://trello.com/c/xV0rgaXK/44-spike-removing-the-first-page-of-coronavirus-email-subscription-journey

## What
In the email sign-up journey, go straight to 'confirm' if there are no subscription options (like topics or child-taxons) to choose from.

## Why
The 'new' and 'confirm' view are very similar when there are no options to choose from (see screenshots below). This just means more clicks for users.

<img width="1019" alt="Screenshot 2020-03-24 at 15 31 58" src="https://user-images.githubusercontent.com/29889908/77445167-a5cf0380-6de4-11ea-972a-578ab5f9ea24.png">
<img width="900" alt="Screenshot 2020-03-24 at 15 32 09" src="https://user-images.githubusercontent.com/29889908/77445605-31489480-6de5-11ea-8e20-69ad8694471e.png">
