### PR TITLE
Show error when user tries to confirm email-signup without a topic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_token
-  rescue_from GdsApi::HTTPNotFound, with: :error_not_found
+  #rescue_from GdsApi::HTTPNotFound, with: :error_not_found
   rescue_from GdsApi::HTTPForbidden, with: :forbidden
   rescue_from GdsApi::HTTPGone, with: :gone
 
@@ -37,6 +37,10 @@ private
 
   def forbidden
     render status: :forbidden, plain: "403 forbidden"
+  end
+
+  def bad_request
+    render status: :bad_request, plain: "400 bad request"
   end
 
   def gone

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -24,8 +24,7 @@ class ContentItemSignupsController < ApplicationController
       @content_item = EmailAlertFrontend.services(:content_store).content_item(params["current_topic"])
       new
     elsif !valid_document_type?
-      redirect_to "/"
-      false
+      render status: :bad_request
     else
       @subscription = ContentItemSubscriptionPresenter.new(content_item)
     end
@@ -47,8 +46,7 @@ private
 
   def require_content_item_param
     unless valid_content_item_param?
-      redirect_to "/"
-      false
+      error 400
     end
   end
 
@@ -69,6 +67,8 @@ private
     @content_item ||= EmailAlertFrontend
       .services(:content_store)
       .content_item(content_item_path)
+    rescue GdsApi::HTTPNotFound
+      bad_request
   end
 
   def handle_redirects

--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -11,32 +11,49 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">What do you want to get alerts about?</h1>
+    <% if flash[:error] %>
+      <%= render "govuk_publishing_components/components/error_summary", {
+        title: t('subscriptions.new_topic.general_problem'),
+        items: [
+          {
+            text: t('subscriptions.new_topic.required_question'),
+            href: "#email-topic-input",
+          }
+        ]
+      } %>
+    <% end %>
 
     <%= form_tag({action: "confirm"}, method: "get") do %>
 
-      <p class="app-email-option">Everything published to GOV.UK about</p>
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "topic",
-        id_prefix: "all",
-        items: [{
-          value: @content_item['base_path'],
-          text: @content_item['title'],
-          conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe
-        }]
-      } %>
+      <%= render "govuk_publishing_components/components/fieldset", {
+        id: "email-topic-input",
+        legend_text: tag.h1(t('subscriptions.new_topic.title'), class: "govuk-heading-l"),
+        error_message: flash[:error],
+      } do %>
+        <p class="app-email-option">Everything published to GOV.UK about</p>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "topic",
+          id_prefix: "all",
+          items: [{
+            value: @content_item['base_path'],
+            text: @content_item['title'],
+            conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe
+          }]
+        } %>
 
-      <p class='app-email-option'>or only one of the following <%= @subscription.child_taxons.count %> sub-topics</p>
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "topic",
-        id_prefix: "topics",
-        items: @subscription.child_taxons.each.map { |taxon| {
-          :value => taxon['base_path'],
-          :text => taxon['title'],
-          :conditional => taxon['description'].present? ? ('<p class="govuk-body">This will include: ' + taxon['description'] + '</p>').html_safe : nil
-        } }
-      } %>
+        <p class='app-email-option'>or only one of the following <%= @subscription.child_taxons.count %> sub-topics</p>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "topic",
+          id_prefix: "topics",
+          items: @subscription.child_taxons.each.map { |taxon| {
+            :value => taxon['base_path'],
+            :text => taxon['title'],
+            :conditional => taxon['description'].present? ? ('<p class="govuk-body">This will include: ' + taxon['description'] + '</p>').html_safe : nil
+          } }
+        } %>
+      <% end %>
 
+      <%= hidden_field_tag 'current_topic', @content_item['base_path'] %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Select",
         margin_bottom: true

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -1,5 +1,10 @@
 en:
   subscriptions:
+    new_topic:
+      title: What do you want to get alerts about?
+      general_problem: "There is a problem"
+      required_question: "You must select an option"
+      missing_topic: "Select an option"
     new_frequency:
       general_problem: "There is a problem"
       required_question: "You must answer this question"

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ContentItemSignupsController do
       expect(response).to have_http_status(:found)
       expect(response.location).to eq "http://test.host/email-signup?topic=%2Fcleaning%2Fbroomsticks"
     end
+
     it "redirects to the homepage if there is no destination path" do
       stub_content_store_has_item(
         "/magical/broomsticks",
@@ -31,6 +32,7 @@ RSpec.describe ContentItemSignupsController do
 
   shared_examples "handles bad input data correctly" do
     it "redirects to root if topic param is missing" do
+      stub_content_store_does_not_have_item("/education/some-rando-item")
       make_request(bad_param: "/education/some-rando-item")
 
       expect(response).to have_http_status(:found)


### PR DESCRIPTION
Previously, we redirected to root (GOVUK homepage) for all instances when requests to new/confirm/create had invalid or missing params.
There are cases where we may still want to do this, so I've tried to keep those as-is.

However, if a user tries to click through from the initial taxon sign-up page without selecting a topic, we now show a useful error message and redirect them back to the selection page.

Possible scenarios:
- New (without topic param): redirect to /
- New (with invalid topic param): 404
- __Confirm (without topic param, submitted via form with current_topic): show error__ 
- Confirm (without topic param, direct link so no current_topic): redirect to /
- Confirm (with invalid topic param): 404