### PR TITLE
Default coronavirus email frequency to daily

### DIFF
--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -15,7 +15,7 @@ module FrequenciesHelper
 
   def frequency_options(topic_id)
     options = {}
-    if topic_id == "coronavirus-covid-19-uk-government-response"
+    if topic_id == "coronavirus-covid-19"
       options[:checked_frequency] = "daily"
     end
     options

--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -12,4 +12,12 @@ module FrequenciesHelper
       }
     end
   end
+
+  def frequency_options(topic_id)
+    options = {}
+    if topic_id == "coronavirus-covid-19-uk-government-response"
+      options[:checked_frequency] = "daily"
+    end
+    options
+  end
 end

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -31,7 +31,7 @@
       } do %>
         <%= render "govuk_publishing_components/components/radio", {
           name: "frequency",
-          items: frequencies,
+          items: frequencies(frequency_options(@topic_id)),
         } %>
       <% end %>
 

--- a/spec/helpers/frequencies_helper_spec.rb
+++ b/spec/helpers/frequencies_helper_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe FrequenciesHelper do
+  describe "#frequency_options" do
+    it "returns empty options without a topic_id" do
+      options = frequency_options(nil)
+      expect(options).to eq({})
+    end
+
+    it "returns empty options non listed topic_id" do
+      options = frequency_options("not-listed-topic-id")
+      expect(options).to eq({})
+    end
+
+    it "returns default options for a listed topic_id" do
+      options = frequency_options("coronavirus-covid-19-uk-government-response")
+      expect(options).to eq({ checked_frequency: "daily" })
+    end
+  end
+
+  describe "#frequencies" do
+    it "returns default frequencies without options" do
+      expect(frequencies).to eq([
+        {
+          value: :immediately,
+          text: "Every time something changes on GOV.UK",
+          checked: false,
+        },
+        {
+          value: :daily,
+          text: "Once a day, with all the updates made that day (recommended)",
+          checked: false,
+        },
+        {
+          value: :weekly,
+          text: "Once a week, with all the updates made that week",
+          checked: false,
+        },
+      ])
+    end
+
+    it "returns default frequencies with options" do
+      expect(frequencies({ checked_frequency: "daily" })).to eq([
+        {
+          value: :immediately,
+          text: "Every time something changes on GOV.UK",
+          checked: false,
+        },
+        {
+          value: :daily,
+          text: "Once a day, with all the updates made that day (recommended)",
+          checked: true,
+        },
+        {
+          value: :weekly,
+          text: "Once a week, with all the updates made that week",
+          checked: false,
+        },
+      ])
+    end
+  end
+end

--- a/spec/helpers/frequencies_helper_spec.rb
+++ b/spec/helpers/frequencies_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FrequenciesHelper do
     end
 
     it "returns default options for a listed topic_id" do
-      options = frequency_options("coronavirus-covid-19-uk-government-response")
+      options = frequency_options("coronavirus-covid-19")
       expect(options).to eq({ checked_frequency: "daily" })
     end
   end


### PR DESCRIPTION
## What

When users get to the frequency select page of the coronavirus taxon sign up page (https://www.gov.uk/email/subscriptions/new?topic_id=coronavirus-covid-19) the default should be set as daily digest.

## Why

It's our biggest subscription list (~300,000). Lots of content is being tagged with it and each of these triggers a notification if on immediate alerts. On busy days it's both a lot of emails to send and a lot of emails to receive.

https://trello.com/c/5TZstRq7/317-coronavirus-taxon-sign-up-set-default-to-the-daily-digest