### PR TITLE
Remove support for unused fields

### DIFF
--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -2,6 +2,7 @@ require "active_model"
 
 class EmailAlertSignup
   include ActiveModel::Model
+  include Rails.application.routes.url_helpers
 
   validates :signup_page, presence: true
 
@@ -14,7 +15,8 @@ class EmailAlertSignup
 
   def find_or_create
     if valid?
-      @subscription_url = find_or_create_subscription.dig("subscriber_list", "subscription_url")
+      slug = find_or_create_subscription.dig("subscriber_list", "slug")
+      @subscription_url = new_subscription_path(topic_id: slug)
       true
     else
       false

--- a/app/models/email_alert_signup.rb
+++ b/app/models/email_alert_signup.rb
@@ -34,20 +34,13 @@ class EmailAlertSignup
     signup_page["title"]
   end
 
-  def govdelivery_title
-    details["govdelivery_title"]
-  end
-
 private
 
   attr_reader :signup_page, :base_path
 
   def subscription_params
     subscriber_list = details["subscriber_list"]
-
-    subscription_params = {
-      title: govdelivery_title.presence || title,
-    }
+    subscription_params = { title: title }
 
     if subscriber_list["document_type"].present?
       subscription_params[:document_type] = subscriber_list["document_type"]

--- a/spec/features/email_alert_signup_spec.rb
+++ b/spec/features/email_alert_signup_spec.rb
@@ -23,17 +23,16 @@ RSpec.feature "Email alert signup" do
   end
 
   def and_i_click_to_signup_to_alerts
-    subscriber_list_id = SecureRandom.uuid
-    @subscriber_list_url = new_subscription_path(topic_id: subscriber_list_id)
+    @subscriber_list_id = SecureRandom.uuid
 
     stub_email_alert_api_has_subscriber_list(
       "tags" => @tags,
-      "id" => subscriber_list_id,
-      "subscription_url" => @subscriber_list_url,
+      "id" => @subscriber_list_id,
+      "slug" => @subscriber_list_id,
     )
 
     stub_email_alert_api_has_subscriber_list_by_slug(
-      slug: subscriber_list_id,
+      slug: @subscriber_list_id,
       returned_attributes: {
         "title" => @title,
       },
@@ -43,6 +42,7 @@ RSpec.feature "Email alert signup" do
   end
 
   def then_i_can_subscribe_to_alerts
-    expect(page).to have_current_path(@subscriber_list_url)
+    subscriber_list_url = new_subscription_path(topic_id: @subscriber_list_id)
+    expect(page).to have_current_path(subscriber_list_url)
   end
 end

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -3,7 +3,6 @@ RSpec.describe EmailAlertSignup do
   include GdsApi::TestHelpers::EmailAlertApi
 
   let(:api_client) { double(:api_client, find_or_create_subscriber_list: true) }
-  let(:policy_item) { govuk_content_schema_example("policy_email_alert_signup") }
   let(:travel_index_item) { govuk_content_schema_example("travel_advice_index_email_alert_signup") }
   let(:travel_country_item) { govuk_content_schema_example("travel_advice_country_email_alert_signup") }
 
@@ -69,45 +68,10 @@ RSpec.describe EmailAlertSignup do
         email_signup.find_or_create
       end
     end
-
-    context "when the signup page is for a policy" do
-      let(:signup_page) { mock_response(policy_item) }
-
-      it "sends the correct subscription params to the email alert api" do
-        expect(api_client).to receive(:find_or_create_subscriber_list)
-          .with(
-            "title" => "Employment policy",
-            "tags" => { "policies" => %w[employment] },
-          )
-          .and_return(mock_subscriber_list)
-
-        email_signup = EmailAlertSignup.new(signup_page)
-        email_signup.find_or_create
-      end
-    end
-
-    context "when the signup page doesn't have a govdelivery_title" do
-      let(:item_without_govdelivery_title) do
-        travel_index_item["title"] = "Some Title"
-        travel_index_item["details"]["govdelivery_title"] = ""
-        travel_index_item
-      end
-
-      let(:signup_page) { mock_response(item_without_govdelivery_title) }
-
-      it "falls back to using the content item's title" do
-        expect(api_client).to receive(:find_or_create_subscriber_list)
-          .with(hash_including("title" => "Some Title"))
-          .and_return(mock_subscriber_list)
-
-        email_signup = EmailAlertSignup.new(signup_page)
-        email_signup.find_or_create
-      end
-    end
   end
 
   describe "#subscription_url" do
-    let(:signup_page) { mock_response(policy_item) }
+    let(:signup_page) { mock_response(travel_country_item) }
 
     it "is the subscription_url returned by the API" do
       expect(api_client).to receive(:find_or_create_subscriber_list)

--- a/spec/models/email_alert_signup_spec.rb
+++ b/spec/models/email_alert_signup_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EmailAlertSignup do
   let(:travel_country_item) { govuk_content_schema_example("travel_advice_country_email_alert_signup") }
 
   let(:mock_subscriber_list) do
-    mock_response(subscriber_list: { subscription_url: "http://foo" })
+    mock_response(subscriber_list: { slug: "topic-id" })
   end
 
   before do
@@ -80,7 +80,8 @@ RSpec.describe EmailAlertSignup do
       email_signup = EmailAlertSignup.new(signup_page)
       email_signup.find_or_create
 
-      expect("http://foo").to eq(email_signup.subscription_url)
+      expect(email_signup.subscription_url)
+        .to eq("/email/subscriptions/new?topic_id=topic-id")
     end
   end
 end


### PR DESCRIPTION
This removes support for a couple of fields:

- govdelivery_title on email_alert_signup content items
- subscription_url for subscriber lists

In the former case, we can also update the schema to mark
this field as unused e.g. by removing it.

Please see the commits for more details.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️