### PR TITLE
Remove redundant government navigation

### DIFF
--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -26,14 +26,6 @@ class EmailAlertSignup
       .find_or_create_subscriber_list(subscription_params)
   end
 
-  def government?
-    base_path.starts_with?("/government")
-  end
-
-  def government_content_section
-    base_path.split("/")[2]
-  end
-
   def details
     signup_page["details"]
   end

--- a/app/views/email_alert_signups/new.html.erb
+++ b/app/views/email_alert_signups/new.html.erb
@@ -1,10 +1,6 @@
 <% content_for :title, email_alert_signup.title %>
 <% content_for :meta_description, email_alert_signup.summary %>
 
-<% if email_alert_signup.government? %>
-  <%= render 'govuk_publishing_components/components/government_navigation', active: email_alert_signup.government_content_section %>
-<% end %>
-
 <header class="app-title">
   <%= title email_alert_signup.title, context: "Email alert subscription" %>
 </header>


### PR DESCRIPTION
https://trello.com/c/233ZtYfR/504-design-how-to-discourage-new-subscriptions-for-individual-emails

Previously we used to show a bunch of links on the initial page for
a '/government/*/email-signup' type subscription. Since only travel
advice still uses the '*/email-signup' workflow [1], we can safely
delete this untested and unused feature.

Removing this now will simplify our upcoming work around revamping
the signup pages; it's an unnecessary complication.

[1]: https://github.com/alphagov/email-alert-frontend#signup