### PR TITLE
Add pull request template for email-alert-frontend

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


### PR DESCRIPTION
We will soon make email-alert-frontend continuously deployed so this
adds some guidance around the process to the PRs.

Dependant on:

- [x] https://github.com/alphagov/govuk-puppet/pull/10877