### PR TITLE
Update common pages for new subscriptions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,6 +6,7 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/component_support";
 @import "govuk_publishing_components/components/back-link";
 @import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/details";
 @import "govuk_publishing_components/components/error-message";
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/feedback";

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -34,18 +34,20 @@ class SubscriptionsController < ApplicationController
   def verify
     return frequency_form_redirect unless valid_frequency
 
-    @back_url = url_for(
-      host: Plek.new.website_root,
-      action: :new,
-      topic_id: @topic_id,
-      frequency: @frequency,
-      address: @address,
-    )
-
     if @address.present?
+      @title = GdsApi.email_alert_api
+        .get_subscriber_list(slug: @topic_id)
+        .to_h.dig("subscriber_list", "title")
       VerifySubscriptionEmailService.call(@address, @frequency, @topic_id)
       render :check_email
     else
+      @back_url = url_for(
+        host: Plek.new.website_root,
+        action: :new,
+        topic_id: @topic_id,
+        frequency: @frequency,
+        address: @address,
+      )
       flash.now[:error] = t("subscriptions.new_address.missing_email")
       render :new_address
     end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,9 +3,6 @@ class SubscriptionsController < ApplicationController
   before_action :assign_attributes
 
   def new
-    @title = GdsApi.email_alert_api
-      .get_subscriber_list(slug: @topic_id)
-      .to_h.dig("subscriber_list", "title")
     if @frequency.present?
       return frequency_form_redirect unless valid_frequency
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -3,15 +3,16 @@ class SubscriptionsController < ApplicationController
   before_action :assign_attributes
 
   def new
-    @back_url = @frequency.blank? ? govuk_url : url_for(action: :new, topic_id: @topic_id)
     @title = GdsApi.email_alert_api
       .get_subscriber_list(slug: @topic_id)
       .to_h.dig("subscriber_list", "title")
     if @frequency.present?
       return frequency_form_redirect unless valid_frequency
 
+      @back_url = new_subscription_path(topic_id: @topic_id)
       render :new_address
     else
+      @back_url = govuk_url
       render :new_frequency
     end
   end
@@ -26,7 +27,7 @@ class SubscriptionsController < ApplicationController
       )
     else
       flash.now[:error] = t("subscriptions.new_frequency.missing_frequency")
-      @back_url = url_for(action: :new, topic_id: @topic_id)
+      @back_url = new_subscription_path(topic_id: @topic_id)
       render :new_frequency
     end
   end
@@ -41,13 +42,7 @@ class SubscriptionsController < ApplicationController
       VerifySubscriptionEmailService.call(@address, @frequency, @topic_id)
       render :check_email
     else
-      @back_url = url_for(
-        host: Plek.new.website_root,
-        action: :new,
-        topic_id: @topic_id,
-        frequency: @frequency,
-        address: @address,
-      )
+      @back_url = new_subscription_path(topic_id: @topic_id, frequency: @frequency, address: @address)
       flash.now[:error] = t("subscriptions.new_address.missing_email")
       render :new_address
     end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -33,9 +33,6 @@ class SubscriptionsController < ApplicationController
     return frequency_form_redirect unless valid_frequency
 
     if @address.present?
-      @title = GdsApi.email_alert_api
-        .get_subscriber_list(slug: @topic_id)
-        .to_h.dig("subscriber_list", "title")
       VerifySubscriptionEmailService.call(@address, @frequency, @topic_id)
       render :check_email
     else
@@ -59,7 +56,6 @@ private
       .to_h.fetch("subscriber_list")
     @frequency = subscription_params[:frequency]
     @address = subscription_params[:address]
-    @title = @subscriber_list["title"]
   end
 
   def subscription_params

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -84,8 +84,6 @@ private
       sanitised_referer_uri.query = referer_uri.query
       sanitised_referer_uri.fragment = referer_uri.fragment
       sanitised_referer_uri.to_s
