### PR TITLE
Simplify request handling for content item signups

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -21,12 +21,8 @@ class ContentItemSignupsController < ApplicationController
   def confirm; end
 
   def create
-    if content_item.to_h.present?
-      signup = ContentItemSubscriberList.new(content_item.to_h)
-      redirect_to signup.subscription_management_url
-    else
-      redirect_to confirm_content_item_signup_path(link: content_item_path)
-    end
+    signup = ContentItemSubscriberList.new(content_item.to_h)
+    redirect_to signup.subscription_management_url
   end
 
 private

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -63,8 +63,8 @@ private
   end
 
   def assign_list_params
-    @list_params = ContentItemSubscriberList.new(content_item.to_h).params
-  rescue ContentItemSubscriberList::UnsupportedContentItemError
+    @list_params = GenerateSubscriberListParamsService.call(content_item.to_h)
+  rescue GenerateSubscriberListParamsService::UnsupportedContentItemError
     bad_request
   end
 end

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -31,15 +31,12 @@ class ContentItemSignupsController < ApplicationController
 private
 
   def handle_redirects
-    if @content_item["document_type"] == "redirect"
-      destination_path = @content_item.dig("redirects", 0, "destination")
-      if destination_path.nil?
-        redirect_to("/")
-      else
-        redirect_to(new_content_item_signup_path(topic: destination_path))
-      end
-      false
-    end
+    return unless @content_item["document_type"] == "redirect"
+
+    destination_path = @content_item.dig("redirects", 0, "destination")
+    return error_not_found if destination_path.nil?
+
+    redirect_to(new_content_item_signup_path(topic: destination_path))
   end
 
   def assign_content_item

--- a/app/models/content_item_subscriber_list.rb
+++ b/app/models/content_item_subscriber_list.rb
@@ -1,30 +1,20 @@
 class ContentItemSubscriberList
-  include Rails.application.routes.url_helpers
-
   def initialize(content_item)
     @content_item = content_item
-
-    @subscriber_list = GdsApi.email_alert_api
-      .find_or_create_subscriber_list(subscription_params)
   end
 
-  def subscription_management_url
-    slug = subscriber_list.dig("subscriber_list", "slug")
-    new_subscription_path(topic_id: slug)
-  end
-
-private
-
-  attr_reader :content_item, :subscriber_list
-
-  class UnsupportedContentItemError < StandardError; end
-
-  def subscription_params
+  def params
     {
       "title" => content_item["title"],
       "links" => link_hash,
     }
   end
+
+private
+
+  attr_reader :content_item
+
+  class UnsupportedContentItemError < StandardError; end
 
   def link_hash
     case content_item_type

--- a/app/models/content_item_subscriber_list.rb
+++ b/app/models/content_item_subscriber_list.rb
@@ -1,4 +1,6 @@
 class ContentItemSubscriberList
+  include Rails.application.routes.url_helpers
+
   def initialize(content_item)
     @content_item = content_item
 
@@ -7,7 +9,8 @@ class ContentItemSubscriberList
   end
 
   def subscription_management_url
-    subscriber_list.dig("subscriber_list", "subscription_url")
+    slug = subscriber_list.dig("subscriber_list", "slug")
+    new_subscription_path(topic_id: slug)
   end
 
 private

--- a/app/services/generate_subscriber_list_params_service.rb
+++ b/app/services/generate_subscriber_list_params_service.rb
@@ -1,9 +1,9 @@
-class ContentItemSubscriberList
+class GenerateSubscriberListParamsService < ApplicationService
   def initialize(content_item)
     @content_item = content_item
   end
 
