### PR TITLE
Use `heading_level` param instead of `is_page_heading` (radio component)

### DIFF
--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -28,7 +28,7 @@
         name: "frequency",
         id: "email-frequency-input",
         heading: t("subscriptions.new_frequency.title"),
-        is_page_heading: true,
+        heading_level: 1,
         heading_size: "l",
         error_message: flash[:error],
         items: frequencies


### PR DESCRIPTION
 ~🙅🏻‍♀️ Do not merge, depends on alphagov/govuk_publishing_components#2051 🙅🏻‍♀️~
(now up to date with the latest gem changes)

The email frequency page uses a [radio component](https://components.publishing.service.gov.uk/component-guide/radio) with the `is_page_heading` parameter. 
Changes are being made to remove the `is_page_heading` parameter, and achieve the same result using `heading_level` and/or `heading_size` instead. The reasons behind this are described in more detail in this [issue](https://github.com/alphagov/govuk_publishing_components/issues/1953).


This swaps `is_page_heading` for `heading_level` 1.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