-    elsif @subscriber_list["url"]&.match?(%r{^/get-ready-brexit-check/results})
-      (Plek.new.website_root + @subscriber_list["url"]).to_s
     else
       Plek.new.website_root
     end

--- a/app/views/subscriptions/check_email.html.erb
+++ b/app/views/subscriptions/check_email.html.erb
@@ -1,20 +1,29 @@
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-      href: @back_url
-  } %>
-<% end %>
-
 <% content_for :title, t("subscriptions.check_email.title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= tag.h1 t("subscriptions.check_email.title"), class: "govuk-heading-l" %>
+    <h1 class="govuk-heading-l"><%= t("subscriptions.check_email.title") %></h1>
 
-    <%= tag.p t("subscriptions.check_email.description_html", address: @address), class: "govuk-body" %>
-    <%= tag.p t("subscriptions.check_email.instruction"), class: "govuk-body" %>
+    <p class="govuk-body">
+      <%= t("subscriptions.check_email.description_html", address: @address) %>
+    </p>
 
-    <%= render "govuk_publishing_components/components/inset_text", {
-      text: t("subscriptions.check_email.expiry")
-    } %>
+    <p class="govuk-body">
+      <%= t("subscriptions.check_email.instruction") %>
+    </p>
+
+    <p class="govuk-body">
+      <strong><%= @title %></strong>
+    </p>
+
+    <p class="govuk-body">
+      <%= t("subscriptions.check_email.expiry") %>
+    </p>
+
+    <%= render "govuk_publishing_components/components/details", {
+      title: t("subscriptions.check_email.not_received_title"),
+    } do %>
+      <%= t("subscriptions.check_email.not_received_detail_html") %>
+    <% end %>
   </div>
 </div>

--- a/app/views/subscriptions/check_email.html.erb
+++ b/app/views/subscriptions/check_email.html.erb
@@ -13,7 +13,7 @@
     </p>
 
     <p class="govuk-body">
-      <strong><%= @title %></strong>
+      <strong><%= @subscriber_list["title"] %></strong>
     </p>
 
     <p class="govuk-body">

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("subscriptions.new_address.title") + ' - ' + @title %>
+<% content_for :title, t("subscriptions.new_address.title") %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -21,22 +21,15 @@
       } %>
     <% end %>
 
-    <%= tag.h1 t("subscriptions.new_address.title"), class: "govuk-heading-l" %>
+    <h1 class="govuk-heading-l"><%= t("subscriptions.new_address.title") %></h1>
 
-    <%= tag.p t("subscriptions.new_address.description_html", title: @title), class: "govuk-body" %>
-
-    <p class="govuk-body">
-      <%= t("subscriptions.new_address.summary.#{@frequency}") %>
-    </p>
-
-    <%= form_tag verify_subscription_path, method: :post, class: "checklist-email-signup", novalidate: "novalidate" do %>
+    <%= form_tag verify_subscription_path, method: :post, novalidate: "novalidate" do %>
       <%= hidden_field_tag :topic_id, @topic_id %>
       <%= hidden_field_tag :frequency, @frequency %>
 
       <%= render "govuk_publishing_components/components/input", {
         error_message: flash[:error],
         id: "email-address-input",
-        label: { text: t("subscriptions.new_address.question") },
         name: :address,
         type: "email",
         value: @address,
@@ -53,14 +46,6 @@
           track_label: "#{@topic_id} #{@frequency}",
         },
       } %>
-    <%- end -%>
-
-    <p class="govuk-body">
-      We won’t share your email address with anyone. Read our
-      <%= link_to "privacy policy (opens in a new tab)",
-                  "/help/privacy-policy",
-                  target: "_blank",
-                  class: "govuk-link" %>.
-    </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -1,10 +1,11 @@
-<% content_for :title, t("subscriptions.new_frequency.question") + ' - ' + @title %>
+<% content_for :title, t("subscriptions.new_frequency.title") %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: @back_url
   } %>
 <% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -32,21 +33,21 @@
       <%= render "govuk_publishing_components/components/radio", {
         name: "frequency",
         id: "email-frequency-input",
-        heading: t("subscriptions.new_frequency.question"),
+        heading: t("subscriptions.new_frequency.title"),
         is_page_heading: true,
         heading_size: "l",
         error_message: flash[:error],
         items: frequencies
       } %>
 
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: "<p>You can unsubscribe from emails or change your subscription at any time.</p>".html_safe
-      } %>
-
       <%= render "govuk_publishing_components/components/button", {
         text: "Continue",
         margin_bottom: true
       } %>