-  def params
+  def call
     {
       "title" => content_item["title"],
       "links" => link_hash,

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ContentItemSignupsController do
       expect(response).to have_http_status(:found)
       expect(response.location).to eq "http://test.host/email-signup?topic=%2Fcleaning%2Fbroomsticks"
     end
-    it "redirects to the homepage if there is no destination path" do
+    it "returns not found if there is no destination path" do
       stub_content_store_has_item(
         "/magical/broomsticks",
         document_type: "redirect",
@@ -23,9 +23,7 @@ RSpec.describe ContentItemSignupsController do
       )
 
       get :new, params: { topic: "/magical/broomsticks" }
-
-      expect(response).to have_http_status(:found)
-      expect(response.location).to eq "http://test.host/"
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -72,19 +72,17 @@ RSpec.feature "Content item signup" do
   end
 
   def and_i_click_to_signup_to_alerts
-    subscriber_list_id = @taxon[:base_path]
-    @subscriber_list_url = new_subscription_path(topic_id: subscriber_list_id)
-
     stub_email_alert_api_has_subscriber_list(
       "links" => { "taxon_tree" => [@taxon[:content_id]] },
       "id" => @taxon[:base_path],
-      "subscription_url" => @subscriber_list_url,
+      "slug" => @taxon[:base_path],
     )
 
     click_on "Continue"
   end
 
   def then_i_can_subscribe_to_alerts
-    expect(page).to have_current_path(@subscriber_list_url)
+    expected_path = new_subscription_path(topic_id: @taxon[:base_path])
+    expect(page).to have_current_path(expected_path)
   end
 end

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe ContentItemSubscriberList do
 
       allow(mock_email_alert_api)
         .to receive(:find_or_create_subscriber_list)
-        .and_return("subscriber_list" => { "subscription_url" => "/something" })
+        .and_return("subscriber_list" => { "slug" => "something" })
     end
 
     it "creates a subscriber list for taxons" do
       content_item.merge!("document_type" => "taxon")
       signup = described_class.new(content_item)
-      expect(signup.subscription_management_url).to eq "/something"
+      expect(signup.subscription_management_url).to eq "/email/subscriptions/new?topic_id=something"
 
       expect(mock_email_alert_api)
         .to have_received(:find_or_create_subscriber_list)

--- a/spec/models/content_item_subscriber_list_spec.rb
+++ b/spec/models/content_item_subscriber_list_spec.rb
@@ -1,93 +1,70 @@
 RSpec.describe ContentItemSubscriberList do
-  describe "#subscription_management_url" do
-    let(:mock_email_alert_api) do
-      instance_double(GdsApi.email_alert_api.class)
-    end
-
+  describe "#params" do
     let(:content_item) do
       { "title" => "Foo", "content_id" => "foo-id" }
     end
 
-    before do
-      allow(GdsApi).to receive(:email_alert_api)
-        .and_return(mock_email_alert_api)
-
-      allow(mock_email_alert_api)
-        .to receive(:find_or_create_subscriber_list)
-        .and_return("subscriber_list" => { "slug" => "something" })
-    end
-
-    it "creates a subscriber list for taxons" do
+    it "returns subscriber list params for taxons" do
       content_item.merge!("document_type" => "taxon")
-      signup = described_class.new(content_item)
-      expect(signup.subscription_management_url).to eq "/email/subscriptions/new?topic_id=something"
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "taxon_tree" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "taxon_tree" => %w[foo-id] })
     end
 
-    it "creates a subscriber list for an organisation" do
+    it "returns subscriber list params for organisations" do
       content_item.merge!("document_type" => "organisation")
-      described_class.new(content_item).subscription_management_url
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "organisations" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "organisations" => %w[foo-id] })
     end
 
-    it "creates a subscriber list for a person" do
+    it "returns subscriber list params for people" do
       content_item.merge!("document_type" => "person")
-      described_class.new(content_item).subscription_management_url
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "people" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "people" => %w[foo-id] })
     end
 
-    it "creates a subscriber list for a ministerial role" do
+    it "returns subscriber list params for ministerial roles" do
       content_item.merge!("document_type" => "ministerial_role")
-      described_class.new(content_item)
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "roles" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "roles" => %w[foo-id] })
     end
 
-    it "creates a subscriber list for a topical event" do
+    it "returns subscriber list params for topical events" do
       content_item.merge!("document_type" => "topical_event")
-      described_class.new(content_item)
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "topical_events" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "topical_events" => %w[foo-id] })
     end
 
