### PR TITLE
Prepare to require authentication for unsubscribe

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,11 +13,17 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::HTTPForbidden, with: :forbidden
   rescue_from GdsApi::HTTPGone, with: :gone
 
+  helper_method :authenticated?
+
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
       password: ENV.fetch("BASIC_AUTH_PASSWORD"),
     )
+  end
+
+  def authenticated?
+    session["authentication"].present?
   end
 
 private
@@ -50,10 +56,6 @@ private
 
   def require_authentication
     redirect_to :sign_in unless authenticated?
-  end
-
-  def authenticated?
-    session["authentication"].present?
   end
 
   def authenticated_subscriber_id

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -18,7 +18,7 @@ class UnsubscriptionsController < ApplicationController
                      nil
                    end
 
-    if @authenticated_for_subscription
+    if authenticated?
       message = if @title
                   "You have been unsubscribed from ‘#{@title}’"
                 else
@@ -43,7 +43,6 @@ private
     @id = params.require(:id)
     @subscription = GdsApi.email_alert_api.get_subscription(@id)
     @title = @subscription.dig("subscription", "subscriber_list", "title").presence
-    @authenticated_for_subscription = check_authenticated(@subscription)
   end
 
   def check_is_latest
@@ -59,14 +58,5 @@ private
 
   def subscription_ended?(subscription)
     subscription.dig("subscription", "ended_at").present?
-  end
-
-  def check_authenticated(subscription)
-    if authenticated?
-      subscriber_id = subscription.dig("subscription", "subscriber", "id")
-      subscriber_id == authenticated_subscriber_id
-    else
-      false
-    end
   end
 end

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -3,7 +3,7 @@ class UnsubscriptionsController < ApplicationController
   before_action :check_is_latest, only: %i[confirm]
 
   def confirm
-    if subscription_ended?(@subscription)
+    if @subscription["ended_at"].present?
       render :confirm_already_unsubscribed
     else
       render :confirm
@@ -32,8 +32,8 @@ private
 
   def set_attributes
     @id = params.require(:id)
-    @subscription = GdsApi.email_alert_api.get_subscription(@id)
-    @title = @subscription.dig("subscription", "subscriber_list", "title")
+    @subscription = GdsApi.email_alert_api.get_subscription(@id).dig("subscription")
+    @title = @subscription.dig("subscriber_list", "title")
   end
 
   def check_is_latest
@@ -42,12 +42,8 @@ private
       .get_latest_matching_subscription(@id)
       .dig("subscription", "id")
 
-    return if latest_subscription_id == @subscription.dig("subscription", "id")
+    return if latest_subscription_id == @subscription["id"]
 
     redirect_to confirm_unsubscribe_path(latest_subscription_id)
-  end
-
-  def subscription_ended?(subscription)
-    subscription.dig("subscription", "ended_at").present?
   end
 end

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -11,20 +11,18 @@ class UnsubscriptionsController < ApplicationController
   end
 
   def confirmed
-    unsubscribed = begin
-                     GdsApi.email_alert_api.unsubscribe(@id)
-                   rescue GdsApi::HTTPNotFound
-                     # The user has already unsubscribed.
-                     nil
-                   end
+    begin
+      GdsApi.email_alert_api.unsubscribe(@id)
+    rescue GdsApi::HTTPNotFound
+      # The user has already unsubscribed.
+      nil
+    end
 
     if authenticated?
-      if unsubscribed
-        flash[:success] = {
-          message: t("subscriptions_management.index.unsubscribe.message", title: @title),
-          description: t("subscriptions_management.index.unsubscribe.description"),
-        }
-      end
+      flash[:success] = {
+        message: t("subscriptions_management.index.unsubscribe.message", title: @title),
+        description: t("subscriptions_management.index.unsubscribe.description"),
+      }
 
       redirect_to list_subscriptions_path
     end

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -19,11 +19,7 @@ class UnsubscriptionsController < ApplicationController
                    end
 
     if authenticated?
-      message = if @title
-                  "You have been unsubscribed from ‘#{@title}’"
-                else
-                  "You have been unsubscribed"
-                end
+      message = "You have been unsubscribed from ‘#{@title}’"
       description = "It can take up to an hour for this change to take effect."
 
       if unsubscribed
