### PR TITLE
Support content item signup for service manual

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -35,7 +35,14 @@ class ContentItemSignupsController < ApplicationController
 
 private
 
-  PERMITTED_CONTENT_ITEMS = %w[taxon organisation ministerial_role person topical_event topic].freeze
+  PERMITTED_CONTENT_ITEMS = %w[taxon
+                               organisation
+                               ministerial_role
+                               person
+                               topic
+                               topical_event
+                               service_manual_topic
+                               service_manual_service_standard].freeze
 
   def require_content_item_param
     unless valid_content_item_param?

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -24,9 +24,8 @@ class ContentItemSignupsController < ApplicationController
   end
 
   def create
-    signup = ContentItemSubscriberList.new(content_item.to_h)
-
-    if signup.has_content_item?
+    if content_item.to_h.present?
+      signup = ContentItemSubscriberList.new(content_item.to_h)
       redirect_to signup.subscription_management_url
     else
       redirect_to confirm_content_item_signup_path(link: content_item_path)

--- a/app/models/content_item_subscriber_list.rb
+++ b/app/models/content_item_subscriber_list.rb
@@ -43,10 +43,26 @@ private
       ministerial_role_links
     when "topical_event"
       topical_event_links
+    when "service_manual_topic"
+      service_manual_topic_links
+    when "service_manual_service_standard"
+      parent_links
     else
       message = "No link hash available for content items of type #{content_item_type}!"
       raise UnsupportedContentItemError, message
     end
+  end
+
+  def service_manual_topic_links
+    {
+      "service_manual_topics" => [content_item["content_id"]],
+    }
+  end
+
+  def parent_links
+    {
+      "parent" => [content_item["content_id"]],
+    }
   end
 
   def taxon_links

--- a/app/models/content_item_subscriber_list.rb
+++ b/app/models/content_item_subscriber_list.rb
@@ -1,26 +1,21 @@
 class ContentItemSubscriberList
   def initialize(content_item)
     @content_item = content_item
+
+    @subscriber_list = EmailAlertFrontend
+      .services(:email_alert_api)
+      .find_or_create_subscriber_list(subscription_params)
   end
 
   def subscription_management_url
     subscriber_list.dig("subscriber_list", "subscription_url")
   end
 
-  def has_content_item?
-    content_item.present?
-  end
-
 private
 
-  attr_accessor :content_item
+  attr_reader :content_item, :subscriber_list
 
   class UnsupportedContentItemError < StandardError; end
