### PR TITLE
Harden rate limits for verification emails

### DIFF
--- a/app/services/verify_subscriber_email_service.rb
+++ b/app/services/verify_subscriber_email_service.rb
@@ -3,8 +3,14 @@ class VerifySubscriberEmailService < ApplicationService
 
   class RatelimitExceededError < StandardError; end
 
-  MINUTELY_THRESHOLD = 3 # TODO: update this based on data and comment
-  HOURLY_THRESHOLD = 20 # TODO: update this based on data and comment
+  # This allows for up to 2 retries, to account for users
+  # not getting the email quickly enough and resubmitting.
+  MINUTELY_THRESHOLD = 4
+
+  # This allows for up to 10 logins to manage subscriptions
+  # per hour, to account # for the user needing to return
+  # to manage their # subscriptions on different devices.
+  HOURLY_THRESHOLD = 11
 
   def initialize(address)
     @address = address

--- a/app/services/verify_subscription_email_service.rb
+++ b/app/services/verify_subscription_email_service.rb
@@ -1,8 +1,15 @@
 class VerifySubscriptionEmailService < ApplicationService
   class RatelimitExceededError < StandardError; end
 
-  MINUTELY_THRESHOLD = 3 # TODO: update this based on data and comment
-  HOURLY_THRESHOLD = 20 # TODO: update this based on data and comment
+  # This allows for up to 2 retries, to account for users
+  # not getting the email quickly enough and resubmitting,
+  # and for users who subscribe to several things quickly.
+  MINUTELY_THRESHOLD = 4
+
+  # This allows for up to 10 subscriptions per hour. Analysis
+  # shows 99% of subscribers have 10 or fewer active subs,
+  # so this covers someone creating all their subs in bulk.
+  HOURLY_THRESHOLD = 11
 
   def initialize(address, frequency, topic_id)
     @topic_id = topic_id


### PR DESCRIPTION
https://trello.com/c/fCrWTqFj/372-incident-action-rate-limit-email-authentication-emails-by-address