@@ -42,7 +38,7 @@ private
   def set_attributes
     @id = params.require(:id)
     @subscription = GdsApi.email_alert_api.get_subscription(@id)
-    @title = @subscription.dig("subscription", "subscriber_list", "title").presence
+    @title = @subscription.dig("subscription", "subscriber_list", "title")
   end
 
   def check_is_latest

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -19,13 +19,10 @@ class UnsubscriptionsController < ApplicationController
                    end
 
     if authenticated?
-      message = "You have been unsubscribed from ‘#{@title}’"
-      description = "It can take up to an hour for this change to take effect."
-
       if unsubscribed
         flash[:success] = {
-          message: message,
-          description: description,
+          message: t("subscriptions_management.index.unsubscribe.message", title: @title),
+          description: t("subscriptions_management.index.unsubscribe.description"),
         }
       end
 

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, t("unsubscriptions.title.confirm") %>
 
-<% if @authenticated_for_subscription %>
+<% if authenticated? %>
   <% content_for :back_link do %>
     <%= render "govuk_publishing_components/components/back_link", {
       href: list_subscriptions_path
@@ -26,7 +26,7 @@
         },
       } %>
     <% end %>
-    <% if @authenticated_for_subscription %>
+    <% if authenticated? %>
       <p class="govuk-body">
         <%= link_to "Cancel",
                     list_subscriptions_path,

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -6,6 +6,9 @@ en:
         immediately: "You get updates as soon as they happen."
         daily: "You get daily updates."
         weekly: "You get weekly updates."
+      unsubscribe:
+        message: "You have been unsubscribed from ‘%{title}’"
+        description: "It can take up to an hour for this change to take effect."
     update_address:
       heading: Change your email address
       current_email: "Your current email address is %{address}"

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe ApplicationController do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "Cache-Control header" do
+    it "sets it to 'private, no-cache'" do
+      get :index
+      expect(response.headers["Cache-Control"]).to eq("private, no-cache")
+    end
+  end
 end

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -19,11 +19,6 @@ RSpec.describe SubscriberAuthenticationController do
         expect(response).to have_http_status(:ok)
       end
 
-      it "sets the Cache-Control header to 'private, no-cache'" do
-        get :sign_in
-        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
-      end
-
       it "renders a form" do
         get :sign_in
         expect(response.body).to include(%(action="#{request_sign_in_token_path}"))
@@ -91,13 +86,6 @@ RSpec.describe SubscriberAuthenticationController do
         "subscriber_id" => subscriber_id,
         "redirect" => "/email/manage",
       })
-    end
-
-    context "when the page is requested" do
-      it "sets the Cache-Control header to 'private, no-cache'" do
-        get :process_sign_in_token, params: { token: token }
-        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
-      end
     end
 
     context "when an expired token is provided" do

--- a/spec/controllers/subscription_authentication_controller_spec.rb
+++ b/spec/controllers/subscription_authentication_controller_spec.rb
@@ -32,11 +32,6 @@ RSpec.describe SubscriptionAuthenticationController do
         get :authenticate, params: params.merge(token: token)
         expect(response).to redirect_to(subscription_complete_path(params))
       end
-
-      it "sets the Cache-Control header to 'private, no-cache'" do
-        get :authenticate, params: params.merge(token: token)
-        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
-      end
     end
 
     context "the token is expired" do

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -44,11 +44,6 @@ RSpec.describe SubscriptionsController do
         get :new, params: { topic_id: topic_id }
         expect(response).to have_http_status(:ok)
       end
-
-      it "sets the Cache-Control header to 'private, no-cache'" do
-        get :new, params: { topic_id: topic_id }
-        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
-      end
     end
 
     context "when a topic and frequency are provided" do
@@ -94,11 +89,6 @@ RSpec.describe SubscriptionsController do
           topic_id: topic_id, frequency: frequency,
         )
         expect(response).to redirect_to(destination)
-      end
-
-      it "sets the Cache-Control header to 'private, no-cache'" do
-        post :frequency, params: { topic_id: topic_id, frequency: frequency }
-        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
       end
     end
   end
