### PR TITLE
Show no description for taxon when it has none

### DIFF
--- a/app/presenters/content_item_subscription_presenter.rb
+++ b/app/presenters/content_item_subscription_presenter.rb
@@ -12,9 +12,13 @@ class ContentItemSubscriptionPresenter
   end
 
   def description
-    return "This will include: #{content_item['description']}" if is_taxon?
+    description = content_item["description"]
 
-    content_item["description"]
+    return if description.blank?
+
+    return "This will include: #{description}" if is_taxon?
+
+    description
   end
 
   def child_taxons

--- a/spec/unit/presenters/content_item_subscription_presenter_spec.rb
+++ b/spec/unit/presenters/content_item_subscription_presenter_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe ContentItemSubscriptionPresenter do
         presenter = described_class.new(fake_taxon)
         expect(presenter.description).to eq "This will include: description of foo-id"
       end
+
+      it "returns nothing when there is no description" do
+        fake_taxon_without_description = { "document_type" => "taxon", "description" => nil }
+        presenter = described_class.new(fake_taxon_without_description)
+        expect(presenter.description).to be_nil
+      end
     end
 
     context "given an organisation" do


### PR DESCRIPTION
Currently, when taxon description is empty, the prefix "This will include:" is displayed. This makes sure we don't.

We are implementing this fix until we can find a longer-term solution for what is a somewhat flawed behaviour.

To cite @benthorner:

> Example of how this doesn't make sense: https://www.gov.uk/email-signup/?topic=/education/education-in-prisons

> Example of how showing the description at all is a bit questionable: https://www.gov.uk/email-signup?link=/government/organisations/government-digital-service

> Perhaps we just want to ditch the description entirely?

---

https://trello.com/c/V2xPGN2t/246-fix-this-will-include-when-taxon-description-is-empty