### PR TITLE
Require user to select taxon or a child taxon

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -11,7 +11,7 @@ class ContentItemSignupsController < ApplicationController
   before_action :assign_list_params
 
   def new
-    if is_taxon?(@content_item) && taxon_children(@content_item).any?
+    if is_taxon_with_children?(@content_item)
       render "taxon"
     else
       render "confirm"
@@ -19,11 +19,9 @@ class ContentItemSignupsController < ApplicationController
   end
 
   def confirm
-    if is_taxon?(@content_item) && taxon_children(@content_item).any?
-      if params[:topic].nil?
-        flash[:error] = t("content_item_signups.taxon.no_selection")
-        render "taxon"
-      end
+    if is_taxon_with_children?(@content_item) && params[:topic].nil?
+      flash[:error] = t("content_item_signups.taxon.no_selection")
+      render "taxon"
     end
   end
 

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -18,7 +18,14 @@ class ContentItemSignupsController < ApplicationController
     end
   end
 
-  def confirm; end
+  def confirm
+    if is_taxon?(@content_item) && taxon_children(@content_item).any?
+      if params[:topic].nil?
+        flash[:error] = t("content_item_signups.taxon.no_selection")
+        render "taxon"
+      end
+    end
+  end
 
   def create
     slug = GdsApi.email_alert_api
@@ -43,7 +50,7 @@ private
     # Topic param left in for backwards compatibility.
     # Topic is the user-facing terminology for taxons. Expect the taxon base
     # path to be provided in a param of this name.
-    content_item_path = params[:link] || params[:topic]
+    content_item_path = params[:topic] || params[:link]
 
     return bad_request unless content_item_path.to_s.starts_with?("/")
     return bad_request unless URI.parse(content_item_path).relative?

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -43,13 +43,11 @@ private
     destination_path = @content_item.dig("redirects", 0, "destination")
     return error_not_found if destination_path.nil?
 
-    redirect_to(new_content_item_signup_path(topic: destination_path))
+    redirect_to(new_content_item_signup_path(link: destination_path))
   end
 
   def assign_content_item
-    # Topic param left in for backwards compatibility.
-    # Topic is the user-facing terminology for taxons. Expect the taxon base
-    # path to be provided in a param of this name.
+    # Note: the "topic" param has historically appeared in external links
     content_item_path = params[:topic] || params[:link]
 
     return bad_request unless content_item_path.to_s.starts_with?("/")

--- a/app/helpers/taxons_helper.rb
+++ b/app/helpers/taxons_helper.rb
@@ -1,6 +1,7 @@
 module TaxonsHelper
-  def is_taxon?(content_item)
-    content_item["document_type"] == "taxon"
+  def is_taxon_with_children?(content_item)
+    content_item["document_type"] == "taxon" &&
+      taxon_children(content_item).any?
   end
 
   def taxon_children(content_item)

