### PR TITLE
Add an id of "content" to the main element

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
   <body class="govuk-template__body">
     <div class="govuk-width-container" id="wrapper">
       <%= yield :back_link %>
-      <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" role="main">
+      <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" role="main" id="content">
         <div id="email-alert-frontend">
           <%= yield %>
         </div>


### PR DESCRIPTION
## What

Adds `id="content"` to the `main` element.

## Why

Currently, the skip link on email signup pages doesn't work as it's looking for an id with the name `content` which doesn't exist. Ideally, this would be fixed at the static level, however this PR solves the problem for users now, which is arguably more important for the moment.

No visual changes.

**Card:** https://trello.com/c/4Q0ZZleC/428-broken-skip-link