### PR TITLE
Remove homepage redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,10 @@ private
     head :unprocessable_entity
   end
 
+  def bad_request
+    render status: :bad_request, plain: "400 bad request"
+  end
+
   def error_not_found
     render status: :not_found, plain: "404 not found"
   end

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -45,8 +45,7 @@ private
 
   def require_content_item_param
     unless valid_content_item_param?
-      redirect_to "/"
-      false
+      bad_request
     end
   end
 
@@ -83,8 +82,7 @@ private
 
   def validate_document_type
     unless PERMITTED_CONTENT_ITEMS.include?(content_item["document_type"])
-      redirect_to "/"
-      false
+      bad_request
     end
   end
 

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -33,22 +33,19 @@ RSpec.describe ContentItemSignupsController do
     it "redirects to root if topic param is missing" do
       make_request(bad_param: "/education/some-rando-item")
 
-      expect(response).to have_http_status(:found)
-      expect(response.location).to eq "http://test.host/"
+      expect(response).to have_http_status(:bad_request)
     end
 
     it "redirects to root if topic param isn't a valid path" do
       get :new, params: { topic: "/with unencoded spaces" }
 
-      expect(response).to have_http_status(:found)
-      expect(response.location).to eq "http://test.host/"
+      expect(response).to have_http_status(:bad_request)
     end
 
     it "redirects to root if topic param isn't interpreted as a string" do
       get :new, params: { topic: ["/a"] }
 
-      expect(response).to have_http_status(:found)
-      expect(response.location).to eq "http://test.host/"
+      expect(response).to have_http_status(:bad_request)
     end
 
     it "returns a 403 when the user is not authorised" do
@@ -79,8 +76,7 @@ RSpec.describe ContentItemSignupsController do
       stub_content_store_has_item("/cma-cases", document_type: "finder")
       make_request(topic: "/cma-cases")
 
-      expect(response).to have_http_status(:found)
-      expect(response.location).to eq "http://test.host/"
+      expect(response).to have_http_status(:bad_request)
     end
   end
 


### PR DESCRIPTION
Related to https://trello.com/c/XxMJ77lG/302-add-default-to-taxon-selection-page and https://github.com/alphagov/email-alert-frontend/pull/811

## What
Removes the code which redirects a user to the GOV.UK homepage if something goes wrong with email signup and instead raises a 400 Bad Request error.

Summary:

| Scenario | Previous Behaviour | New Behaviour | Example |
| --- | --- | --- | --- |
| New (invalid topic) | redirect to / | returns 400 | /email-signup/?topic=123 |
| New (missing topic) | redirect to / | returns 400 | /email-signup |
| New (not a taxon) | redirect to / | returns 400 | /email-signup/?topic=/cma-cases |
| Confirm (invalid topic) | redirect to / | returns 400 | /email-signup/confirm?utf8=%E2%9C%93&topic=123 |
| Confirm (missing topic) | redirect to / | returns 400 | /email-signup/confirm?utf8=%E2%9C%93 |

## Why
If something goes wrong, throwing a user back to the GOV.UK homepage doesn't seem like a useful thing to do. The existing code returns a 404.
