### PR TITLE
Amend email alerts misleading/vague page titles

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -4,6 +4,9 @@ class SubscriptionsController < ApplicationController
 
   def new
     @back_url = @frequency.blank? ? govuk_url : url_for(action: :new, topic_id: @topic_id)
+    @title = GdsApi.email_alert_api
+      .get_subscriber_list(slug: @topic_id)
+      .to_h.dig("subscriber_list", "title")
     if @frequency.present?
       return frequency_form_redirect unless valid_frequency
 

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -1,4 +1,5 @@
-<% content_for :title, @subscription.title %>
+<% page_heading = "Sign up to get emails" %>
+<% content_for :title, page_heading + ' - ' + @subscription.title %>
 
 <% if live_content_item?(@content_item) %>
   <% content_for :back_link do %>
@@ -11,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">Sign up to get emails</h1>
+    <h1 class="govuk-heading-l"><%= page_heading %></h1>
 
     <p class="govuk-body">
       Get emails when information changes on GOV.UK about: <%= @subscription.title %>.

--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -1,4 +1,5 @@
-<% content_for :title, @content_item['title'] %>
+<% page_heading = "What do you want to get alerts about?" %>
+<% content_for :title, page_heading + ' - ' + @content_item['title'] %>
 
 <% if live_content_item?(@content_item) %>
   <% content_for :back_link do %>
@@ -11,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">What do you want to get alerts about?</h1>
+    <h1 class="govuk-heading-l"><%= page_heading %></h1>
 
     <%= form_tag({ action: :confirm },
                  method: "get",

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("subscriptions.new_address.title") %>
+<% content_for :title, t("subscriptions.new_address.title") + ' - ' + @title %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -1,11 +1,10 @@
-<% content_for :title, t("subscriptions.new_frequency.title") %>
+<% content_for :title, t("subscriptions.new_frequency.question") + ' - ' + t("subscriptions.new_frequency.title") %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: @back_url
   } %>
 <% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("subscriptions.new_frequency.question") + ' - ' + t("subscriptions.new_frequency.title") %>
+<% content_for :title, t("subscriptions.new_frequency.question") + ' - ' + @title %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -1,4 +1,5 @@
-<% content_for :title, t("subscriptions_management.heading") %>
+<% page_heading = 'How often do you want to receive emails?' %>
+<% content_for :title, page_heading + ' - ' + t("subscriptions_management.heading") %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -13,7 +14,7 @@
     <%= form_tag change_frequency_path, method: :post do %>
       <%= hidden_field_tag :id, @subscription_id %>
         <%= render 'govuk_publishing_components/components/fieldset', {
-          legend_text: '<h2 class="govuk-heading-m">How often do you want to receive emails?</h2>'.html_safe,
+          legend_text: '<h2 class="govuk-heading-m">' + page_heading + '</h2>'.html_safe,
         } do %>
           <%= render 'govuk_publishing_components/components/radio', {
             name: 'new_frequency',


### PR DESCRIPTION
## Problem

Page titles of pages within the journey to subscribe to email alerts are problematic.

When starting from https://www.gov.uk/world/switzerland the first three pages all have the same page title: "UK help and services in Switzerland". The page title does not accurately reflect what the [second](https://www.gov.uk/email-signup?link=/world/switzerland) and [third](https://www.gov.uk/email-signup/confirm?utf8=%E2%9C%93&topic=%2Fworld%2Fswitzerland) pages are about.

The [fourth page](https://www.gov.uk/email/subscriptions/new?topic_id=uk-help-and-services-in-switzerland-24e8ef8275) has the page title "Get emails when pages are added or updated" which describe the whole journey but not the single page, while the [fifth page](https://www.gov.uk/email/subscriptions/new?frequency=daily&topic_id=uk-help-and-services-in-switzerland-24e8ef8275) has the page title "Enter your email address" and describes what the page is about but doesn't mention the wider context.
This is a fail of WCAG SC 2.4.2

## Changes

This changes the email signup journey page titles to follow this pattern:  `Page Name -  Topic Name - GOV.UK`. The aim is to provide more context for screen reader users. 
For example: 

https://www.gov.uk/email-signup?link=/world/switzerland
**BEFORE:** UK help and services in Switzerland - GOV.UK
**AFTER:** What do you want to get alerts about? - UK help and services in Switzerland - GOV.UK

https://www.gov.uk/email-signup/confirm?utf8=%E2%9C%93&topic=%2Fworld%2Fswitzerland
**BEFORE:** UK help and services in Switzerland - GOV.UK
**AFTER:** Sign up to get emails - UK help and services in Switzerland - GOV.UK

https://www.gov.uk/email/subscriptions/new?topic_id=uk-help-and-services-in-switzerland-24e8ef8275
**BEFORE:** Get emails when pages are added or updated - GOV.UK
**AFTER:** How often do you want to receive emails? - UK help and services in Switzerland - GOV.UK

https://www.gov.uk/email/subscriptions/new?frequency=daily&topic_id=uk-help-and-services-in-switzerland-24e8ef8275
**BEFORE:** Enter your email address - GOV.UK
**AFTER:** Enter your email address - UK help and services in Switzerland - GOV.UK

https://trello.com/c/gwpTMw63