### PR TITLE
Turn on new colours

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-typography-use-rem: false;
 $govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";


### PR DESCRIPTION
This frontend app still had the legacy colours enabled; this should turn them off and enable the new colours. This will make this app consistent with the rest of GOV.UK.