### PR TITLE
Switch from trackClick to gemTrackClick script

### DIFF
--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -24,7 +24,7 @@
         text: 'Continue',
         margin_bottom: true,
         data_attributes: {
-          module: 'track-click',
+          module: 'gem-track-click',
           track_category: 'email_subscriptions',
           track_action: 'new_frequency',
           track_label: @content_item['title'],

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -39,7 +39,7 @@
         text: "Continue",
         margin_bottom: true,
         data_attributes: {
-          module: 'track-click',
+          module: 'gem-track-click',
           track_category: 'email_subscriptions',
           track_action: 'new_email_confirm',
           track_label: "#{@topic_id} #{@frequency}",


### PR DESCRIPTION
### What

Switch from using `trackClick` script to `gemTrackClick` script. They are virtually the same, the latter being [copied over from `static` to `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/pull/1751).

### Why

Part of [a bigger piece of work](https://github.com/alphagov/static/pull/2405) to reduce the size of assets served to users and keep our codebase to a minimum.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
