### PR TITLE
Update copy for errors on signup

### DIFF
--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -8,7 +8,7 @@
         title: t('subscriptions.new_address.general_problem'),
         items: [
           {
-            text: t('subscriptions.new_address.email_validation'),
+            text: flash[:error],
             href: "#email-address-input",
           }
         ]

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -8,7 +8,7 @@
         title: t('subscriptions.new_frequency.general_problem'),
         items: [
           {
-            text: t('subscriptions.new_frequency.required_question'),
+            text: flash[:error],
             href: "#email-frequency-input",
           }
         ]

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -2,15 +2,13 @@ en:
   subscriptions:
     new_frequency:
       general_problem: "There is a problem"
-      required_question: "You must answer this question"
-      missing_frequency: "Select how often you want updates"
+      missing_frequency: "Choose how often you want to get emails"
       title: How often do you want to get emails?
       unsubscribe_html: Do you need to <a class="govuk-link" href="https://www.gov.uk/help/update-email-notifications">unsubscribe from GOV.UK emails</a>?
     new_address:
-      general_problem: "We weren’t able to process your subscription"
-      email_validation: "There’s a problem with your email address"
-      missing_email: "Please enter your email address."
-      invalid_email: "This doesn’t look like a valid email address – check you’ve entered it correctly."
+      general_problem: "There is a problem"
+      missing_email: "Enter your email address"
+      invalid_email: "Enter an email address in the correct format, like name@example.com"
       title: Enter your email address
     check_email:
       title: Check your email


### PR DESCRIPTION
https://trello.com/c/oYRFCtBm/668-iterate-error-content-and-behaviour-for-new-signup-workflow

This synchronises the copy shown in the flash message with that on
the radio buttons / input box.

## Before

<img width="744" alt="Screenshot 2021-01-13 at 15 42 43" src="https://user-images.githubusercontent.com/9029009/104474648-23534280-55b6-11eb-8f00-961dc2e0839e.png">
<img width="758" alt="Screenshot 2021-01-13 at 15 42 51" src="https://user-images.githubusercontent.com/9029009/104474654-23ebd900-55b6-11eb-8ee6-0e68a0db0d84.png">
<img width="736" alt="Screenshot 2021-01-13 at 15 43 04" src="https://user-images.githubusercontent.com/9029009/104474657-23ebd900-55b6-11eb-8fe3-7861d31080dd.png">

## After

<img width="764" alt="Screenshot 2021-01-13 at 15 42 03" src="https://user-images.githubusercontent.com/9029009/104474707-2ea66e00-55b6-11eb-8f75-f83b1185338e.png">
<img width="738" alt="Screenshot 2021-01-13 at 15 42 16" src="https://user-images.githubusercontent.com/9029009/104474708-2fd79b00-55b6-11eb-8c00-7e65cb2c30ee.png">
<img width="722" alt="Screenshot 2021-01-13 at 15 42 25" src="https://user-images.githubusercontent.com/9029009/104474712-30703180-55b6-11eb-9ab6-26cffd720823.png">



⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️