### PR TITLE
Add coronavirus weekly email volume

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -7,7 +7,7 @@ class ContentItemSignupsController < ApplicationController
   before_action :require_content_item_param
   before_action :handle_redirects
   before_action :validate_document_type
-  helper_method :estimated_email_frequency
+  helper_method :weekly_email_volume_estimate
 
   def new
     @subscription = ContentItemSubscriptionPresenter.new(@content_item)
@@ -82,7 +82,7 @@ private
     end
   end
 
-  def estimated_email_frequency
+  def weekly_email_volume_estimate
     EmailVolume::WeeklyEmailVolume.new(content_item).estimate
   end
 end

--- a/app/models/email_volume/organisation_weekly_email_volume.rb
+++ b/app/models/email_volume/organisation_weekly_email_volume.rb
@@ -1,8 +1,8 @@
 module EmailVolume
   class OrganisationWeeklyEmailVolume
-    HIGH = "40 - 60".freeze
-    MEDIUM = "0 - 20".freeze
-    LOW = "0 - 5".freeze
+    HIGH = "40 to 60".freeze
+    MEDIUM = "0 to 20".freeze
+    LOW = "0 to 5".freeze
 
     def initialize(organisation)
       @organisation = organisation

--- a/app/models/email_volume/taxon_weekly_email_volume.rb
+++ b/app/models/email_volume/taxon_weekly_email_volume.rb
@@ -1,8 +1,8 @@
 module EmailVolume
   class TaxonWeeklyEmailVolume
-    HIGH = "40 - 60".freeze
-    MEDIUM = "0 - 20".freeze
-    LOW = "0 - 5".freeze
+    HIGH = "40 to 60".freeze
+    MEDIUM = "0 to 20".freeze
+    LOW = "0 to 5".freeze
 
     def initialize(taxon)
       @taxon = taxon

--- a/app/models/email_volume/topical_event_weekly_email_volume.rb
+++ b/app/models/email_volume/topical_event_weekly_email_volume.rb
@@ -1,0 +1,22 @@
+module EmailVolume
+  class TopicalEventWeeklyEmailVolume
+    VOLUME = "40 to 60".freeze
+    COROVIRUS_TOPICAL_EVENT_BASE_PATH = "/government/topical-events/coronavirus-covid-19-uk-government-response".freeze
+
+    private_constant :COROVIRUS_TOPICAL_EVENT_BASE_PATH
+
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def estimate
+      VOLUME if coronavirus_topical_event?
+    end
+
+  private
+
+    def coronavirus_topical_event?
+      @content_item["base_path"] == COROVIRUS_TOPICAL_EVENT_BASE_PATH
+    end
+  end
+end

--- a/app/models/email_volume/weekly_email_volume.rb
+++ b/app/models/email_volume/weekly_email_volume.rb
@@ -18,6 +18,8 @@ module EmailVolume
         TaxonWeeklyEmailVolume.new(@content_item)
       when "organisation"
         OrganisationWeeklyEmailVolume.new(@content_item)
+      when "topical_event"
+        TopicalEventWeeklyEmailVolume.new(@content_item)
       end
     end
 

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -21,9 +21,9 @@
       <p class="govuk-body"><%= @subscription.description %></p>
     <% end %>
 
-    <% if estimated_email_frequency %>
+    <% if weekly_email_volume_estimate %>
       <p class="govuk-body">
-        This might be between <%= estimated_email_frequency %> updates a week.
+        There might be <%= weekly_email_volume_estimate %> changes a week.
       </p>
   <% end %>
 

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Content item signup" do
     )
 
     # Based on the position of this taxon in the taxonomy:
-    expect(page).to have_content("This might be between 0 - 20 updates a week")
+    expect(page).to have_content("There might be 0 to 20 changes a week")
     expect(page).to have_content("You can choose how often you want to receive emails.")
 
     click_on "Sign up"

--- a/spec/models/weekly_email_volume_spec.rb
+++ b/spec/models/weekly_email_volume_spec.rb
@@ -84,5 +84,24 @@ RSpec.describe EmailVolume::WeeklyEmailVolume do
         expect(described_class.new(person).estimate).to be_nil
       end
     end
+
+    context "given a topical event page" do
+      it "returns the estimated volume for the coronavirus page" do
+        coronavirus_page = {
+          document_type: "topical_event",
+          base_path: "/government/topical-events/coronavirus-covid-19-uk-government-response",
+        }.deep_stringify_keys
+
+        expect(described_class.new(coronavirus_page).estimate).to eql "40 to 60"
+      end
+
+      it "returns no estimated volume for non-coronavirus topical event pages" do
+        coronavirus_page = {
+          document_type: "topical_event",
+        }.deep_stringify_keys
+
+        expect(described_class.new(coronavirus_page).estimate).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
This sets expectation for the weekly volume of changes for the coronavirus topic.

<img width="630" alt="Screenshot 2020-04-02 at 12 29 18" src="https://user-images.githubusercontent.com/3141541/78244465-984d0400-74dd-11ea-955c-0bd4fd3616cb.png">

The implementation is somewhat hacky. However, the plan is to migrate the coronavirus topical event to a taxon, which means the hack will be removed then.

https://trello.com/c/1TbLyQXY/73-display-estimated-weekly-email-volume-for-coronavirus-email-sign-up