### PR TITLE
Add missing h1

### DIFF
--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -33,6 +33,8 @@
         name: "frequency",
         id: "email-frequency-input",
         heading: t("subscriptions.new_frequency.question"),
+        is_page_heading: true,
+        heading_size: "l",
         error_message: flash[:error],
         items: frequencies(frequency_options(@topic_id)),
       } %>


### PR DESCRIPTION
## What? 

Updating page so it includes a `h1`, also updating `README` so startup is clearer

## Why?
[Ticket](https://trello.com/c/12elBDh4)
[There is no h1 on this page](https://www.gov.uk/email/subscriptions/new?topic_id=uk-help-and-services-in-switzerland-24e8ef8275). The main content starts with an h2.
Not a strict WCAG fail, screen reader users might find it more difficult to get to the main content and understand the structure of the page. 

## Visual Changes

Before:

![Screenshot 2020-11-17 at 14 25 57](https://user-images.githubusercontent.com/71266765/99429490-01b04480-2900-11eb-88be-758eba179fe5.png)


After:

![Screenshot 2020-11-19 at 14 21 13](https://user-images.githubusercontent.com/71266765/99679788-40ffa200-2a74-11eb-8a36-539c6ef563f9.png)

## Anything else?
Can view via this local URL

`http://email-alert-frontend.dev.gov.uk/email/subscriptions/new?topic_id=uk-help-and-services-in-switzerland`

The README has also been updated to include some clearer startup guidance (I ran into some problems: the docker `--live` flag is essential for this repo, this wasn't clear to me as I ran into errors spinning this up in isolation.

