### PR TITLE
Update to heading component

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ In order to verify the email for a new subscription:
 
 This allows the user to list, modify and delete their subscriptions [[login](https://www.gov.uk/email/manage/authenticate)]. It uses a similar, but separate email/token process to authenticate a user, establishing a session for them to make their changes.
 
+### Testing 
+
+Some pages are only accessible from a link sent in an email. The documentation on [receiving emails from Email Alert API in Integration and Staging](https://docs.publishing.service.gov.uk/manual/receiving-emails-from-email-alert-api-in-integration-and-staging.html) will show how to send emails so these pages can be viewed.
+
 ## Nomenclature
 
 ### Tags and links
 
-Uniquely define a list people can subscribe to. The criteria within are used to figure out whether an update is relevant subscribers in the list. Defined in [the docs for email-alert-api](https://github.com/alphagov/email-alert-api/blob/master/doc/matching-content-to-subscriber-lists.md).
+Uniquely define a list people can subscribe to. The criteria within are used to figure out whether an update is relevant subscribers in the list. Defined in [the docs for email-alert-api](https://docs.publishing.service.gov.uk/apps/email-alert-api/matching-content-to-subscriber-lists.html).
 
 ```
 tags: { topics: { any: ["business-tax/vat"] } }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/feedback";
 @import "govuk_publishing_components/components/fieldset";
 @import "govuk_publishing_components/components/govspeak";
+@import "govuk_publishing_components/components/heading";
 @import "govuk_publishing_components/components/hint";
 @import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/inset-text";

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -3,7 +3,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l"><%= t("content_item_signups.confirm.title") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("content_item_signups.confirm.title"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6
+    } %>
 
     <p class="govuk-body">
       <%= t("content_item_signups.confirm.description") %>

--- a/app/views/content_item_signups/taxon.html.erb
+++ b/app/views/content_item_signups/taxon.html.erb
@@ -15,7 +15,12 @@
       } %>
     <% end %>
 
-    <h1 class="govuk-heading-l"><%= t("content_item_signups.taxon.title") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("content_item_signups.taxon.title"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <%= form_tag({ action: :confirm },
                  method: "get",

--- a/app/views/email_alert_signups/new.html.erb
+++ b/app/views/email_alert_signups/new.html.erb
@@ -3,7 +3,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l"><%= t("email_alert_signups.new.title") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("email_alert_signups.new.title"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <p class="govuk-body">
       <%= t("email_alert_signups.new.description") %>

--- a/app/views/subscriber_authentication/request_sign_in_token.html.erb
+++ b/app/views/subscriber_authentication/request_sign_in_token.html.erb
@@ -2,7 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("subscriber_authentication.request_sign_in_token.heading") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriber_authentication.request_sign_in_token.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.confirmation", address: @address) %></p>
     <p class="govuk-body"><%= t("subscriber_authentication.request_sign_in_token.prompt") %></p>

--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -3,7 +3,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("subscriber_authentication.heading") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriber_authentication.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <% if flash[:error_summary] == "email" %>
       <%= render 'govuk_publishing_components/components/error_summary', {

--- a/app/views/subscriptions/check_email.html.erb
+++ b/app/views/subscriptions/check_email.html.erb
@@ -2,7 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("subscriptions.check_email.title") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriptions.check_email.title"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <p class="govuk-body">
       <%= t("subscriptions.check_email.description_html", address: @address) %>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -15,8 +15,13 @@
       } %>
     <% end %>
 
-    <h1 class="govuk-heading-l"><%= t("subscriptions.new_address.title") %></h1>
-
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriptions.new_address.title"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+  
     <%= form_tag verify_subscription_path, method: :post, novalidate: "novalidate" do %>
       <%= hidden_field_tag :topic_id, @topic_id %>
       <%= hidden_field_tag :frequency, @frequency %>

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -8,7 +8,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("subscriptions_management.confirm_unsubscribe_all.heading") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriptions_management.confirm_unsubscribe_all.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <p class="govuk-body"><%= t("subscriptions_management.confirm_unsubscribe_all.description") %></p>
 

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -26,11 +26,20 @@
       <% end %>
     <% end %>
 
-    <h1 class="govuk-heading-l"><%= t("subscriptions_management.heading") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriptions_management.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
-    <h2 class="govuk-heading-m">
-      <%= "Subscriptions for #{@subscriber['address']}" %>
-    </h2>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Subscriptions for #{@subscriber['address']}",
+      heading_level: 2,
+      font_size: "m",
+      margin_bottom: 4,
+    } %>
+
     <p class="govuk-body">
       <%= link_to "Change email address",
                   update_address_path,
@@ -48,9 +57,13 @@
       </p>
     <% else %>
       <% @subscriptions.each do |_key, subscription| %>
-        <h3 class="govuk-heading-s">
-          <%= subscription['subscriber_list']['title'] %>
-        </h3>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: subscription['subscriber_list']['title'],
+          heading_level: 3,
+          font_size: "s",
+          margin_bottom: 4
+        } %>
+
         <p class='govuk-body'>
           <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
         </p>

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -8,7 +8,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("subscriptions_management.update_address.heading") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriptions_management.update_address.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <% if flash[:error] %>
       <%= render 'govuk_publishing_components/components/error_summary', {

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -9,7 +9,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("subscriptions_management.heading") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriptions_management.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <%= form_tag change_frequency_path, method: :post do %>
       <%= hidden_field_tag :id, @subscription_id %>

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -10,7 +10,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("unsubscriptions.title.confirm") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("unsubscriptions.title.confirm"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <%= render "confirmation" %>
 

--- a/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
+++ b/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
@@ -14,7 +14,12 @@ content_for :title, page_title
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= page_title %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: page_title,
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <%= render "confirmation" %>
   </div>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -2,7 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t("unsubscriptions.title.confirmed") %></h1>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("unsubscriptions.title.confirmed"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
 
     <%= render "confirmation" %>
   </div>


### PR DESCRIPTION
## What?

Updating headings to use [component gem](https://components.publishing.service.gov.uk/component-guide/heading)

## Why?

As part of on-going work to update Frontend apps inline with component gem architecture, improves a11y, consistency & allows changes to be cascaded across all apps. ([ticket](https://trello.com/c/JlKrHDdn))

## Visuals 

No visual changes, Design maintained.

Example links impacted:
https://www.gov.uk/email-signup/confirm?topic=%2Fmoney%2Fexpenses-employee-benefits
https://www.gov.uk/foreign-travel-advice/canada/email-signup
https://www.gov.uk/email/subscriptions/verify
https://www.gov.uk/email/manage
https://www.gov.uk/email/manage/authenticate
https://www.gov.uk/email/manage/unsubscribe-all
https://www.gov.uk/email/manage/address

## Anything else?

`README` broken link updated + link to docs explaining how to receive test emails.

---

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
