### PR TITLE
Rescue GdsApi::HTTPClientError and return bad request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :invalid_token
+  rescue_from GdsApi::HTTPClientError, with: :bad_request
   rescue_from GdsApi::HTTPNotFound, with: :error_not_found
   rescue_from GdsApi::HTTPForbidden, with: :forbidden
   rescue_from GdsApi::HTTPGone, with: :gone

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe ContentItemSignupsController do
       expect(response).to have_http_status(:bad_request)
     end
 
+    it "returns a 400 when the content store returns a bad request response" do
+      base_path = "/#{SecureRandom.hex}"
+      url = content_store_endpoint + "/content#{base_path}"
+      stub_request(:get, url).to_return(status: 400, headers: {})
+
+      get :new, params: { topic: base_path }
+
+      expect(response).to have_http_status(:bad_request)
+    end
+
     it "returns a 403 when the user is not authorised" do
       base_path = "/#{SecureRandom.hex}"
       url = content_store_endpoint + "/content#{base_path}"


### PR DESCRIPTION
Trello: https://trello.com/c/koo6gJov/355-increase-visibility-of-sentry-alerts-for-email-apps-and-services

In our Sentry error log there are numerous errors raised when clients
have tried to put in dubious strings in a query string which have then
been forwarded to internal Rails APIs [1].

These dubious query strings can result in the downstream Rails APIs
returning a 400 bad request response. It seems appropriate to then
return this to user.

One thing to note is that this will catch all other 4xx responses (such
as 422 or 401) that are not configured with their own exception
handlers. This doesn't seem too big a semantic problem since they are
types of bad request so meet the semantics. Were this to become a
problem we would want to expand GdsApiAdapters to have a dedicated
HTTPBadRequest exception.

[1]: https://sentry.io/organizations/govuk/issues/881296490/?project=202221&query=&statsPeriod=14d