### PR TITLE
Replace list description with hard-coded text

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -37,10 +37,12 @@
         <p class='govuk-body'>
           <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
         </p>
-        <% if subscription['subscriber_list']['description'].present? %>
-          <%= render "govuk_publishing_components/components/govspeak", {} do %>
-            <%= raw(Kramdown::Document.new(subscription['subscriber_list']['description']).to_html) %>
-          <% end %>
+        <% if subscription['subscriber_list']['url'] =~ %r{transition-check/results} %>
+          <p class="govuk-body">
+            <%= link_to 'You can view a copy of your results on GOV.UK',
+                        subscription['subscriber_list']['url'],
+                        class: %w[govuk-link govuk-link--no-visited-state] %>
+          </p>
         <% end %>
         <p class="govuk-body">
           <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -20,10 +20,7 @@ RSpec.describe SubscriptionsManagementController do
         {
           "id" => subscription_id,
           "created_at" => "2019-09-16 02:08:08 01:00",
-          "subscriber_list" => {
-            "title" => "Some thing",
-            "description" => "[You can view a copy of your results on GOV.UK.](https://www.gov.uk/get-ready-brexit-check/results?c%5B%5D=automotive)",
-          },
+          "subscriber_list" => { "title" => "Some thing" },
         },
       ],
     )
@@ -51,8 +48,31 @@ RSpec.describe SubscriptionsManagementController do
         get :index, session: session
         expect(response.body).to include("Some thing")
         expect(response.body).to include("Created on 16 September 2019 at 2:08am")
+      end
+    end
+
+    context "when the subscription is for a brexit checker list" do
+      before do
+        stub_email_alert_api_has_subscriber_subscriptions(
+          subscriber_id,
+          subscriber_address,
+          subscriptions: [
+            {
+              "id" => subscription_id,
+              "created_at" => "2019-09-16 02:08:08 01:00",
+              "subscriber_list" => {
+                "title" => "Some thing",
+                "url" => "/transition-check/results?c%5B%5D=automotive",
+              },
+            },
+          ],
+        )
+      end
+
+      it "renders a link to the list URL" do
+        get :index, session: session
         expect(response.body).to include(
-          "<p><a href=\"https://www.gov.uk/get-ready-brexit-check/results?c%5B%5D=automotive\">You can view a copy of your results on GOV.UK.</a></p>",
+          "href=\"/transition-check/results?c%5B%5D=automotive\">You can view a copy of your results on GOV.UK</a>",
         )
       end
     end


### PR DESCRIPTION
https://trello.com/c/gbYVX8lK/690-send-users-a-link-to-their-results-as-part-of-subscribing-to-the-checker

Previously we relied on the list description being a markdown URL
for Brexit Checker results. However, we want to move away from a
freeform description in the API because:

- It's only used for Brexit Checker lists.
- It's freeform, so we can't track the links (in emails).
- The description is repetitive and inaccurate (really a URL).

This replaces the description with the same text, but hard-coded,
which makes it easier to replace, clearer in purpose, and (thus)
 easier to target for deletion in the future.

## Design (unchanged)

<img width="544" alt="Screenshot 2020-12-15 at 14 41 26" src="https://user-images.githubusercontent.com/9029009/102230011-48d02c00-3ee4-11eb-9f8a-1f686e1371ab.png">



⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️