### PR TITLE
Update 'manage your subscriptions' content

### DIFF
--- a/app/views/subscriber_authentication/request_sign_in_token.html.erb
+++ b/app/views/subscriber_authentication/request_sign_in_token.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, 'Manage your subscriptions' %>
+<% content_for :title, t("subscriber_authentication.request_sign_in_token.heading") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("subscriber_authentication.heading") %></h1>
+    <h1 class="govuk-heading-l"><%= t("subscriber_authentication.request_sign_in_token.heading") %></h1>
 
     <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.confirmation", address: @address) %></p>
     <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.prompt") %></p>

--- a/app/views/subscriber_authentication/request_sign_in_token.html.erb
+++ b/app/views/subscriber_authentication/request_sign_in_token.html.erb
@@ -6,5 +6,6 @@
 
     <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.confirmation", address: @address) %></p>
     <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.prompt") %></p>
+    <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.delay_warning") %></p>
   </div>
 </div>

--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Manage your subscriptions' %>
+<% content_for :title, t("subscriber_authentication.heading") %>
 
 
 <div class="govuk-grid-row">

--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -22,6 +22,8 @@
       } %>
     <% end %>
 
+    <p class="govuk-body"><%= t("subscriber_authentication.sign_in.description") %></p>
+
     <%= form_tag request_sign_in_token_path, method: :post do %>
       <%= render 'govuk_publishing_components/components/input', {
         error_message: flash[:error],
@@ -32,7 +34,7 @@
         value: @address,
       } %>
 
-      <p class="govuk-body"><%= t("subscriber_authentication.sign_in.description") %></p>
+      <p class="govuk-body"><%= t("subscriber_authentication.sign_in.action") %></p>
 
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Continue',

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -15,7 +15,7 @@ en:
         title: That link has expired
         description: Enter your email address again to manage your subscriptions
     request_sign_in_token:
-      heading: "Check your email inbox"
+      heading: "Check your inbox"
       confirmation: "We’ve sent an email to %{address}."
       prompt: Click the link in the email to manage your subscriptions.
       delay_warning: It can take up to 15 minutes for the email to arrive.

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -6,10 +6,10 @@ en:
       action: We’ll send you an email with a link in to manage your subscriptions.
       email_input:
         label: Your email address
-      missing_email: "Enter your email address."
-      invalid_email: "This does not look like a valid email address – check you’ve entered it correctly."
+      missing_email: "Enter your email address"
+      invalid_email: "This does not look like a valid email address – check you’ve entered it correctly"
       email_error:
-        title: We could not sign you in
+        title: We cannot send you an email
         description: There’s a problem with your email address
       bad_token_error:
         title: That link has expired

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -2,7 +2,8 @@ en:
   subscriber_authentication:
     heading: Manage your email subscriptions
     sign_in:
-      description: We’ll send you an email with a link in to manage your subscriptions.
+      description: For security, we need you to confirm your email address.
+      action: We’ll send you an email with a link in to manage your subscriptions.
       email_input:
         label: Your email address
       missing_email: "Enter your email address."

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -15,7 +15,7 @@ en:
         title: That link has expired
         description: Enter your email address again to manage your subscriptions
     request_sign_in_token:
-      heading: "Check your emails"
+      heading: "Check your email inbox"
       confirmation: "We’ve sent an email to %{address}."
       prompt: Click the link in the email to manage your subscriptions.
       delay_warning: It can take up to 15 minutes for the email to arrive.

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -6,7 +6,7 @@ en:
       email_input:
         label: What’s your email address?
       missing_email: "Please enter your email address."
-      invalid_email: "This doesn’t look like a valid email address – check you’ve entered it correctly."
+      invalid_email: "This does not look like a valid email address – check you’ve entered it correctly."
       email_error:
         title: We could not sign you in
         description: There’s a problem with your email address

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -1,8 +1,8 @@
 en:
   subscriber_authentication:
-    heading: Manage your subscriptions
+    heading: Manage your email subscriptions
     sign_in:
-      description: We’ll send you an email with a link in to manage your subscriptions.  There may be a delay of up to 15 minutes before you receive this email.
+      description: We’ll send you an email with a link in to manage your subscriptions.
       email_input:
         label: What’s your email address?
       missing_email: "Please enter your email address."
@@ -15,4 +15,4 @@ en:
         description: Enter your email address again to change your subscription
     request_sign_in_token:
       confirmation: "We’ve sent an email to %{address}."
-      prompt: Check your inbox and click on the link to manage your subscriptions.
+      prompt: Click the link in the email to manage your subscriptions. It can take up to 15 minutes for the email to arrive.

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -13,7 +13,7 @@ en:
         description: There’s a problem with your email address
       bad_token_error:
         title: That link has expired
-        description: Enter your email address again to manage your subscription
+        description: Enter your email address again to manage your subscriptions
     request_sign_in_token:
       heading: "Check your emails"
       confirmation: "We’ve sent an email to %{address}."

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -14,5 +14,6 @@ en:
         title: That link has expired
         description: Enter your email address again to manage your subscription
     request_sign_in_token:
+      heading: "Check your emails"
       confirmation: "We’ve sent an email to %{address}."
       prompt: Click the link in the email to manage your subscriptions. It can take up to 15 minutes for the email to arrive.

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -8,7 +8,7 @@ en:
       missing_email: "Please enter your email address."
       invalid_email: "This doesn’t look like a valid email address – check you’ve entered it correctly."
       email_error:
-        title: We weren’t able to sign you in
+        title: We could not sign you in
         description: There’s a problem with your email address
       bad_token_error:
         title: That link has expired

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -4,8 +4,8 @@ en:
     sign_in:
       description: We’ll send you an email with a link in to manage your subscriptions.
       email_input:
-        label: What’s your email address?
-      missing_email: "Please enter your email address."
+        label: Your email address
+      missing_email: "Enter your email address."
       invalid_email: "This does not look like a valid email address – check you’ve entered it correctly."
       email_error:
         title: We could not sign you in

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -16,4 +16,5 @@ en:
     request_sign_in_token:
       heading: "Check your emails"
       confirmation: "We’ve sent an email to %{address}."
-      prompt: Click the link in the email to manage your subscriptions. It can take up to 15 minutes for the email to arrive.
+      prompt: Click the link in the email to manage your subscriptions.
+      delay_warning: It can take up to 15 minutes for the email to arrive.

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -12,7 +12,7 @@ en:
         description: There’s a problem with your email address
       bad_token_error:
         title: That link has expired
-        description: Enter your email address again to change your subscription
+        description: Enter your email address again to manage your subscription
     request_sign_in_token:
       confirmation: "We’ve sent an email to %{address}."
       prompt: Click the link in the email to manage your subscriptions. It can take up to 15 minutes for the email to arrive.


### PR DESCRIPTION
This PR updates the content for the _Manage your subscriptions_ journey.

The content changes aim to:

* set user expectations
* provide useful information at the most appropriate point in the journey
* improve the consistency of content elsewhere in the email notifications service