### PR TITLE
Fix email signup feature to use realistic content

### DIFF
--- a/spec/features/email_alert_signup_spec.rb
+++ b/spec/features/email_alert_signup_spec.rb
@@ -10,11 +10,10 @@ RSpec.feature "Email alert signup" do
   end
 
   def given_there_is_a_signup_page
-    content_item = govuk_content_schema_example("policy_email_alert_signup")
-    @base_path = content_item["base_path"]
-    @tags = content_item["details"]["subscriber_list"]["tags"]
-    @title = content_item["title"]
-    stub_content_store_has_item(@base_path, content_item.to_json)
+    @content_item = govuk_content_schema_example("travel_advice_country_email_alert_signup")
+    @base_path = @content_item["base_path"]
+    @title = @content_item["title"]
+    stub_content_store_has_item(@base_path, @content_item.to_json)
   end
 
   def when_i_visit_the_signup_page
@@ -26,9 +25,10 @@ RSpec.feature "Email alert signup" do
     @subscriber_list_id = SecureRandom.uuid
 
     stub_email_alert_api_has_subscriber_list(
-      "tags" => @tags,
-      "id" => @subscriber_list_id,
-      "slug" => @subscriber_list_id,
+      @content_item["details"]["subscriber_list"].merge(
+        "id" => @subscriber_list_id,
+        "slug" => @subscriber_list_id,
+      ),
     )
 
     stub_email_alert_api_has_subscriber_list_by_slug(


### PR DESCRIPTION
Previously we switched to using travel advice content item examples
[1], as these are the only remaining users of the email_alert_signup
schema. Raising the PR to remove the "policy" examples from GOV.UK
Content Schemas [2] highlighted this usage as one that was missed.

[1]: https://github.com/alphagov/email-alert-frontend/pull/946/commits/f92828d8cbe6a8149566cee343c6738d5d2a4e04#diff-4caeb9a462fa907750b801ea20af71116356e3bc655b4cc7cd07a846cdde559fL6
[2]: https://github.com/alphagov/govuk-content-schemas/pull/1033


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️