### PR TITLE
Rewrite content for development homepage

### DIFF
--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -3,52 +3,18 @@
 <%= render "govuk_publishing_components/components/title", title: "Email Alert Frontend" %>
 
 <p class="govuk-body">
-  This page is intended to only be shown in development and on Heroku review
-  apps. It won't be shown on GOV.UK as there are no routes to it.
+  This page is intended to only be shown in development.
 </p>
 
 <p class="govuk-body">
-  <%= link_to "Email Alert Frontend",
-              "https://github.com/alphagov/email-alert-frontend",
-              class: "govuk-link" %>
-  provides means to sign-up for GOV.UK mailing lists and manage
-  subscriptions.
+See the <%= link_to "README",
+            "https://github.com/alphagov/email-alert-frontend/blob/master/README.md",
+            class: "govuk-link" %> for usage.
 </p>
-
-<h2 class="govuk-heading-l">Component Guide</h2>
 
 <p class="govuk-body">
   To see the available components, take a look at the
   <%= link_to "Component Guide",
               govuk_publishing_components.component_guide_path,
-              class: "govuk-link" %>
+              class: "govuk-link" %>.
 </p>
-
-<h2 class="govuk-heading-l">Example sign-up pages</h2>
-
-<p class="govuk-body">
-  Note: these links depend on the appropriate pages being published to the
-  <%= link_to "Content store",
-              "https://github.com/alphagov/content-store",
-              class: "govuk-link" %>
-  that is being used and to proceed with any sign-up requires an
-  instance of
-  <%= link_to "Email Alert API",
-              "https://github.com/alphagov/email-alert-api",
-              class: "govuk-link" %>
-  to be available.
-</p>
-
-<ul class="govuk-list govuk-list--bullet">
-  <li>
-    <%= link_to "Foreign Travel Advice",
-                "/foreign-travel-advice/email-signup",
-                class: "govuk-link" %>
-  </li>
-  <li>
-    <%= link_to "Government Digital Service",
-                new_content_item_signup_path(link: "/government/organisations/government-digital-service"),
-                class: "govuk-link" %>
-  </li>
-</ul>
-


### PR DESCRIPTION
https://trello.com/c/mk5M2aKD/619-general-design-and-stylistic-updates-to-signup-workflow

Since a developer may not think to spin up the app in order to
learn about it, we should favour having documentation in the
README, which happens to already cover all of the content here.
On the other hand, keeping this page still provides a nicer
experience for someone who's new to the app. This replaces the
previous content with some simple links to further info.

## Before

<img width="1028" alt="Screenshot 2020-11-25 at 15 57 21" src="https://user-images.githubusercontent.com/9029009/100251941-3ee78880-2f37-11eb-9c4c-e79f84e98d88.png">

## After

<img width="679" alt="Screenshot 2020-11-25 at 15 53 04" src="https://user-images.githubusercontent.com/9029009/100251958-4313a600-2f37-11eb-94e8-c4d685294bba.png">
