### PR TITLE
Override topical event title for email

### DIFF
--- a/app/presenters/content_item_subscription_presenter.rb
+++ b/app/presenters/content_item_subscription_presenter.rb
@@ -3,6 +3,14 @@ class ContentItemSubscriptionPresenter
     @content_item = content_item
   end
 
+  def title
+    if content_item["content_id"] == "c4cd0e8a-3ae1-4385-8936-1cfafe5031fb"
+      "Coronavirus (COVID-19)"
+    else
+      content_item["title"]
+    end
+  end
+
   def description
     return "This will include: #{content_item['description']}" if is_taxon?
 

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, @content_item['title'] %>
+<% content_for :title, @subscription.title %>
 
 <% if live_content_item?(@content_item) %>
   <% content_for :back_link do %>
@@ -14,7 +14,7 @@
     <h1 class="govuk-heading-l">Sign up to get emails</h1>
 
     <p class="govuk-body">
-      Get emails when information changes on GOV.UK about: <%= @content_item['title'] %>.
+      Get emails when information changes on GOV.UK about: <%= @subscription.title %>.
     </p>
 
     <% if @subscription.description.present? %>


### PR DESCRIPTION
Trello: https://trello.com/c/x2QeWfip/61-rename-coronavirus-email-subscription-title

## What
Temporarily override the Coronavirus topical event title for the email signup journey.

## Why
We added a [migration task to rename the email subscriber list title itself](https://github.com/alphagov/email-alert-api/pull/1199), but this isn't used in the email alert frontend when someone is signing up. Instead, this relies on the content_item of (in this case) the topical event. 

We could rename the topical event itself in Whitehall but this is may need more discussion with content designers and more broadcasting of the change. Let's add a quick override here and remove it once the product team have switched to the new taxonomy.

## Before
<img width="592" alt="Screenshot 2020-04-07 at 11 44 31" src="https://user-images.githubusercontent.com/29889908/78660730-8399b300-78c5-11ea-9213-54536a8c3bb9.png">

## After
<img width="588" alt="Screenshot 2020-04-07 at 11 44 18" src="https://user-images.githubusercontent.com/29889908/78660739-87c5d080-78c5-11ea-9997-eba17c213321.png">


