### PR TITLE
Fix 'find out how to subscribe' link

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -53,7 +53,7 @@
       <p class="govuk-body">
         You aren’t subscribed to any topics on GOV.UK.
         <%= link_to "Find out how to subscribe",
-                    "help/get-emails-about-updates-to-govuk",
+                    "/help/get-emails-about-updates-to-govuk",
                     class: "govuk-link" %>.
       </p>
     <% else %>


### PR DESCRIPTION
### What
This relative link is presented on a page that resides on `/email/manage` and returns a 404 (resolving in `/email/help/get-emails-about-updates-to-govuk` so we make it absolute to fix the issue.

### Why
Flagged by users while on 2nd line

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