+
+      <p class="govuk-body">
+        <%= t("subscriptions.new_frequency.unsubscribe_html") %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/config/locales/frequencies.yml
+++ b/config/locales/frequencies.yml
@@ -1,5 +1,5 @@
 en:
   frequencies:
-    immediately: Every time something changes on GOV.UK, you may get a lot of emails
-    daily: Once a day, with all the updates made that day
-    weekly: Once a week, with all the updates made that week
+    immediately: Each time we add or update a page (you may get more than one email a day)
+    daily: Once a day
+    weekly: Once a week

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -21,7 +21,12 @@ en:
         daily: "You’ll get an email each day if a page is added or changed."
         weekly: "You’ll get one email per week if a page is added or changed."
     check_email:
-      title: Check your email inbox to confirm your subscription
-      description_html: "We’ve sent an email to: <strong>‘%{address}’</strong>"
-      instruction: Use the link in the email to confirm your subscription.
-      expiry: You have 7 days to confirm.
+      title: Check your email
+      description_html: "We’ve sent an email to <strong>%{address}</strong>"
+      instruction: "Click the link in the email to confirm you want emails from GOV.UK about:"
+      expiry: The link will stop working after 7 days.
+      not_received_title: Not received an email?
+      not_received_detail_html: |
+        <p>Emails sometimes take a few minutes to arrive.</p>
+        <p>If you do not receive an email soon, check your spam or junk folder.</p>
+        <p>If this does not work, <a target="_blank" href="https://www.gov.uk/contact/govuk">contact GOV.UK</a> for help.</p>

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -4,8 +4,8 @@ en:
       general_problem: "There is a problem"
       required_question: "You must answer this question"
       missing_frequency: "Select how often you want updates"
-      question: How often do you want to receive emails?
-      title: Get emails when pages are added or updated
+      title: How often do you want to get emails?
+      unsubscribe_html: Do you need to <a target="_blank" href="https://www.gov.uk/help/update-email-notifications">unsubscribe from GOV.UK emails</a>?
     new_address:
       general_problem: "We weren’t able to process your subscription"
       email_validation: "There’s a problem with your email address"

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -12,14 +12,6 @@ en:
       missing_email: "Please enter your email address."
       invalid_email: "This doesn’t look like a valid email address – check you’ve entered it correctly."
       title: Enter your email address
-      description_html: |
-        You’re subscribing to get email notifications about: <br/>
-        <strong>%{title}</strong>.
-      question: "What’s your email address?"
-      summary:
-        immediately: "You’ll get an email every time a page is added or changed."
-        daily: "You’ll get an email each day if a page is added or changed."
-        weekly: "You’ll get one email per week if a page is added or changed."
     check_email:
       title: Check your email
       description_html: "We’ve sent an email to <strong>%{address}</strong>"

--- a/spec/features/subscribe_back_spec.rb
+++ b/spec/features/subscribe_back_spec.rb
@@ -15,13 +15,6 @@ RSpec.feature "Subscribe back" do
     then_i_can_only_go_back_to_govuk
   end
 
-  scenario "confirm email" do
-    when_i_start_signup_via_govuk
-    and_i_select_frequency_and_submit
-    and_i_fill_in_my_email
-    then_i_can_see_a_back_url_with_correct_parameters
-  end
-
   def given_there_is_content_i_can_subscribe_to
     @topic_id = SecureRandom.uuid
 
