### PR TITLE
Record the origin of new content item-based lists

### DIFF
--- a/app/services/generate_subscriber_list_params_service.rb
+++ b/app/services/generate_subscriber_list_params_service.rb
@@ -7,6 +7,7 @@ class GenerateSubscriberListParamsService < ApplicationService
     {
       "title" => content_item["title"],
       "links" => link_hash,
+      "url" => content_item["base_path"],
     }
   end
 

--- a/spec/services/generate_subscriber_list_params_service_spec.rb
+++ b/spec/services/generate_subscriber_list_params_service_spec.rb
@@ -1,63 +1,67 @@
 RSpec.describe GenerateSubscriberListParamsService do
   describe ".call" do
     let(:content_item) do
-      { "title" => "Foo", "content_id" => "foo-id" }
+      { "title" => "Foo", "content_id" => "foo-id", "base_path" => "/foo" }
+    end
+
+    let(:list_params) do
+      { "title" => content_item["title"], "url" => content_item["base_path"] }
     end
 
     it "returns subscriber list params for taxons" do
       content_item.merge!("document_type" => "taxon")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "taxon_tree" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "taxon_tree" => %w[foo-id] }))
     end
 
     it "returns subscriber list params for organisations" do
       content_item.merge!("document_type" => "organisation")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "organisations" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "organisations" => %w[foo-id] }))
     end
 
     it "returns subscriber list params for people" do
       content_item.merge!("document_type" => "person")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "people" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "people" => %w[foo-id] }))
     end
 
     it "returns subscriber list params for ministerial roles" do
       content_item.merge!("document_type" => "ministerial_role")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "roles" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "roles" => %w[foo-id] }))
     end
 
     it "returns subscriber list params for topical events" do
       content_item.merge!("document_type" => "topical_event")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "topical_events" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "topical_events" => %w[foo-id] }))
     end
 
     it "returns subscriber list params for topics" do
       content_item.merge!("document_type" => "topic")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "topics" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "topics" => %w[foo-id] }))
     end
 
     it "returns subscriber list params for service manual topics" do
       content_item.merge!("document_type" => "service_manual_topic")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "service_manual_topics" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "service_manual_topics" => %w[foo-id] }))
     end
 
     it "returns subscriber list params for the service standard" do
       content_item.merge!("document_type" => "service_manual_service_standard")
 
       expect(described_class.call(content_item))
-        .to match("title" => "Foo", "links" => { "parent" => %w[foo-id] })
+        .to match(list_params.merge("links" => { "parent" => %w[foo-id] }))
     end
 
     it "raises an error when the document type is not supported" do


### PR DESCRIPTION
https://trello.com/c/3H67DU88/456-epic-record-the-origin-of-all-subscriber-lists-on-govuk

The URL property of subscriber lists was introduced to support the
Brexit Checker [1], but the functionality applies to all lists. We
think that recording these URLs will in future help us to determine
which lists are still "alive", by checking they refer to a live URL
on GOV.UK. This takes a step in that direction.

[1]: https://github.com/alphagov/finder-frontend/blob/2b565b6ccb6449d329dba00bb39d4d629a42c81a/app/controllers/brexit_checker_controller.rb#L189


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️