@@ -163,11 +153,6 @@ RSpec.describe SubscriptionsController do
       it "sends a request to email-alert-api" do
         post :verify, params: params
         expect(request).to have_been_requested
-      end
-
-      it "sets the Cache-Control header to 'private, no-cache'" do
-        post :verify, params: params
-        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
       end
     end
 

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -45,11 +45,6 @@ RSpec.describe SubscriptionsManagementController do
         get :index, session: session_data
         expect(response).to have_http_status(:ok)
       end
-
-      it "sets the Cache-Control header to 'private, no-cache'" do
-        get :index, session: session_data
-        expect(response.headers["Cache-Control"]).to eq("private, no-cache")
-      end
     end
 
     context "when there is a subscriber with a subscription" do

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -114,7 +114,10 @@ RSpec.describe UnsubscriptionsController do
 
       it "sets a flash to confirm" do
         post :confirmed, params: { id: id }, session: session
-        expect(flash[:success][:message]).to eq("You have been unsubscribed from ‘#{title}’")
+
+        expect(flash[:success][:message]).to eq(
+          I18n.t!("subscriptions_management.index.unsubscribe.message", title: title),
+        )
       end
     end
   end

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe UnsubscriptionsController do
         stub_email_alert_api_has_no_subscription_for_uuid(id)
       end
 
