### PR TITLE
Add error page for invalid sessions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "govuk_publishing_components", "~> 21.36.1"
 gem "jwt", "~> 2.2"
 gem "plek", "~> 3.0"
 gem "sass-rails", "~> 5.0"
-gem "slimmer", "~> 13.2"
+gem "slimmer", "~> 13.3.0"
 gem "uglifier", "~> 4.2"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       tilt
     sentry-raven (3.0.0)
       faraday (>= 1.0)
-    slimmer (13.2.2)
+    slimmer (13.3.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -323,7 +323,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0)
   rubocop-govuk
   sass-rails (~> 5.0)
-  slimmer (~> 13.2)
+  slimmer (~> 13.3.0)
   timecop (~> 0.9.1)
   uglifier (~> 4.2)
   webmock (~> 3.8)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_token
+
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
   rescue_from GdsApi::HTTPForbidden, with: :forbidden
   rescue_from GdsApi::HTTPGone, with: :gone
@@ -23,6 +25,11 @@ private
   def set_cache_control_header
     response.cache_control[:private] = true
     response.cache_control[:extras] = %w[no-cache]
+  end
+
+  def invalid_token
+    reset_session
+    render "sessions/invalid", status: :unprocessable_entity
   end
 
   def error_not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,7 @@ private
   end
 
   def invalid_token
+    response.set_header("X-Slimmer-Ignore-Error", "true")
     reset_session
     render "sessions/invalid", status: :unprocessable_entity
   end

--- a/app/views/sessions/invalid.html.erb
+++ b/app/views/sessions/invalid.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, t("sessions.invalid.title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= tag.h1 t("sessions.invalid.heading"), class: "govuk-heading-l" %>
+
+    <%= tag.p t("sessions.invalid.description"), class: "govuk-body" %>
+     <%= tag.p t("sessions.invalid.action"), class: "govuk-body" %>
+  </div>
+</div>

--- a/config/locales/sessions.yml
+++ b/config/locales/sessions.yml
@@ -1,0 +1,7 @@
+en:
+  sessions:
+    invalid:
+      title: 'Sorry, there was a problem'
+      heading: 'Sorry, there was a problem'
+      description: 'We cannot show you the page you were expecting.'
+      action: 'Go back and try again.'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe ApplicationController do
+  render_views
+  controller do
+    def index
+      raise ActionController::InvalidAuthenticityToken
+    end
+  end
+
+  describe "handling InvalidAuthenticityToken exceptions" do
+    it "renders the invalid session template" do
+      get :index
+      expect(response.body).to include("Sorry, there was a problem")
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end


### PR DESCRIPTION
Previously we were showing users the default rails 422 pages on InvalidAuthenticityToken exceptions. This adds a GOV.UK styled error page, thats should be less confusing and tell the users to try the form again.

## Before
<img width="727" alt="Screenshot 2020-04-08 at 15 30 35" src="https://user-images.githubusercontent.com/29889908/78796220-f1b9a500-79ad-11ea-8995-a271d4dff0cb.png">

## After
<img width="1011" alt="Screenshot 2020-04-09 at 11 05 10" src="https://user-images.githubusercontent.com/29889908/78883916-0a7b9680-7a52-11ea-9924-210026b1bc5e.png">

