### PR TITLE
Update title of manage subscriptions page

### DIFF
--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -1,6 +1,6 @@
 en:
   subscriptions_management:
-    heading: Manage your subscriptions
+    heading: Change your email preferences
     index:
       subscription:
         immediately: "You get updates as soon as they happen."


### PR DESCRIPTION
https://trello.com/c/l2cC0fY4/678-update-sign-in-journey-email-screens-to-match-design

This is to be consistent with the CTA used prior to logging in.

Before | After
-------|-----
<img width="590" alt="Screenshot 2021-01-26 at 15 59 24" src="https://user-images.githubusercontent.com/9029009/105869962-b39a7a00-5fef-11eb-9b09-fd3d3df862e5.png"> | <img width="656" alt="Screenshot 2021-01-26 at 15 59 09" src="https://user-images.githubusercontent.com/9029009/105870227-f78d7f00-5fef-11eb-846b-9d4d00d1ccdb.png"> |

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️