-      it "renders a page informing them the subscription has already ended" do
+      it "renders a confirmation page" do
         post :confirmed, params: { id: id }
 
         expect(response.body).to include(

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe UnsubscriptionsController do
   include GdsApi::TestHelpers::EmailAlertApi
+  include SessionHelper
 
   render_views
 
@@ -93,9 +94,7 @@ RSpec.describe UnsubscriptionsController do
     end
 
     context "when a user is authenticated" do
-      let(:session) do
-        { "authentication" => { "subscriber_id" => subscriber_id } }
-      end
+      let(:session) { session_for(subscriber_id) }
 
       it "redirects to subscription management" do
         post :confirmed, params: { id: id }, session: session

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -20,11 +20,6 @@ RSpec.describe UnsubscriptionsController do
       expect(response).to have_http_status(:ok)
     end
 
-    it "sets the Cache-Control header to 'private, no-cache'" do
-      get :confirm, params: { id: id }
-      expect(response.headers["Cache-Control"]).to eq("private, no-cache")
-    end
-
     context "when the subscription has already ended" do
       before do
         stub_email_alert_api_has_subscription(
@@ -68,11 +63,6 @@ RSpec.describe UnsubscriptionsController do
     it "responds with a 200" do
       post :confirmed, params: { id: id }
       expect(response).to have_http_status(:ok)
-    end
-
-    it "sets the Cache-Control header to 'private, no-cache'" do
-      post :confirmed, params: { id: id }
-      expect(response.headers["Cache-Control"]).to eq("private, no-cache")
     end
 
     it "renders a confirmation page" do

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -17,28 +17,12 @@ RSpec.describe UnsubscriptionsController do
   describe "GET /email/unsubscribe/:id" do
     it "responds with a 200" do
       get :confirm, params: { id: id }
-
       expect(response).to have_http_status(:ok)
     end
 
     it "sets the Cache-Control header to 'private, no-cache'" do
       get :confirm, params: { id: id }
-
       expect(response.headers["Cache-Control"]).to eq("private, no-cache")
-    end
-
-    it "renders a form" do
-      get :confirm, params: { id: id }
-
-      expect(response.body).to include(%(action="/email/unsubscribe/#{id}"))
-    end
-
-    it "renders the title on the page" do
-      get :confirm, params: { id: id }
-
-      expect(response.body).to include(
-        I18n.t!("unsubscriptions.confirmation.with_title", title: title),
-      )
     end
 
     context "when the subscription has already ended" do
@@ -50,12 +34,11 @@ RSpec.describe UnsubscriptionsController do
 
       it "show a message saying subscription has ended" do
         get :confirm, params: { id: id }
-
         expect(response.body).to include("You’ve already unsubscribed from VAT Rates")
       end
     end
 
-    context "when the user has unsubscribed and resubscribed, then clicked 'Unsubscribe' from their previous subscription" do
+    context "when the user has modified their subscription" do
       let(:original_subscription_id) { SecureRandom.uuid }
       let(:latest_subscription_id) { SecureRandom.uuid }
 
@@ -76,59 +59,7 @@ RSpec.describe UnsubscriptionsController do
 
       it "redirects to the latest subscription" do
         get :confirm, params: { id: original_subscription_id }
-
-        expect(response).to have_http_status(:found)
-        expect(response.headers["Location"]).to end_with("/email/unsubscribe/#{latest_subscription_id}")
-      end
-    end
-
-    context "when the user has changed their frequency, then clicked 'Unsubscribe' from their previous subscription" do
-      let(:original_subscription_id) { SecureRandom.uuid }
-      let(:latest_subscription_id) { SecureRandom.uuid }
-
-      before do
-        stub_email_alert_api_has_subscriptions([
-          {
-            id: original_subscription_id,
-            frequency: "immediately",
-            ended: true,
-          },
-          {
-            id: latest_subscription_id,
-            frequency: "daily",
-            ended: false,
-          },
-        ])
-      end
-
-      it "redirects to the latest subscription" do
-        get :confirm, params: { id: original_subscription_id }
-
-        expect(response).to have_http_status(:found)
-        expect(response.headers["Location"]).to end_with("/email/unsubscribe/#{latest_subscription_id}")
-      end
-    end
-
-    context "when a user is authenticated" do
-      let(:session) do
-        { "authentication" => { "subscriber_id" => 1 } }
-      end
-
-      it "shows a cancel button" do
-        get :confirm, params: { id: id }, session: session
-
-        expect(response.body).to have_link("Cancel", href: list_subscriptions_path)
-      end
-    end
-
-    context "when a user is authenticated but not to the list this is from" do
-      let(:session) do
-        { "authenticated" => { "subscriber_id" => 2 } }
-      end
-
-      it "doesn't show a cancel button" do
-        get :confirm, params: { id: id }, session: session
-        expect(response.body).not_to include("Cancel")
+        expect(response).to redirect_to(confirm_unsubscribe_path(latest_subscription_id))
       end
     end
   end
@@ -136,13 +67,11 @@ RSpec.describe UnsubscriptionsController do
   describe "POST /email/unsubscribe/:id" do
     it "responds with a 200" do
       post :confirmed, params: { id: id }
-
       expect(response).to have_http_status(:ok)
     end
 
     it "sets the Cache-Control header to 'private, no-cache'" do
       post :confirmed, params: { id: id }
-
       expect(response.headers["Cache-Control"]).to eq("private, no-cache")
     end
 
@@ -156,7 +85,6 @@ RSpec.describe UnsubscriptionsController do
 
     it "sends an unsubscribe request to email-alert-api" do
       post :confirmed, params: { id: id }
-
       assert_unsubscribed(id)
     end
 
@@ -187,18 +115,6 @@ RSpec.describe UnsubscriptionsController do
       it "sets a flash to confirm" do
         post :confirmed, params: { id: id }, session: session
         expect(flash[:success][:message]).to eq("You have been unsubscribed from ‘#{title}’")
-        expect(flash[:success][:description]).to eq("It can take up to an hour for this change to take effect.")
-      end
-    end
-
-    context "when a user is authenticated but not to the list this is from" do
-      let(:session) do
-        { "authenticated" => { "subscriber_id" => subscriber_id + 1 } }
-      end
-
-      it "doesn't redirect" do
-        post :confirmed, params: { id: id }, session: session
-        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -101,11 +101,11 @@ RSpec.describe UnsubscriptionsController do
         ])
       end
 
-      it "redirects the user to manage their subscriptions" do
+      it "redirects to the latest subscription" do
         get :confirm, params: { id: original_subscription_id }
 
         expect(response).to have_http_status(:found)
-        expect(response.headers["Location"]).to end_with("/email/authenticate")
+        expect(response.headers["Location"]).to end_with("/email/unsubscribe/#{latest_subscription_id}")
       end
     end
 

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -1,30 +1,73 @@
-RSpec.feature "Unsubscribe after receiving confirmation link" do
+RSpec.feature "Unsubscribe" do
   include GdsApi::TestHelpers::EmailAlertApi
