### PR TITLE
Serve assets from www hostname

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,5 +28,12 @@ module EmailAlertFrontend
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # Path within public/ where assets are compiled to
+    config.assets.prefix = "/assets/email-alert-frontend"
+
+    # allow overriding the asset host with an enironment variable, useful for
+    # when router is proxying to this app but asset proxying isn't set up.
+    config.asset_host = ENV["ASSET_HOST"]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,8 +45,6 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  config.asset_host = ENV["GOVUK_ASSET_ROOT"] if ENV["GOVUK_ASSET_ROOT"].present?
-
   # Allow requests for all domains e.g. <app>.dev.gov.uk
   config.hosts.clear
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,10 +1,4 @@
 Rails.application.configure do
-  # Set GOVUK_ASSET_ROOT for heroku - for review apps we have the hostname set
-  # at the time of the app being built so can't be set up in the app.json
-  if !ENV.include?("GOVUK_ASSET_ROOT") && ENV["HEROKU_APP_NAME"]
-    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
-  end
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -38,8 +32,6 @@ Rails.application.configure do
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
   config.slimmer.asset_host = Plek.current.find("static")
 
   # Specifies the header that your server uses for sending files.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,10 +30,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
-
-  config.slimmer.asset_host = Plek.current.find("static")
-
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,8 +8,6 @@ Rails.application.config.assets.version = "1.0"
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
-Rails.application.config.assets.digest = true
-
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,8 +8,6 @@ Rails.application.config.assets.version = "1.0"
 # Add Yarn node_modules folder to the asset load path.
 Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
-Rails.application.config.assets.prefix = "/email-alert-frontend"
-
 Rails.application.config.assets.digest = true
 
 # Precompile additional assets.


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This allows asset host to be set by ASSET_HOST env var rather than
GOVUK_ASSET_HOST. This is in preparation for the assets of this app
changing hostname from assets.publishing.service.gov.uk to www.gov.uk.

As part of this change the path to assets is changed to
/assets/email-alert-frontend

The expectation is that this env var will only be set in dev
environments when proxying isn't set up for router.