### PR TITLE
Use individual component JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,6 @@
-// =require govuk_publishing_components/all_components
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/radio


### PR DESCRIPTION
Update email-alert-frontend to import the Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

Note: despite recent changes to the suggested sass feature, the suggested sass for calculators remains unchanged.

## Filesize comparison

<img width="436" alt="Screenshot 2020-06-17 at 10 47 19" src="https://user-images.githubusercontent.com/861310/84883133-16a25680-b088-11ea-8307-cb7f5274da03.png">

JS before: **472 KB**

<img width="437" alt="Screenshot 2020-06-17 at 10 47 44" src="https://user-images.githubusercontent.com/861310/84883149-1d30ce00-b088-11ea-9545-ae3f98a413a3.png">

JS after: **215 KB**


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

