### PR TITLE
Remove support for redirecting after sign in

### DIFF
--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -28,8 +28,7 @@ class SubscriberAuthenticationController < ApplicationController
     end
 
     authenticate_subscriber(token.data[:subscriber_id])
-    destination = safe_redirect_destination || list_subscriptions_path
-    redirect_to destination
+    redirect_to list_subscriptions_path
   end
 
 private
@@ -46,15 +45,5 @@ private
 
   def deauthenticate_subscriber
     session["authentication"] = nil
-  end
-
-  def safe_redirect_destination
-    redirect = token.data[:redirect]
-    return nil unless redirect
-
-    parsed = URI.parse(redirect)
-    redirect if parsed.relative? && redirect[0] == "/"
-  rescue URI::InvalidURIError
-    nil
   end
 end

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -82,10 +82,7 @@ RSpec.describe SubscriberAuthenticationController do
 
   describe "GET /email/authenticate/process" do
     let(:token) do
-      encrypt_and_sign_token(data: {
-        "subscriber_id" => subscriber_id,
-        "redirect" => "/email/manage",
-      })
+      encrypt_and_sign_token(data: { "subscriber_id" => subscriber_id })
     end
 
     context "when an expired token is provided" do


### PR DESCRIPTION
https://trello.com/c/sgJIkObA/662-authenticate-before-unsubscribing-from-digest-emails

This isn't tested, and isn't used in practice: we always take the
user to their list of subscriptions.