### PR TITLE
Updating Govspeak to use `do` block

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -38,9 +38,9 @@
           <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
         </p>
         <% if subscription['subscriber_list']['description'].present? %>
-          <%= render "govuk_publishing_components/components/govspeak", {
-            content: raw(Kramdown::Document.new(subscription['subscriber_list']['description']).to_html)
-          } %>
+          <%= render "govuk_publishing_components/components/govspeak", {} do %>
+            <%= raw(Kramdown::Document.new(subscription['subscriber_list']['description']).to_html) %>
+          <% end %>
         <% end %>
         <p class="govuk-body">
           <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>


### PR DESCRIPTION
The GOV.UK Components gem will soon release a breaking change (https://github.com/alphagov/govuk_publishing_components/pull/1632) that will mean that:

```erb
<%= render "govuk_publishing_components/components/govspeak", {
  content: sanitize("<p>This is some body text with <a href=#>a link</a></p>")
} %>
```

will raise an error.

Changing it to:

```erb
<%= render "govuk_publishing_components/components/govspeak" do %>
  <%= sanitize(some_html_in_a_variable_from_elsewhere) %>
<% end %>
```

gives the same results and won't break things.