+  include TokenHelper
 
-  scenario do
+  scenario "when using a one-click link" do
     given_i_have_a_subscription
     when_i_visit_the_unsubscribe_page
-    and_i_click_on_unsubscribe
+    and_i_confirm_to_unsubscribe
     then_i_see_that_i_am_unsubscribed
   end
 
+  scenario "when managing subscriptions" do
+    given_i_have_a_subscription
+    and_i_have_a_secret_sign_in_token
+    when_i_visit_the_management_page
+    and_i_click_on_unsubscribe
+    and_i_confirm_to_unsubscribe
+    then_i_see_the_management_page
+  end
+
   def given_i_have_a_subscription
-    @subscriber_list_id = SecureRandom.uuid
+    @subscription_id = SecureRandom.uuid
     @title = "A thing to subscribe to"
+    @subscriber_id = SecureRandom.uuid
+
     stub_email_alert_api_has_subscription(
-      @subscriber_list_id,
+      @subscription_id,
       "immediately",
       title: @title,
+      subscriber_id: @subscriber_id,
     )
   end
 
   def when_i_visit_the_unsubscribe_page
-    visit confirm_unsubscribe_path(@subscriber_list_id)
+    visit confirm_unsubscribe_path(@subscription_id)
+  end
+
+  def and_i_have_a_secret_sign_in_token
+    @address = "test@test.com"
+
+    @token = encrypt_and_sign_token(data: {
+      "address" => @address,
+      "subscriber_id" => @subscriber_id,
+    })
+  end
+
+  def when_i_visit_the_management_page
+    stub_email_alert_api_has_subscriber_subscriptions(
+      @subscriber_id,
+      @address,
+      nil,
+      subscriptions: [
+        {
+          "id" => @subscription_id,
+          "created_at" => Time.zone.now,
+          "subscriber_list" => {},
+        },
+      ],
+    )
+
+    visit process_sign_in_token_path(token: @token)
   end
 
   def and_i_click_on_unsubscribe
+    click_on "Unsubscribe"
+  end
+
+  def and_i_confirm_to_unsubscribe
     @unsubscribe_request = stub_email_alert_api_unsubscribes_a_subscription(
-      @subscriber_list_id,
+      @subscription_id,
     )
     click_on "Unsubscribe"
   end
@@ -33,6 +76,13 @@ RSpec.feature "Unsubscribe after receiving confirmation link" do
     expect(@unsubscribe_request).to have_been_requested
     expect(page).to have_content(
       I18n.t!("unsubscriptions.confirmation.with_title", title: @title),
+    )
+  end
+
+  def then_i_see_the_management_page
+    expect(current_path).to eq list_subscriptions_path
+    expect(page).to have_content(
+      "You have been unsubscribed from ‘#{@title}’",
     )
   end
 end

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -82,7 +82,7 @@ RSpec.feature "Unsubscribe" do
   def then_i_see_the_management_page
     expect(current_path).to eq list_subscriptions_path
     expect(page).to have_content(
-      "You have been unsubscribed from ‘#{@title}’",
+      I18n.t!("subscriptions_management.index.unsubscribe.message", title: @title),
     )
   end
 end

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -1,0 +1,9 @@
+module SessionHelper
+  def session_for(subscriber_id)
+    {
+      "authentication": {
+        "subscriber_id": subscriber_id,
+      },
+    }.with_indifferent_access
+  end
+end


### PR DESCRIPTION
https://trello.com/c/sgJIkObA/662-authenticate-before-unsubscribing-from-digest-emails

This simplifies the existing unsubscribe controller and associated
tests, so that it's easier to add more code: we want to require the
user is authenticated in some way, in order to prove they own the
subscription they are unsubscribing from.

This PR makes a couple of minor behavioural changes:

- We always redirect to the latest subscription, irrespective of frequency.
- We always show/redirect appropriately if the user is signed in.

I decided to cut this PR here, since the volume of change is already
quite large. Please see the commits for more details.