### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
-
 gem "rails", "6.0.3.3"
 
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,8 +353,5 @@ DEPENDENCIES
   uglifier
   webmock
 
-RUBY VERSION
-   ruby 2.6.6
-
 BUNDLED WITH
    1.17.3

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -21,7 +21,7 @@ private
   def read_token
     len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
     key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
-    crypt = ActiveSupport::MessageEncryptor.new(key, OPTIONS)
+    crypt = ActiveSupport::MessageEncryptor.new(key, **OPTIONS)
     decrypted_data = crypt.decrypt_and_verify(token)
     decrypted_data&.symbolize_keys
   rescue ActiveSupport::MessageEncryptor::InvalidMessage

--- a/spec/support/token_helper.rb
+++ b/spec/support/token_helper.rb
@@ -3,7 +3,7 @@ module TokenHelper
     len = ActiveSupport::MessageEncryptor.key_len(AuthToken::CIPHER)
     secret = Rails.application.secrets.email_alert_auth_token
     key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
-    crypt = ActiveSupport::MessageEncryptor.new(key, AuthToken::OPTIONS)
+    crypt = ActiveSupport::MessageEncryptor.new(key, **AuthToken::OPTIONS)
     crypt.encrypt_and_sign(data, expires_in: expiry)
   end
 end


### PR DESCRIPTION
These are the changes necessary for Ruby 2.7.1

I've left the Ruby version as 2.6.6 since there's an automatic script to change all the apps' Ruby versions at once.

Couple of deprecation warnings coming from GDS API Adapters, which are addressed in this PR https://github.com/alphagov/gds-api-adapters/pull/1003