### PR TITLE
Fix not showing link to some checker results

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -37,7 +37,8 @@
         <p class='govuk-body'>
           <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
         </p>
-        <% if subscription['subscriber_list']['url'] =~ %r{transition-check/results} %>
+        <% if subscription['subscriber_list']['url'] =~ %r{transition-check/results} ||
+          subscription['subscriber_list']['url'] =~ %r{get-ready-brexit-check/results} %>
           <p class="govuk-body">
             <%= link_to 'You can view a copy of your results on GOV.UK',
                         subscription['subscriber_list']['url'],

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -51,29 +51,31 @@ RSpec.describe SubscriptionsManagementController do
       end
     end
 
-    context "when the subscription is for a brexit checker list" do
-      before do
-        stub_email_alert_api_has_subscriber_subscriptions(
-          subscriber_id,
-          subscriber_address,
-          subscriptions: [
-            {
-              "id" => subscription_id,
-              "created_at" => "2019-09-16 02:08:08 01:00",
-              "subscriber_list" => {
-                "title" => "Some thing",
-                "url" => "/transition-check/results?c%5B%5D=automotive",
+    %w[transition-check get-ready-brexit-check].each do |prefix|
+      context "when the subscription is for a #{prefix} list" do
+        before do
+          stub_email_alert_api_has_subscriber_subscriptions(
+            subscriber_id,
+            subscriber_address,
+            subscriptions: [
+              {
+                "id" => subscription_id,
+                "created_at" => "2019-09-16 02:08:08 01:00",
+                "subscriber_list" => {
+                  "title" => "Some thing",
+                  "url" => "/#{prefix}/results?c%5B%5D=automotive",
+                },
               },
-            },
-          ],
-        )
-      end
+            ],
+          )
+        end
 
-      it "renders a link to the list URL" do
-        get :index, session: session
-        expect(response.body).to include(
-          "href=\"/transition-check/results?c%5B%5D=automotive\">You can view a copy of your results on GOV.UK</a>",
-        )
+        it "renders a link to the list URL" do
+          get :index, session: session
+          expect(response.body).to include(
+            "href=\"/#{prefix}/results?c%5B%5D=automotive\">You can view a copy of your results on GOV.UK</a>",
+          )
+        end
       end
     end
 


### PR DESCRIPTION
Previously we adopted this hack in favour of manually specifying a
fake "description" for each subscriber list [1]. However, we forgot
that the URL for checker results has changed. This fixes the hack
to cope with both versions of the checker results URL.

[1]: 65f6e09


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️