@@ -34,23 +27,8 @@ RSpec.feature "Subscribe back" do
     )
   end
 
-  def when_i_confirm_my_email
-    visit "/email/subscriptions/verify?topic_id=#{@topic_id}?frequency=1&address=user@domain.uk"
-  end
-
   def when_i_start_signup_via_govuk
     visit "/email/subscriptions/new?topic_id=#{@topic_id}"
-  end
-
-  def and_i_select_frequency_and_submit
-    stub_email_alert_api_sends_subscription_verification_email("person@somewhere.uk", "daily", @topic_id)
-    choose(option: "daily")
-    click_on "Continue"
-  end
-
-  def and_i_fill_in_my_email
-    fill_in "address", with: "person@somewhere.uk"
-    click_on "Continue"
   end
 
   def when_i_start_signup_externally
@@ -64,12 +42,6 @@ RSpec.feature "Subscribe back" do
 
   def then_i_can_only_go_back_to_govuk
     expect(back_link_href).to match(%r{gov.uk/some/page\?query=string$})
-  end
-
-  def then_i_can_see_a_back_url_with_correct_parameters
-    expect(back_link_href).to match(%r{gov.uk})
-    params = Rack::Utils.parse_query(URI.parse(back_link_href).query).symbolize_keys
-    expect(params).to include(frequency: "daily", topic_id: @topic_id, address: "person@somewhere.uk")
   end
 
   def back_link_href

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Subscribe" do
 
   def and_i_enter_my_email_address
     expect(back_link_href).to include(new_subscription_path(topic_id: @topic_id))
-    expect(page).to have_content(I18n.t!("subscriptions.new_address.question"))
+    expect(page).to have_content(I18n.t!("subscriptions.new_address.title"))
 
     address = "test@test.com"
     fill_in :address, with: address

--- a/spec/features/subscribe_spec.rb
+++ b/spec/features/subscribe_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Subscribe" do
   end
 
   def and_i_choose_a_frequency
-    expect(page).to have_content(I18n.t!("subscriptions.new_frequency.question"))
+    expect(page).to have_content(I18n.t!("subscriptions.new_frequency.title"))
     @frequency = "weekly"
     choose "frequency", option: @frequency, visible: false
     click_on "Continue"


### PR DESCRIPTION
https://trello.com/c/mk5M2aKD/619-general-design-and-stylistic-updates-to-signup-workflow

This updates the pages that are common to all new subscription flows
with a new design. Please see the commits for more details.

One general theme is that I've used 'target="_blank"' for all links.
While the design didn't specify either way, most of the links seem to
be providing additional information, where it would not make sense for
the user to navigate away.

## Before

<img width="643" alt="Screenshot 2020-11-23 at 13 18 45" src="https://user-images.githubusercontent.com/9029009/99966618-7b2bb500-2d8e-11eb-8f67-106e80a67ab4.png">
<img width="705" alt="Screenshot 2020-11-23 at 13 18 54" src="https://user-images.githubusercontent.com/9029009/99966621-7bc44b80-2d8e-11eb-8712-7bbeded08f27.png">
<img width="675" alt="Screenshot 2020-11-23 at 13 19 00" src="https://user-images.githubusercontent.com/9029009/99966623-7c5ce200-2d8e-11eb-9795-6f9a1518455a.png">

## After

<img width="668" alt="Screenshot 2020-11-23 at 17 22 21" src="https://user-images.githubusercontent.com/9029009/99994090-7d067000-2db0-11eb-8d5a-68a97b84eef7.png">

<img width="642" alt="Screenshot 2020-11-23 at 13 18 20" src="https://user-images.githubusercontent.com/9029009/99966639-81ba2c80-2d8e-11eb-8487-61bd87dc1115.png">
<img width="671" alt="Screenshot 2020-11-23 at 13 18 29" src="https://user-images.githubusercontent.com/9029009/99966640-8252c300-2d8e-11eb-9714-dd366390283a.png">
