### PR TITLE
Require some kind of authentication to unsubscribe

### DIFF
--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -49,11 +49,11 @@ private
   end
 
   def check_owns_subscription
-    return if authenticated? &&
-      @subscription.dig("subscriber", "id") == authenticated_subscriber_id
+    expected_id = @subscription.dig("subscriber", "id")
+    return if authenticated? && expected_id == authenticated_subscriber_id
 
     token = AuthToken.new(params[:token].to_s)
-    return if token.valid? && token.data[:subscription_id] == @id
+    return if token.valid? && token.data[:subscriber_id] == expected_id
 
     flash[:error_summary] = "bad_token" if params[:token]
     redirect_to sign_in_path

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -45,7 +45,7 @@ private
 
     return if latest_subscription_id == @subscription["id"]
 
-    redirect_to confirm_unsubscribe_path(latest_subscription_id)
+    redirect_to confirm_unsubscribe_path(latest_subscription_id, token: params[:token])
   end
 
   def check_owns_subscription

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -1,7 +1,7 @@
 class UnsubscriptionsController < ApplicationController
   before_action :set_attributes
-  before_action :check_is_latest, only: %i[confirm]
   before_action :check_owns_subscription
+  before_action :check_is_latest, only: %i[confirm]
 
   def confirm
     if @subscription["ended_at"].present?

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -50,8 +50,11 @@ private
 
   def check_owns_subscription
     expected_id = @subscription.dig("subscriber", "id")
+
+    # Check for users who have signed in (have a session)
     return if authenticated? && expected_id == authenticated_subscriber_id
 
+    # Check for users who have a one-click unsubscribe link
     token = AuthToken.new(params[:token].to_s)
     return if token.valid? && token.data[:subscriber_id] == expected_id
 

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -15,6 +15,8 @@
     <%= render "confirmation" %>
 
     <%= form_tag(action: :confirmed) do %>
+      <%= hidden_field_tag :token, params[:token] %>
+
       <%= render 'govuk_publishing_components/components/button', {
         text: 'Unsubscribe',
         margin_bottom: true,
@@ -26,6 +28,7 @@
         },
       } %>
     <% end %>
+
     <% if authenticated? %>
       <p class="govuk-body">
         <%= link_to "Cancel",

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -108,8 +108,11 @@ RSpec.describe UnsubscriptionsController do
       end
 
       it "redirects to the latest subscription" do
-        make_request(params: { id: original_subscription_id })
-        expect(response).to redirect_to(confirm_unsubscribe_path(latest_subscription_id))
+        token = encrypt_and_sign_token(data: { "subscription_id" => original_subscription_id })
+        make_request(params: { id: original_subscription_id, token: token })
+
+        expected_path = confirm_unsubscribe_path(latest_subscription_id, token: token)
+        expect(response).to redirect_to(expected_path)
       end
     end
   end

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe UnsubscriptionsController do
   shared_examples "requires authentication" do
     context "when the token is for a different subscription" do
       it "redirects to the sign in page" do
-        token = encrypt_and_sign_token(data: { "subscription_id" => "other" })
+        token = encrypt_and_sign_token(data: { "subscriber_id" => "other" })
         make_request(params: { id: id, token: token })
         expect(response).to redirect_to sign_in_path
         expect(flash[:error_summary]).to eq("bad_token")
@@ -28,7 +28,7 @@ RSpec.describe UnsubscriptionsController do
 
     context "when the token is expired" do
       it "redirects to the sign in page" do
-        token = encrypt_and_sign_token(data: { "subscription_id" => id }, expiry: 0)
+        token = encrypt_and_sign_token(data: { "subscriber_id" => subscriber_id }, expiry: 0)
         make_request(params: { id: id, token: token })
         expect(response).to redirect_to sign_in_path
         expect(flash[:error_summary]).to eq("bad_token")
@@ -62,7 +62,7 @@ RSpec.describe UnsubscriptionsController do
 
     context "when the user has a one-click link" do
       it "responds with a 200" do
-        token = encrypt_and_sign_token(data: { "subscription_id" => id })
+        token = encrypt_and_sign_token(data: { "subscriber_id" => subscriber_id })
         make_request(params: { id: id, token: token })
         expect(response).to have_http_status(:ok)
       end
@@ -108,7 +108,7 @@ RSpec.describe UnsubscriptionsController do
       end
 
       it "redirects to the latest subscription" do
-        token = encrypt_and_sign_token(data: { "subscription_id" => original_subscription_id })
+        token = encrypt_and_sign_token(data: { "subscriber_id" => subscriber_id })
         make_request(params: { id: original_subscription_id, token: token })
 
         expected_path = confirm_unsubscribe_path(latest_subscription_id, token: token)
@@ -125,7 +125,7 @@ RSpec.describe UnsubscriptionsController do
     it_behaves_like "requires authentication"
 
     context "when the user has a one-click link" do
-      let(:token) { encrypt_and_sign_token(data: { "subscription_id" => id }) }
+      let(:token) { encrypt_and_sign_token(data: { "subscriber_id" => subscriber_id }) }
 
       it "responds with a 200" do
         make_request(params: { id: id, token: token })
@@ -152,7 +152,7 @@ RSpec.describe UnsubscriptionsController do
       end
 
       it "renders a confirmation page" do
-        token = encrypt_and_sign_token(data: { "subscription_id" => id })
+        token = encrypt_and_sign_token(data: { "subscriber_id" => subscriber_id })
         make_request(params: { id: id, token: token })
 
         expect(response.body).to include(

--- a/spec/controllers/unsubscriptions_controller_spec.rb
+++ b/spec/controllers/unsubscriptions_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe UnsubscriptionsController do
 
     context "when the user is signed in" do
       it "responds with a 200" do
-        get :confirm, params: { id: id }, session: session_for(id)
+        get :confirm, params: { id: id }, session: session_for(subscriber_id)
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Unsubscribe" do
   end
 
   def when_i_visit_the_unsubscribe_page
-    token = encrypt_and_sign_token(data: { "subscription_id" => @subscription_id })
+    token = encrypt_and_sign_token(data: { "subscriber_id" => @subscriber_id })
     visit confirm_unsubscribe_path(@subscription_id, token: token)
   end
 

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -32,7 +32,8 @@ RSpec.feature "Unsubscribe" do
   end
 
   def when_i_visit_the_unsubscribe_page
-    visit confirm_unsubscribe_path(@subscription_id)
+    token = encrypt_and_sign_token(data: { "subscription_id" => @subscription_id })
+    visit confirm_unsubscribe_path(@subscription_id, token: token)
   end
 
   def and_i_have_a_secret_sign_in_token


### PR DESCRIPTION
https://trello.com/c/sgJIkObA/662-authenticate-before-unsubscribing-from-digest-emails

Please see the commits for more details. Note that the approach
changes in the final commit, as I realised the original way had
a flaw in it. Hopefully the story is easy to follow, but I can
try to rewrite the branch if not.