-    it "creates a subscriber list for a topic" do
+    it "returns subscriber list params for topics" do
       content_item.merge!("document_type" => "topic")
-      described_class.new(content_item)
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "topics" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "topics" => %w[foo-id] })
     end
 
-    it "creates a subscriber list for a service manual topic" do
+    it "returns subscriber list params for service manual topics" do
       content_item.merge!("document_type" => "service_manual_topic")
-      described_class.new(content_item)
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "service_manual_topics" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "service_manual_topics" => %w[foo-id] })
     end
 
-    it "creates a subscriber list for the service standard" do
+    it "returns subscriber list params for the service standard" do
       content_item.merge!("document_type" => "service_manual_service_standard")
-      described_class.new(content_item)
 
-      expect(mock_email_alert_api)
-        .to have_received(:find_or_create_subscriber_list)
-        .with("title" => "Foo", "links" => { "parent" => %w[foo-id] })
+      expect(described_class.new(content_item).params)
+        .to match("title" => "Foo", "links" => { "parent" => %w[foo-id] })
+    end
+
+    it "raises an error when the document type is not supported" do
+      content_item.merge!("document_type" => "other")
+
+      expect { described_class.new(content_item).params }
+        .to raise_error ContentItemSubscriberList::UnsupportedContentItemError
     end
   end
 end

--- a/spec/services/generate_subscriber_list_params_service_spec.rb
+++ b/spec/services/generate_subscriber_list_params_service_spec.rb
@@ -1,5 +1,5 @@
-RSpec.describe ContentItemSubscriberList do
-  describe "#params" do
+RSpec.describe GenerateSubscriberListParamsService do
+  describe ".call" do
     let(:content_item) do
       { "title" => "Foo", "content_id" => "foo-id" }
     end
@@ -7,64 +7,64 @@ RSpec.describe ContentItemSubscriberList do
     it "returns subscriber list params for taxons" do
       content_item.merge!("document_type" => "taxon")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "taxon_tree" => %w[foo-id] })
     end
 
     it "returns subscriber list params for organisations" do
       content_item.merge!("document_type" => "organisation")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "organisations" => %w[foo-id] })
     end
 
     it "returns subscriber list params for people" do
       content_item.merge!("document_type" => "person")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "people" => %w[foo-id] })
     end
 
     it "returns subscriber list params for ministerial roles" do
       content_item.merge!("document_type" => "ministerial_role")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "roles" => %w[foo-id] })
     end
 
     it "returns subscriber list params for topical events" do
       content_item.merge!("document_type" => "topical_event")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "topical_events" => %w[foo-id] })
     end
 
     it "returns subscriber list params for topics" do
       content_item.merge!("document_type" => "topic")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "topics" => %w[foo-id] })
     end
 
     it "returns subscriber list params for service manual topics" do
       content_item.merge!("document_type" => "service_manual_topic")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "service_manual_topics" => %w[foo-id] })
     end
 
     it "returns subscriber list params for the service standard" do
       content_item.merge!("document_type" => "service_manual_service_standard")
 
-      expect(described_class.new(content_item).params)
+      expect(described_class.call(content_item))
         .to match("title" => "Foo", "links" => { "parent" => %w[foo-id] })
     end
 
     it "raises an error when the document type is not supported" do
       content_item.merge!("document_type" => "other")
 
-      expect { described_class.new(content_item).params }
-        .to raise_error ContentItemSubscriberList::UnsupportedContentItemError
+      expect { described_class.call(content_item) }
+        .to raise_error GenerateSubscriberListParamsService::UnsupportedContentItemError
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/mk5M2aKD/619-general-design-and-stylistic-updates-to-signup-workflow

Fixes: https://github.com/alphagov/email-alert-frontend/issues/913

This PR makes a few changes to the the request handling:

- Use list "slug" instead of "subscription_url" for redirects
- Stop redirecting to "gov.uk" for blank redirect content items

I've also done a bit of refactoring, with the final part -
the controller tests - saved for a later PR, due to the
need to add some missing API test helpers first.