--- a/app/views/content_item_signups/taxon.html.erb
+++ b/app/views/content_item_signups/taxon.html.erb
@@ -3,6 +3,18 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+    <% if flash[:error] %>
+      <%= render "govuk_publishing_components/components/error_summary", {
+        title: t('content_item_signups.taxon.general_problem'),
+        items: [
+          {
+            text: flash[:error],
+            href: "#topic",
+          }
+        ]
+      } %>
+    <% end %>
+
     <h1 class="govuk-heading-l"><%= t("content_item_signups.taxon.title") %></h1>
 
     <%= form_tag({ action: :confirm },
@@ -22,15 +34,17 @@
       <%= render "govuk_publishing_components/components/radio", {
         name: "topic",
         id_prefix: "topic",
+        error_message: flash[:error],
         items: radio_items + [
           :or,
           {
             value: @content_item['base_path'],
             text: "#{@content_item['title']} (all topics)",
-            checked: true,
           }
         ]
       } %>
+
+      <%= hidden_field_tag "link", @content_item['base_path'] %>
 
       <%= render "govuk_publishing_components/components/button", {
         text: "Continue",

--- a/config/locales/content_item_signups.yml
+++ b/config/locales/content_item_signups.yml
@@ -5,3 +5,5 @@ en:
       description: "You’ll get emails when we add or update pages about:"
     taxon:
       title: What do you want to get emails about?
+      general_problem: There is a problem
+      no_selection: Select a topic

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe ContentItemSignupsController do
         redirects: [{ destination: "/cleaning/broomsticks" }],
       )
 
-      make_request(topic: "/magical/broomsticks")
-      expected_path = new_content_item_signup_path(topic: "/cleaning/broomsticks")
+      make_request(link: "/magical/broomsticks")
+      expected_path = new_content_item_signup_path(link: "/cleaning/broomsticks")
       expect(response).to redirect_to(expected_path)
     end
 
     it "returns a 404 if there is no destination path" do
       stub_content_store_has_item("/magical/broomsticks", document_type: "redirect")
-      make_request(topic: "/magical/broomsticks")
+      make_request(link: "/magical/broomsticks")
       expect(response).to have_http_status(:not_found)
     end
   end
@@ -31,10 +31,10 @@ RSpec.describe ContentItemSignupsController do
     end
 
     it "returns a 400 if the content item path is invalid" do
-      make_request(topic: "/with unencoded spaces")
+      make_request(link: "/with unencoded spaces")
       expect(response).to have_http_status(:bad_request)
 
-      make_request(topic: ["/a"])
+      make_request(link: ["/a"])
       expect(response).to have_http_status(:bad_request)
     end
 
@@ -43,7 +43,7 @@ RSpec.describe ContentItemSignupsController do
       url = content_store_endpoint + "/content#{base_path}"
       stub_request(:get, url).to_return(status: 400, headers: {})
 
-      make_request(topic: base_path)
+      make_request(link: base_path)
       expect(response).to have_http_status(:bad_request)
     end
 
@@ -52,19 +52,19 @@ RSpec.describe ContentItemSignupsController do
       url = content_store_endpoint + "/content#{base_path}"
       stub_request(:get, url).to_return(status: 403, headers: {})
 
-      make_request(topic: base_path)
+      make_request(link: base_path)
       expect(response).to have_http_status(:forbidden)
     end
 
     it "returns a 404 if the content item is not found" do
       stub_content_store_does_not_have_item("/education/some-rando-item")
-      make_request(topic: "/education/some-rando-item")
+      make_request(link: "/education/some-rando-item")
       expect(response).to have_http_status(:not_found)
     end
 
     it "returns a 410 if the content item is unpublished" do
       stub_content_store_has_gone_item("/taxon-is-gone")
-      make_request(topic: "/taxon-is-gone")
+      make_request(link: "/taxon-is-gone")
       expect(response).to have_http_status(:gone)
     end
   end
@@ -72,7 +72,7 @@ RSpec.describe ContentItemSignupsController do
   shared_examples "limited to certain types" do
     it "returns a 400 if the content item is not supported" do
       stub_content_store_has_item("/cma-cases", document_type: "finder")
-      make_request(topic: "/cma-cases")
+      make_request(link: "/cma-cases")
       expect(response).to have_http_status(:bad_request)
     end
   end
@@ -84,7 +84,7 @@ RSpec.describe ContentItemSignupsController do
 
     it "shows a page to confirm the subscription" do
       stub_content_store_has_item("/organisation", document_type: "organisation")
-      make_request(topic: "/organisation")
+      make_request(link: "/organisation")
       expect(response.body).to include(I18n.t!("content_item_signups.confirm.title"))
     end
 
@@ -93,7 +93,7 @@ RSpec.describe ContentItemSignupsController do
                                   document_type: "taxon",
                                   links: { "child_taxons" => %w[child-taxon] })
 
-      make_request(topic: "/my-taxon")
+      make_request(link: "/my-taxon")
       expect(response.body).to include(I18n.t!("content_item_signups.taxon.title"))
     end
 
@@ -138,7 +138,7 @@ RSpec.describe ContentItemSignupsController do
       stub_email_alert_api_does_not_have_subscriber_list("links" => { organisations: [content_id] })
       stub_email_alert_api_creates_subscriber_list("links" => { organisations: [content_id] }, "slug" => "my-list")
 
