### PR TITLE
Add extreme EmailVolume value

### DIFF
--- a/app/models/email_volume/taxon_weekly_email_volume.rb
+++ b/app/models/email_volume/taxon_weekly_email_volume.rb
@@ -1,5 +1,6 @@
 module EmailVolume
   class TaxonWeeklyEmailVolume
+    EXTREME = "200 to 800".freeze
     HIGH = "40 to 60".freeze
     MEDIUM = "0 to 20".freeze
     LOW = "0 to 5".freeze
@@ -10,6 +11,9 @@ module EmailVolume
 
     def estimate
       parent_taxon = extract_parent_from(@taxon)
+
+      # Is for covid-19
+      return EXTREME if @taxon.dig("base_path") == "/coronavirus-taxon"
 
       # Is at the top of the taxonomy
       return HIGH if parent_taxon.blank?

--- a/spec/models/weekly_email_volume_spec.rb
+++ b/spec/models/weekly_email_volume_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe EmailVolume::WeeklyEmailVolume do
       }.deep_stringify_keys
     end
 
+    context "given the Coronavirus (COVID-19) taxon" do
+      coronavirus_taxon = { document_type: "taxon", base_path: "/coronavirus-taxon", links: { parent_taxons: [] } }.deep_stringify_keys
+
+      it "returns an EXTREME range" do
+        expect(described_class.new(coronavirus_taxon).estimate).to eq EmailVolume::TaxonWeeklyEmailVolume::EXTREME
+      end
+    end
+
     context "given a top level taxon" do
       it "returns a HIGH range" do
         expect(described_class.new(top_taxon).estimate).to eq EmailVolume::TaxonWeeklyEmailVolume::HIGH


### PR DESCRIPTION
The only taxon we are getting extreme volumes for are notifications
for content tagged with the Coronavirus taxon. We want to inform
the user what these numbers are, so that they can get decide whether
they still want to get immediate notifications. The min value is
based on a daily average, and the maximum is on a day's maximum
content changes during the first couple of weeks of the taxon's
existence.

https://trello.com/c/rcC3U4Ah

## Screenshots

### Before
![Screenshot 2020-06-16 at 5 27 34 pm](https://user-images.githubusercontent.com/424772/84801176-c202cb00-aff6-11ea-9355-7c21b6587a94.png)

### After
![Screenshot 2020-06-16 at 5 27 17 pm](https://user-images.githubusercontent.com/424772/84801190-c6c77f00-aff6-11ea-9ba2-4615d6382f22.png)
