### PR TITLE
Add email autocomplete to new subscription view

### DIFF
--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -40,6 +40,7 @@
         name: :address,
         type: "email",
         value: @address,
+        autocomplete: "email",
       } %>
 
       <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
## What
Adds `autocomplete="email"` to the input component for collecting a user's email address for the new subscription view.

## Why
Input fields that don't include the appropriate autocomplete attribute values vail WCAG SC 1.3.5.

No visual changes.

**Card:** https://trello.com/c/jmQAcEG3/371-email-alerts-missing-autocomplete-attribute