-
-  def subscriber_list
-    EmailAlertFrontend.services(:email_alert_api)
-      .find_or_create_subscriber_list(subscription_params)
-  end
 
   def subscription_params
     {

--- a/app/models/content_item_subscriber_list.rb
+++ b/app/models/content_item_subscriber_list.rb
@@ -32,75 +32,28 @@ private
   def link_hash
     case content_item_type
     when "taxon"
-      taxon_links
+      single_link(key: "taxon_tree")
     when "topic"
-      topic_links
+      single_link(key: "topics")
     when "organisation"
-      organisation_links
+      single_link(key: "organisations")
     when "person"
-      person_links
+      single_link(key: "people")
     when "ministerial_role"
-      ministerial_role_links
+      single_link(key: "roles")
     when "topical_event"
-      topical_event_links
+      single_link(key: "topical_events")
     when "service_manual_topic"
-      service_manual_topic_links
+      single_link(key: "service_manual_topics")
     when "service_manual_service_standard"
-      parent_links
+      single_link(key: "parent")
     else
-      message = "No link hash available for content items of type #{content_item_type}!"
-      raise UnsupportedContentItemError, message
+      raise UnsupportedContentItemError
     end
   end
 
-  def service_manual_topic_links
-    {
-      "service_manual_topics" => [content_item["content_id"]],
-    }
-  end
-
-  def parent_links
-    {
-      "parent" => [content_item["content_id"]],
-    }
-  end
-
-  def taxon_links
-    {
-      # 'taxon_tree' is the key used in email-alert-service for
-      # notifications, so create a subscriber list with this key.
-      "taxon_tree" => [content_item["content_id"]],
-    }
-  end
-
-  def organisation_links
-    {
-      "organisations" => [content_item["content_id"]],
-    }
-  end
-
-  def topic_links
-    {
-      "topics" => [content_item["content_id"]],
-    }
-  end
-
-  def topical_event_links
-    {
-      "topical_events" => [content_item["content_id"]],
-    }
-  end
-
-  def person_links
-    {
-      "people" => [content_item["content_id"]],
-    }
-  end
-
-  def ministerial_role_links
-    {
-      "roles" => [content_item["content_id"]],
-    }
+  def single_link(key:)
+    { key => [content_item["content_id"]] }
   end
 
   def content_item_type

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -98,5 +98,37 @@ RSpec.describe ContentItemSubscriberList do
           .with("title" => "Summit 2019", "links" => { "topical_events" => %w[summit-id] })
       end
     end
+
+    context "given a service manual topic" do
+      topical_event = { "document_type" => "service_manual_topic",
+                        "title" => "Foo",
+                        "content_id" => "foo-id" }
+
+      it "asks email-alert-api to find or create a subscriber list" do
+        signup = described_class.new(topical_event)
+
+        expect(signup.has_content_item?).to be
+        expect(signup.subscription_management_url).to eq "/something"
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with("title" => "Foo", "links" => { "service_manual_topics" => %w[foo-id] })
+      end
+    end
+
+    context "given the service standard" do
+      topical_event = { "document_type" => "service_manual_service_standard",
+                        "title" => "Foo",
+                        "content_id" => "foo-id" }
+
+      it "asks email-alert-api to find or create a subscriber list" do
+        signup = described_class.new(topical_event)
+
+        expect(signup.has_content_item?).to be
+        expect(signup.subscription_management_url).to eq "/something"
+        expect(mock_email_alert_api)
+          .to have_received(:find_or_create_subscriber_list)
+          .with("title" => "Foo", "links" => { "parent" => %w[foo-id] })
+      end
+    end
   end
 end

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -4,131 +4,90 @@ RSpec.describe ContentItemSubscriberList do
       instance_double(EmailAlertFrontend.services(:email_alert_api).class)
     end
 
+    let(:content_item) do
+      { "title" => "Foo", "content_id" => "foo-id" }
+    end
+
     before do
       allow(EmailAlertFrontend)
         .to receive(:services)
         .with(:email_alert_api)
         .and_return(mock_email_alert_api)
+
       allow(mock_email_alert_api)
         .to receive(:find_or_create_subscriber_list)
         .and_return("subscriber_list" => { "subscription_url" => "/something" })
     end
 
-    context "given a taxon" do
-      it "asks email-alert-api to find or create a subscriber list" do
-        taxon = { "document_type" => "taxon",
-                  "title" => "Foo",
-                  "content_id" => "foo-id",
-                  "base_path" => "/taxy/taxon" }
+    it "creates a subscriber list for taxons" do
+      content_item.merge!("document_type" => "taxon")
+      signup = described_class.new(content_item)
 
-        signup = described_class.new(taxon)
+      expect(signup.has_content_item?).to be
+      expect(signup.subscription_management_url).to eq "/something"
 
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Foo", "links" => { "taxon_tree" => %w[foo-id] })
-      end
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "taxon_tree" => %w[foo-id] })
     end
 
-    context "when no content item is present" do
-      it "does nothing" do
-        signup = described_class.new(nil)
-
-        expect(signup.has_content_item?).to_not be
-      end
+    it "does nothing when no content item is present" do
+      signup = described_class.new(nil)
+      expect(signup.has_content_item?).to_not be
     end
 
-    context "given an organisation" do
-      organisation = { "document_type" => "organisation", "title" => "Org", "content_id" => "org-id" }
+    it "creates a subscriber list for an organisation" do
+      content_item.merge!("document_type" => "organisation")
+      described_class.new(content_item).subscription_management_url
 
-      it "asks email-alert-api to find or create a subscriber list" do
-        signup = described_class.new(organisation)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Org", "links" => { "organisations" => %w[org-id] })
-      end
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "organisations" => %w[foo-id] })
     end
 
-    context "given a person" do
-      person = { "document_type" => "person", "title" => "Peter", "content_id" => "person-id" }
+    it "creates a subscriber list for a person" do
+      content_item.merge!("document_type" => "person")
+      described_class.new(content_item).subscription_management_url
 
-      it "asks email-alert-api to find or create a subscriber list" do
-        signup = described_class.new(person)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Peter", "links" => { "people" => %w[person-id] })
-      end
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "people" => %w[foo-id] })
     end
 
-    context "given a ministerial role" do
-      ministerial_role = { "document_type" => "ministerial_role",
-                           "title" => "pm",
-                           "content_id" => "pm-id" }
+    it "creates a subscriber list for a ministerial role" do
+      content_item.merge!("document_type" => "ministerial_role")
+      described_class.new(content_item).subscription_management_url
 
-      it "asks email-alert-api to find or create a subscriber list" do
-        signup = described_class.new(ministerial_role)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "pm", "links" => { "roles" => %w[pm-id] })
-      end
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "roles" => %w[foo-id] })
     end
 
-    context "given a topical event" do
-      topical_event = { "document_type" => "topical_event",
-                        "title" => "Summit 2019",
-                        "content_id" => "summit-id" }
+    it "creates a subscriber list for a topical event" do
+      content_item.merge!("document_type" => "topical_event")
+      described_class.new(content_item).subscription_management_url
 
