### PR TITLE
Select parent taxon by default

### DIFF
--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -22,6 +22,7 @@
         items: [{
           value: @content_item['base_path'],
           text: @content_item['title'],
+          checked: true,
           conditional: '<p class="govuk-body">This will include alerts about all the topics below</p>'.html_safe
         }]
       } %>

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -62,6 +62,7 @@ RSpec.feature "Content item signup" do
 
     visit new_content_item_signup_path(topic: @taxon[:base_path])
     expect(page).to have_content(@taxon[:title])
+    expect(page).to have_checked_field("all-0")
     expect(page).to have_content(@taxon.dig(:links, :child_taxons).first[:title])
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/XxMJ77lG/302-add-default-to-taxon-selection-page

## What
Preselect the parent taxon on the taxonomy email sign-up page.

## Why
This used to be the behaviour but it was removed which meant someone trying to click through the journey without any topic selected was being redirected to the GOV.UK homepage - a confusing/jarring thing to happen for a user.

**Note: other scenarios will still redirect to the homepage - this PR does not address that. That is addressed in a separate PR https://github.com/alphagov/email-alert-frontend/pull/812**

## Before
<img width="633" alt="Screenshot 2020-06-03 at 11 08 57" src="https://user-images.githubusercontent.com/29889908/83624522-a4f7e200-a58a-11ea-8edb-1fde5380be9b.png">

## After
<img width="631" alt="Screenshot 2020-06-03 at 11 08 44" src="https://user-images.githubusercontent.com/29889908/83624539-aa552c80-a58a-11ea-9df2-129a033dba70.png">
