### PR TITLE
Add a controller method to authenticate a user by GOV.UK Account

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "rails", "6.0.3.4"
 
 gem "gds-api-adapters"
 gem "govuk_app_config"
+gem "govuk_personalisation"
 gem "govuk_publishing_components"
 gem "jwt"
 gem "plek"
@@ -13,6 +14,7 @@ gem "slimmer"
 gem "uglifier"
 
 group :development, :test do
+  gem "climate_control"
   gem "govuk_test"
   gem "jasmine"
   gem "jasmine_selenium_runner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (1.0.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crack (0.4.3)
@@ -109,6 +110,8 @@ GEM
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
+    govuk_personalisation (0.5.0)
+      rails (~> 6)
     govuk_publishing_components (24.15.3)
       govuk_app_config
       kramdown
@@ -352,8 +355,10 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  climate_control
   gds-api-adapters
   govuk_app_config
+  govuk_personalisation
   govuk_publishing_components
   govuk_schemas
   govuk_test

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -1,4 +1,5 @@
 class SubscriberAuthenticationController < ApplicationController
+  include GovukPersonalisation::AccountConcern
   include SessionsHelper
 
   def sign_in
@@ -30,6 +31,29 @@ class SubscriberAuthenticationController < ApplicationController
 
     authenticate_subscriber(token.data[:subscriber_id])
     redirect_to list_subscriptions_path
+  end
+
+  def process_govuk_account
+    head :not_found and return unless ENV["FEATURE_FLAG_GOVUK_ACCOUNT"] == "enabled"
+
+    api_response = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(govuk_account_session: account_session_header)
+    set_account_session_header(api_response["govuk_account_session"])
+    authenticate_subscriber(api_response.dig("subscriber", "id"))
+    redirect_to list_subscriptions_path
+  rescue GdsApi::HTTPUnauthorized
+    deauthenticate_subscriber
+    logout!
+    uri = GdsApi.account_api.get_sign_in_url(redirect_path: process_govuk_account_path)["auth_uri"]
+    uri += "&_ga=#{params[:_ga]}" if params[:_ga]
+    redirect_to uri
+  rescue GdsApi::HTTPForbidden => e
+    deauthenticate_subscriber
+    set_account_session_header(JSON.parse(e.http_body)["govuk_account_session"])
+    render plain: "This GOV.UK account does not have a verified email address."
+  rescue GdsApi::HTTPNotFound => e
+    deauthenticate_subscriber
+    set_account_session_header(JSON.parse(e.http_body)["govuk_account_session"])
+    render plain: "This GOV.UK account does not have a notifications account."
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       get "/authenticate" => "subscriber_authentication#sign_in", as: :sign_in
       post "/authenticate" => "subscriber_authentication#verify", as: :verify_subscriber
       get "/authenticate/process" => "subscriber_authentication#process_sign_in_token", as: :process_sign_in_token
+      get "/authenticate/account" => "subscriber_authentication#process_govuk_account", as: :process_govuk_account
     end
 
     scope "/subscriptions" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 require "webmock/rspec"
 require "slimmer/rspec"
+require "gds_api/test_helpers/account_api"
 require "gds_api/test_helpers/email_alert_api"
 
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
We added a new endpoint to email-alert-api to authenticate a user by
GOV.UK Account, returning the subscriber details if the email address
is verified and matches a subscriber.  This commit makes the
corresponding change on the email-alert-frontend side, exposing that
feature to users.

This is not complete, we still need to solve some design issues, like:

- What do we show in the error cases?

- Do we prompt a user to explicitly "link" the accounts, rather than
just sign them in?

- Do we forbid users from changing their notifications email address
if it's linked to an account?  Would it be confusing if the addresses
get out of sync?

So for now it's hidden behind a feature flag.

See also https://github.com/alphagov/email-alert-api/pull/1638

---

[Trello card](https://trello.com/c/H0gos8kf/873-backend-work-to-allow-logging-in-to-email-alert-frontend-with-an-account)
