### PR TITLE
Add Redis connection healthcheck

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ module EmailAlertFrontend
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # Add lib directory to autoload paths
+    config.autoload_paths += Dir[Rails.root.join("lib")]
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,5 +40,5 @@ Rails.application.routes.draw do
     get "/authenticate", to: redirect("/email/manage/authenticate")
   end
 
-  get "/healthcheck", to: GovukHealthcheck.rack_response
+  get "/healthcheck", to: GovukHealthcheck.rack_response(Healthchecks::RedisConnection)
 end

--- a/lib/healthchecks/redis_connection.rb
+++ b/lib/healthchecks/redis_connection.rb
@@ -1,0 +1,21 @@
+module Healthchecks
+  class RedisConnection
+    def name
+      :redis_connection
+    end
+
+    def status
+      client = Redis.new
+
+      client.set("healthcheck", "val")
+      client.get("healthcheck")
+      client.del("healthcheck")
+
+      client.close
+
+      GovukHealthcheck::OK
+    rescue StandardError
+      GovukHealthcheck::CRITICAL
+    end
+  end
+end

--- a/spec/lib/healthchecks/redis_connection_spec.rb
+++ b/spec/lib/healthchecks/redis_connection_spec.rb
@@ -1,0 +1,11 @@
+RSpec.describe Healthchecks::RedisConnection do
+  it "returns 'ok' status" do
+    expect(described_class.new.status).to eq(:ok)
+  end
+
+  it "returns 'critical' status if unable to connect to Redis" do
+    allow(Redis).to receive(:new).and_raise(Redis::CannotConnectError)
+
+    expect(described_class.new.status).to eq(:critical)
+  end
+end


### PR DESCRIPTION
This adds some added functionality to the healthcheck for
email-alert-frontend to enable CD.

As per the requirement for CD: 'It has a test that checks for
connectivity to any read/write dependencies'. The only DB
email-alert-frontend uses is Redis during [rate limiting]. Opening a
Redis connection and then adding, fetching and deleting a key value pair
before closing the collection seems a sufficient test for Redis
connectivity.

[rate limiting]: https://github.com/alphagov/email-alert-frontend/blob/a32156a677f3989623faf6953de6aa4c8e073e29/app/services/verify_subscriber_email_service.rb#L52