### PR TITLE
Change topic to sub-topic

### DIFF
--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -26,7 +26,7 @@
         }]
       } %>
 
-      <p class='app-email-option'>or only one of the following <%= @subscription.child_taxons.count %> topics</p>
+      <p class='app-email-option'>or only one of the following <%= @subscription.child_taxons.count %> sub-topics</p>
       <%= render "govuk_publishing_components/components/radio", {
         name: "topic",
         id_prefix: "topics",


### PR DESCRIPTION
Trello: https://trello.com/c/55FokrdD/300-update-how-we-describe-sub-topics-on-the-taxon-selector-page

## What
Change "or one of the following [x] topics" to "or one of the following [x] sub-topics"

## Why
It makes things clearer and also more consistent with how we refer to them on [search filters](https://www.gov.uk/search/research-and-statistics)

## Before
<img width="545" alt="Screenshot 2020-05-22 at 10 02 39" src="https://user-images.githubusercontent.com/29889908/82650978-6faad600-9c13-11ea-8ac6-2a3652dc3210.png">

## After
<img width="551" alt="Screenshot 2020-05-22 at 10 02 17" src="https://user-images.githubusercontent.com/29889908/82650967-6c174f00-9c13-11ea-8b74-bfe6abb0d8b1.png">
