### PR TITLE
Bump GDS API Adapters and fix test stubs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     ffi (1.13.1)
-    gds-api-adapters (67.2.1)
+    gds-api-adapters (68.0.0)
       addressable
       link_header
       null_logger

--- a/spec/controllers/subscription_authentication_controller_spec.rb
+++ b/spec/controllers/subscription_authentication_controller_spec.rb
@@ -17,10 +17,9 @@ RSpec.describe SubscriptionAuthenticationController do
         )
 
         stub_email_alert_api_creates_a_subscription(
-          123,
-          address,
-          params[:frequency],
-          nil,
+          subscriber_list_id: 123,
+          address: address,
+          frequency: params[:frequency],
         )
       end
 

--- a/spec/features/subscribe_opt_in_spec.rb
+++ b/spec/features/subscribe_opt_in_spec.rb
@@ -31,10 +31,9 @@ RSpec.feature "Subscribe opt-in" do
     )
 
     @request = stub_email_alert_api_creates_a_subscription(
-      @subscriber_list_id,
-      @address,
-      "immediately",
-      nil,
+      subscriber_list_id: @subscriber_list_id,
+      address: @address,
+      frequency: "immediately",
     )
 
     visit confirm_subscription_path(


### PR DESCRIPTION
https://trello.com/c/hdOrNhuC/669-sign-in-after-subscribing

This matches the new interface for the helper [1].

[1]: https://github.com/alphagov/gds-api-adapters/blob/4ad9b70a4e06b65268a8128a5b5842ffa461575a/lib/gds_api/test_helpers/email_alert_api.rb#L221-L228


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️