### PR TITLE
Add govuk-compatibility-govuktemplate to remove font duplication.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 $govuk-typography-use-rem: false;
+$govuk-compatibility-govuktemplate: true;
 
 @import "govuk_publishing_components/all_components";
 


### PR DESCRIPTION
While implementing some web performance monitoring I noticed that we are downloading both v1 and v2 fonts for pages using this app. I believe this is because we are missing `$govuk-compatibility-govuktemplate: true;`

![emails-waterfall](https://user-images.githubusercontent.com/1223960/81921780-0d2e5600-95d3-11ea-8cde-06b61326de4e.png)

This PR should hopefully stop the v2 fonts and bring the weight down to 120KB instead of 184KB. Full WebPageTest results can be seen [here](https://www.webpagetest.org/result/200514_K2_aa4405c1178f4d924eb69ae51a83f9e4/1/details/#waterfall_view_step1)
 