### PR TITLE
Email subscription sign up content updates

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -19,7 +19,9 @@ class ContentItemSignupsController < ApplicationController
     end
   end
 
-  def confirm; end
+  def confirm
+    @subscription = ContentItemSubscriptionPresenter.new(content_item)
+  end
 
   def create
     signup = ContentItemSubscriberList.new(content_item.to_h)

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -11,11 +11,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">What you’ll get</h1>
+    <h1 class="govuk-heading-l">Sign up to get emails</h1>
 
     <p class="govuk-body">
-      You'll get alerts when the government publishes or changes anything on GOV.UK about: <%= @content_item['title'] %>.
+      Get emails when information changes on GOV.UK about: <%= @content_item['title'] %>.
     </p>
+
+    <% if @subscription.description.present? %>
+      <p class="govuk-body"><%= @subscription.description %></p>
+    <% end %>
 
     <% if estimated_email_frequency %>
       <p class="govuk-body">
@@ -24,26 +28,12 @@
   <% end %>
 
     <p class="govuk-body">
-      You can choose to receive email alerts:
+      You can choose how often you want to receive emails.
     </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>instantly</li>
-      <li>once a day, with all updates made that day</li>
-      <li>once a week, with all updates made that week</li>
-    </ul>
-
-    <p class="govuk-body">
-      You can set your preferences once you've signed up.
-    </p>
-
-    <%= render "govuk_publishing_components/components/inset_text", {
-      text: "The preferences you set will apply to all of your email alerts from GOV.UK."
-    } %>
 
     <%= form_tag(:action => :create) do %>
       <%= hidden_field_tag 'link', @content_item['base_path'] %>
-      <%= submit_tag('Sign up now', class: 'govuk-button') %>
+      <%= submit_tag('Sign up', class: 'govuk-button') %>
     <% end %>
 
   </div>

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -21,8 +21,6 @@
       } %>
     <% end %>
 
-    <%= tag.h1 t("subscriptions.new_frequency.title"), class: "govuk-heading-l" %>
-
     <%= form_tag subscription_frequency_path, method: :post, class: "checklist-email-signup" do %>
       <%= hidden_field_tag :topic_id, @topic_id %>
 
@@ -36,6 +34,10 @@
           items: frequencies(frequency_options(@topic_id)),
         } %>
       <% end %>
+
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "<p>Your choice will apply to all of the GOV.UK emails you’re subscribed to.</p><p>You can unsubscribe from emails or change your subscription at any time.</p>".html_safe
+      } %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Continue",

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -36,7 +36,7 @@
       <% end %>
 
       <%= render "govuk_publishing_components/components/inset_text", {
-        text: "<p>Your choice will apply to all of the GOV.UK emails you’re subscribed to.</p><p>You can unsubscribe from emails or change your subscription at any time.</p>".html_safe
+        text: "<p>You can unsubscribe from emails or change your subscription at any time.</p>".html_safe
       } %>
 
       <%= render "govuk_publishing_components/components/button", {

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -13,7 +13,7 @@
     <%= form_tag change_frequency_path, method: :post do %>
       <%= hidden_field_tag :id, @subscription_id %>
         <%= render 'govuk_publishing_components/components/fieldset', {
-          legend_text: '<h2 class="govuk-heading-m">How often do you want to get updates?</h2>'.html_safe,
+          legend_text: '<h2 class="govuk-heading-m">How often do you want to receive emails?</h2>'.html_safe,
         } do %>
           <%= render 'govuk_publishing_components/components/radio', {
             name: 'new_frequency',

--- a/config/locales/frequencies.yml
+++ b/config/locales/frequencies.yml
@@ -1,5 +1,5 @@
 en:
   frequencies:
-    immediately: As soon as they happen
-    daily: Once a day
-    weekly: Once a week
+    immediately: Every time something changes on GOV.UK
+    daily: Once a day, with all the updates made that day (recommended)
+    weekly: Once a week, with all the updates made that week

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -4,7 +4,7 @@ en:
       general_problem: "There is a problem"
       required_question: "You must answer this question"
       missing_frequency: "Select how often you want updates"
-      question: How often do you want to get updates?
+      question: How often do you want to receive emails?
       title: Get emails when pages are added or updated
     new_address:
       general_problem: "We weren’t able to process your subscription"

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -82,9 +82,9 @@ RSpec.feature "Content item signup" do
 
     # Based on the position of this taxon in the taxonomy:
     expect(page).to have_content("This might be between 0 - 20 updates a week")
-    expect(page).to have_content("You can set your preferences once you've signed up.")
+    expect(page).to have_content("You can choose how often you want to receive emails.")
 
-    click_on "Sign up now"
+    click_on "Sign up"
   end
 
   def then_i_can_subscribe_to_alerts

--- a/spec/helpers/frequencies_helper_spec.rb
+++ b/spec/helpers/frequencies_helper_spec.rb
@@ -21,17 +21,17 @@ RSpec.describe FrequenciesHelper do
       expect(frequencies).to eq([
         {
           value: :immediately,
-          text: "As soon as they happen",
+          text: "Every time something changes on GOV.UK",
           checked: false,
         },
         {
           value: :daily,
-          text: "Once a day",
+          text: "Once a day, with all the updates made that day (recommended)",
           checked: false,
         },
         {
           value: :weekly,
-          text: "Once a week",
+          text: "Once a week, with all the updates made that week",
           checked: false,
         },
       ])
@@ -41,17 +41,17 @@ RSpec.describe FrequenciesHelper do
       expect(frequencies({ checked_frequency: "daily" })).to eq([
         {
           value: :immediately,
-          text: "As soon as they happen",
+          text: "Every time something changes on GOV.UK",
           checked: false,
         },
         {
           value: :daily,
-          text: "Once a day",
+          text: "Once a day, with all the updates made that day (recommended)",
           checked: true,
         },
         {
           value: :weekly,
-          text: "Once a week",
+          text: "Once a week, with all the updates made that week",
           checked: false,
         },
       ])


### PR DESCRIPTION
https://trello.com/c/7iBwU6g4/59-update-the-content-for-the-coronavirus-covid-19-uk-government-response-email-subscription-sign-up