-      it "asks email-alert-api to find or create a subscriber list" do
-        signup = described_class.new(topical_event)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Summit 2019", "links" => { "topical_events" => %w[summit-id] })
-      end
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "topical_events" => %w[foo-id] })
     end
 
-    context "given a service manual topic" do
-      topical_event = { "document_type" => "service_manual_topic",
-                        "title" => "Foo",
-                        "content_id" => "foo-id" }
+    it "creates a subscriber list for a service manual topic" do
+      content_item.merge!("document_type" => "service_manual_topic")
+      described_class.new(content_item).subscription_management_url
 
-      it "asks email-alert-api to find or create a subscriber list" do
-        signup = described_class.new(topical_event)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Foo", "links" => { "service_manual_topics" => %w[foo-id] })
-      end
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "service_manual_topics" => %w[foo-id] })
     end
 
-    context "given the service standard" do
-      topical_event = { "document_type" => "service_manual_service_standard",
-                        "title" => "Foo",
-                        "content_id" => "foo-id" }
+    it "creates a subscriber list for the service standard" do
+      content_item.merge!("document_type" => "service_manual_service_standard")
+      described_class.new(content_item).subscription_management_url
 
-      it "asks email-alert-api to find or create a subscriber list" do
-        signup = described_class.new(topical_event)
-
-        expect(signup.has_content_item?).to be
-        expect(signup.subscription_management_url).to eq "/something"
-        expect(mock_email_alert_api)
-          .to have_received(:find_or_create_subscriber_list)
-          .with("title" => "Foo", "links" => { "parent" => %w[foo-id] })
-      end
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "parent" => %w[foo-id] })
     end
   end
 end

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -65,6 +65,15 @@ RSpec.describe ContentItemSubscriberList do
         .with("title" => "Foo", "links" => { "topical_events" => %w[foo-id] })
     end
 
+    it "creates a subscriber list for a topic" do
+      content_item.merge!("document_type" => "topic")
+      described_class.new(content_item)
+
+      expect(mock_email_alert_api)
+        .to have_received(:find_or_create_subscriber_list)
+        .with("title" => "Foo", "links" => { "topics" => %w[foo-id] })
+    end
+
     it "creates a subscriber list for a service manual topic" do
       content_item.merge!("document_type" => "service_manual_topic")
       described_class.new(content_item)

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -22,18 +22,11 @@ RSpec.describe ContentItemSubscriberList do
     it "creates a subscriber list for taxons" do
       content_item.merge!("document_type" => "taxon")
       signup = described_class.new(content_item)
-
-      expect(signup.has_content_item?).to be
       expect(signup.subscription_management_url).to eq "/something"
 
       expect(mock_email_alert_api)
         .to have_received(:find_or_create_subscriber_list)
         .with("title" => "Foo", "links" => { "taxon_tree" => %w[foo-id] })
-    end
-
-    it "does nothing when no content item is present" do
-      signup = described_class.new(nil)
-      expect(signup.has_content_item?).to_not be
     end
 
     it "creates a subscriber list for an organisation" do
@@ -56,7 +49,7 @@ RSpec.describe ContentItemSubscriberList do
 
     it "creates a subscriber list for a ministerial role" do
       content_item.merge!("document_type" => "ministerial_role")
-      described_class.new(content_item).subscription_management_url
+      described_class.new(content_item)
 
       expect(mock_email_alert_api)
         .to have_received(:find_or_create_subscriber_list)
@@ -65,7 +58,7 @@ RSpec.describe ContentItemSubscriberList do
 
     it "creates a subscriber list for a topical event" do
       content_item.merge!("document_type" => "topical_event")
-      described_class.new(content_item).subscription_management_url
+      described_class.new(content_item)
 
       expect(mock_email_alert_api)
         .to have_received(:find_or_create_subscriber_list)
@@ -74,7 +67,7 @@ RSpec.describe ContentItemSubscriberList do
 
     it "creates a subscriber list for a service manual topic" do
       content_item.merge!("document_type" => "service_manual_topic")
-      described_class.new(content_item).subscription_management_url
+      described_class.new(content_item)
 
       expect(mock_email_alert_api)
         .to have_received(:find_or_create_subscriber_list)
@@ -83,7 +76,7 @@ RSpec.describe ContentItemSubscriberList do
 
     it "creates a subscriber list for the service standard" do
       content_item.merge!("document_type" => "service_manual_service_standard")
-      described_class.new(content_item).subscription_management_url
+      described_class.new(content_item)
 
       expect(mock_email_alert_api)
         .to have_received(:find_or_create_subscriber_list)


### PR DESCRIPTION
https://trello.com/c/KNWv9Dgx/258-not-ready-to-start-deprecate-and-remove-legacy-email-signup-pages

Previously these relied on the 'email_alert_signup' functionality in this
app, which we'd like to remove, since most formats now use the generic
'content_item_signup' functionality. This adds support for creating
subscriptions based on the content item.

Please see the commits for more details.