### PR TITLE
Move radio button captions into legends for those radio button fieldsets

### DIFF
--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -22,9 +22,10 @@
                    track_category: "email_subscriptions",
                  }) do %>
 
-      <p class="app-email-option">Everything published to GOV.UK about</p>
+
       <%= render "govuk_publishing_components/components/radio", {
         name: "topic",
+        heading: "Everything published to GOV.UK about",
         id_prefix: "all",
         items: [{
           value: @content_item['base_path'],
@@ -34,9 +35,9 @@
         }]
       } %>
 
-      <p class='app-email-option'>or only one of the following <%= @subscription.child_taxons.count %> sub-topics</p>
       <%= render "govuk_publishing_components/components/radio", {
         name: "topic",
+        heading: "or only one of the following #{@subscription.child_taxons.count} sub-topics",
         id_prefix: "topics",
         items: @subscription.child_taxons.each.map { |taxon| {
           :value => taxon['base_path'],

--- a/app/views/content_item_signups/new.html.erb
+++ b/app/views/content_item_signups/new.html.erb
@@ -37,7 +37,7 @@
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "topic",
-        heading: "or only one of the following #{@subscription.child_taxons.count} sub-topics",
+        heading: "One of the following #{@subscription.child_taxons.count} sub-topics",
         id_prefix: "topics",
         items: @subscription.child_taxons.each.map { |taxon| {
           :value => taxon['base_path'],

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -21,24 +21,21 @@
     <% end %>
 
     <%= form_tag(subscription_frequency_path,
-                 class: "checklist-email-signup",
-                 data: {
-                   module: "track-email-alert-signup-choices",
-                   track_category: "email_subscriptions",
-                   track_action: 'new_address',
-                 }) do %>
+      class: "checklist-email-signup",
+      data: {
+        module: "track-email-alert-signup-choices",
+        track_category: "email_subscriptions",
+        track_action: 'new_address',
+      }) do %>
       <%= hidden_field_tag :topic_id, @topic_id %>
 
-      <%= render "govuk_publishing_components/components/fieldset", {
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "frequency",
         id: "email-frequency-input",
-        legend_text: tag.h2(t("subscriptions.new_frequency.question"), class: "govuk-heading-m"),
+        heading: t("subscriptions.new_frequency.question"),
         error_message: flash[:error],
-      } do %>
-        <%= render "govuk_publishing_components/components/radio", {
-          name: "frequency",
-          items: frequencies(frequency_options(@topic_id)),
-        } %>
-      <% end %>
+        items: frequencies(frequency_options(@topic_id)),
+      } %>
 
       <%= render "govuk_publishing_components/components/inset_text", {
         text: "<p>You can unsubscribe from emails or change your subscription at any time.</p>".html_safe

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -13,14 +13,11 @@
 
     <%= form_tag change_frequency_path, method: :post do %>
       <%= hidden_field_tag :id, @subscription_id %>
-        <%= render 'govuk_publishing_components/components/fieldset', {
-          legend_text: '<h2 class="govuk-heading-m">' + page_heading + '</h2>'.html_safe,
-        } do %>
-          <%= render 'govuk_publishing_components/components/radio', {
-            name: 'new_frequency',
-            items: frequencies(:checked_frequency => @current_frequency)
-          } %>
-        <% end %>
+        <%= render 'govuk_publishing_components/components/radio', {
+          name: 'new_frequency',
+          heading: page_heading,
+          items: frequencies(:checked_frequency => @current_frequency)
+        } %>
 
         <%= render 'govuk_publishing_components/components/button', {
           text: 'Save',


### PR DESCRIPTION
## What
Moves captions for radio button collections into the the legend for that radio button fieldset.

## Why
Currently these captions exist outside the fieldset legends as styled p tags. This makes the caption for the radio fieldset not programatically determinable, failing WCAG SC 4.1.2. By moving it into the legend associated with the radio fieldset it clearly associates that caption with the radio buttons and allows us to make more efficient use of the components gem radio buttons API.

## Visual changes

### Before
![Screenshot 2020-09-07 at 10 46 50](https://user-images.githubusercontent.com/64783893/92496089-99523200-f1ef-11ea-8042-aeabf9981a0a.png)

### After
![Screenshot 2020-09-07 at 10 46 37](https://user-images.githubusercontent.com/64783893/92496103-9f481300-f1ef-11ea-99f8-611334d721ae.png)

**Card:** https://trello.com/c/Np871Jwm/335-email-alerts-missing-legend