### PR TITLE
Update unsubscribe content

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -27,9 +27,9 @@ class SubscriptionsManagementController < ApplicationController
                        new_frequency
                      end
 
-    flash[:success] = t("subscriptions_management.change_frequency.success",
-                        subscription_title: subscription_title,
-                        frequency: frequency_text)
+    flash[:success] = {
+      message: t("subscriptions_management.change_frequency.success", subscription_title: subscription_title, frequency: frequency_text),
+    }
 
     redirect_to list_subscriptions_path
   end
@@ -52,8 +52,9 @@ class SubscriptionsManagementController < ApplicationController
       id: authenticated_subscriber_id,
       new_address: new_address,
     )
-    flash[:success] = t("subscriptions_management.update_address.success",
-                        address: new_address)
+    flash[:success] = {
+      message: t("subscriptions_management.update_address.success", address: new_address),
+    }
 
     redirect_to list_subscriptions_path
   rescue GdsApi::HTTPUnprocessableEntity
@@ -67,7 +68,10 @@ class SubscriptionsManagementController < ApplicationController
   def confirmed_unsubscribe_all
     begin
       email_alert_api.unsubscribe_subscriber(authenticated_subscriber_id)
-      flash[:success] = t("subscriptions_management.confirmed_unsubscribe_all.success")
+      flash[:success] = {
+        message: t("subscriptions_management.confirmed_unsubscribe_all.success_message"),
+        description: t("subscriptions_management.confirmed_unsubscribe_all.success_description"),
+      }
     rescue GdsApi::HTTPNotFound
       # The user has already unsubscribed.
       nil

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -27,7 +27,15 @@ class UnsubscriptionsController < ApplicationController
                 else
                   "You have been unsubscribed"
                 end
-      flash[:success] = message if unsubscribed
+      description = "It can take up to an hour for this change to take effect."
+
+      if unsubscribed
+        flash[:success] = {
+          message: message,
+          description: description,
+        }
+      end
+
       redirect_to list_subscriptions_path
     end
   end

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -6,7 +6,8 @@
 
     <% if flash[:success] %>
       <%= render 'govuk_publishing_components/components/success_alert', {
-        message: flash[:success]
+        message: flash[:success]["message"],
+        description: flash[:success]["description"],
       } %>
     <% end %>
 

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -26,4 +26,4 @@ en:
       description: You won’t get any more automated emails from GOV.UK.
     confirmed_unsubscribe_all:
       success_message: You have been unsubscribed from all your subscriptions.
-      success_description: It may take up to an hour for this change to take effect.
+      success_description: It can take up to an hour for this change to take effect.

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -25,4 +25,5 @@ en:
       heading: Are you sure you want to unsubscribe from everything?
       description: You won’t get any more automated emails from GOV.UK.
     confirmed_unsubscribe_all:
-      success: You have been unsubscribed from all your subscriptions. It may take up to an hour for this change to take effect.
+      success_message: You have been unsubscribed from all your subscriptions.
+      success_description: It may take up to an hour for this change to take effect.

--- a/config/locales/unsubscriptions.yml
+++ b/config/locales/unsubscriptions.yml
@@ -6,4 +6,4 @@ en:
       confirmed: You’ve successfully unsubscribed
     confirmation:
       with_title: You will not get any more emails from GOV.UK about ‘%{title}’.
-      without_title: You won’t get any more emails from GOV.UK about this topic.
+      without_title: You will not get any more emails from GOV.UK about this topic.

--- a/config/locales/unsubscriptions.yml
+++ b/config/locales/unsubscriptions.yml
@@ -5,5 +5,5 @@ en:
       confirm: Are you sure you want to unsubscribe?
       confirmed: You’ve successfully unsubscribed
     confirmation:
-      with_title: You won’t get any more updates about %{title}. It may take up to an hour for this change to take effect.
-      without_title: You won’t get any more updates about this topic. It may take up to an hour for this change to take effect.
+      with_title: You won’t get any more updates about %{title}.
+      without_title: You won’t get any more updates about this topic.

--- a/config/locales/unsubscriptions.yml
+++ b/config/locales/unsubscriptions.yml
@@ -5,5 +5,5 @@ en:
       confirm: Are you sure you want to unsubscribe?
       confirmed: You’ve successfully unsubscribed
     confirmation:
-      with_title: You won’t get any more updates about %{title}.
-      without_title: You won’t get any more updates about this topic.
+      with_title: You will not get any more emails from GOV.UK about ‘%{title}’.
+      without_title: You won’t get any more emails from GOV.UK about this topic.

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe SubscriptionsManagementController do
       it "sets a flash about the success" do
         post :confirmed_unsubscribe_all, session: session_data
         expect(flash[:success][:message]).to match(/unsubscribed from all your subscriptions/)
-        expect(flash[:success][:description]).to match(/It may take up to an hour for this change to take effect./)
+        expect(flash[:success][:description]).to match(/It can take up to an hour for this change to take effect./)
       end
     end
   end

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -234,7 +234,8 @@ RSpec.describe SubscriptionsManagementController do
 
       it "sets a flash about the success" do
         post :confirmed_unsubscribe_all, session: session_data
-        expect(flash[:success]).to match(/unsubscribed from all your subscriptions/)
+        expect(flash[:success][:message]).to match(/unsubscribed from all your subscriptions/)
+        expect(flash[:success][:description]).to match(/It may take up to an hour for this change to take effect./)
       end
     end
   end

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -186,7 +186,8 @@ RSpec.describe UnsubscriptionsController do
 
       it "sets a flash to confirm" do
         post :confirmed, params: { id: id }, session: session
-        expect(flash[:success]).to eq("You have been unsubscribed from ‘#{title}’")
+        expect(flash[:success][:message]).to eq("You have been unsubscribed from ‘#{title}’")
+        expect(flash[:success][:description]).to eq("It can take up to an hour for this change to take effect.")
       end
     end
 

--- a/spec/features/unsubscribe_all_spec.rb
+++ b/spec/features/unsubscribe_all_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature "Bulk unsubscribe after receiving confirmation link" do
   def then_i_can_see_i_have_been_unsubscribed
     expect(@request).to have_been_requested
     expect(page).to have_content(
-      I18n.t("subscriptions_management.confirmed_unsubscribe_all.success"),
+      I18n.t("subscriptions_management.confirmed_unsubscribe_all.success_message"),
     )
   end
 


### PR DESCRIPTION
This PR updates the content for the _unsubscribe_ journey.

The content changes aim to:

* set user expectations
* provide useful information at the most appropriate point in the journey
* improve the consistency of content elsewhere in the email notifications service