-      make_request(topic: "/my-organisation")
+      make_request(link: "/my-organisation")
       expect(response).to redirect_to new_subscription_path(topic_id: "my-list")
     end
 
@@ -148,7 +148,7 @@ RSpec.describe ContentItemSignupsController do
 
       stub_email_alert_api_has_subscriber_list("links" => { organisations: [content_id] }, "slug" => "my-list")
 
-      make_request(topic: "/my-organisation")
+      make_request(link: "/my-organisation")
       expect(response).to redirect_to new_subscription_path(topic_id: "my-list")
     end
   end

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -107,6 +107,16 @@ RSpec.describe ContentItemSignupsController do
       get :confirm, params: params
     end
 
+    it "shows an error if a taxon is not selected" do
+      stub_content_store_has_item("/my-taxon",
+                                  document_type: "taxon",
+                                  links: { "child_taxons" => %w[child-taxon] })
+
+      make_request(link: "/my-taxon")
+      expect(response.body).to include(I18n.t!("content_item_signups.taxon.title"))
+      expect(response.body).to include(I18n.t!("content_item_signups.taxon.no_selection"))
+    end
+
     it_behaves_like "proxy to content store"
     it_behaves_like "router for redirects"
     it_behaves_like "limited to certain types"

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -2,6 +2,8 @@ RSpec.describe ContentItemSignupsController do
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::EmailAlertApi
 
+  render_views
+
   shared_examples "router for redirects" do
     it "follows a redirect for an unpublished content item" do
       stub_content_store_has_item(
@@ -78,6 +80,21 @@ RSpec.describe ContentItemSignupsController do
   describe "#new" do
     def make_request(params)
       get :new, params: params
+    end
+
+    it "shows a page to confirm the subscription" do
+      stub_content_store_has_item("/organisation", document_type: "organisation")
+      make_request(topic: "/organisation")
+      expect(response.body).to include(I18n.t!("content_item_signups.confirm.title"))
+    end
+
+    it "shows a special page for taxons with children" do
+      stub_content_store_has_item("/my-taxon",
+                                  document_type: "taxon",
+                                  links: { "child_taxons" => %w[child-taxon] })
+
+      make_request(topic: "/my-taxon")
+      expect(response.body).to include(I18n.t!("content_item_signups.taxon.title"))
     end
 
     it_behaves_like "proxy to content store"

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature "Content item signup" do
   def given_there_is_a_topic
     @links_type = "taxon_tree"
     @content_item = {
+      content_id: SecureRandom.uuid,
       base_path: "/education/further-education",
       title: "Further education",
       document_type: "taxon",
@@ -34,6 +35,7 @@ RSpec.feature "Content item signup" do
   def given_there_is_an_organisation
     @links_type = "organisations"
     @content_item = {
+      content_id: SecureRandom.uuid,
       title: "Organisation",
       base_path: "/my-organisation",
       document_type: "organisation",

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Content item signup" do
   end
 
   def when_i_visit_the_signup_page
-    visit new_content_item_signup_path(topic: @content_item[:base_path])
+    visit new_content_item_signup_path(link: @content_item[:base_path])
     expect(page).to have_content(@content_item[:title])
   end
 

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Content item signup" do
   end
 
   def and_i_refine_my_selection
-    expect(page).to have_checked_field("topic-2")
+    expect(page).to_not have_checked_field
     expect(page).to have_content(@content_item.dig(:links, :child_taxons).first[:title])
 
     choose @content_item[:title]


### PR DESCRIPTION
https://trello.com/c/oYRFCtBm/668-iterate-error-content-and-behaviour-for-new-signup-workflow

This also starts to move towards using the "link" query param for email
signup. Please see the commits for more details.

## After

<img width="521" alt="Screenshot 2021-01-14 at 10 52 38" src="https://user-images.githubusercontent.com/9029009/104581550-a4faad00-5656-11eb-82e8-3e359c0bb583.png">


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️