### PR TITLE
Remove case where a user has a GOV.UK Account but no Subscriber

### DIFF
--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -47,10 +47,6 @@ class SubscriberAuthenticationController < ApplicationController
     deauthenticate_subscriber
     set_account_session_header(JSON.parse(e.http_body)["govuk_account_session"])
     render plain: "This GOV.UK account does not have a verified email address."
-  rescue GdsApi::HTTPNotFound => e
-    deauthenticate_subscriber
-    set_account_session_header(JSON.parse(e.http_body)["govuk_account_session"])
-    render plain: "This GOV.UK account does not have a notifications account."
   end
 
 private

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -243,31 +243,6 @@ RSpec.describe SubscriberAuthenticationController do
           end
         end
       end
-
-      context "when there is no matching subscriber" do
-        before do
-          stub_email_alert_api_authenticate_subscriber_by_govuk_account_no_subscriber(session_id, new_govuk_account_session: new_session_id)
-        end
-
-        it "renders an error response" do
-          get :process_govuk_account
-          expect(response.body).to eq("This GOV.UK account does not have a notifications account.")
-        end
-
-        it "clears any existing session" do
-          get :process_govuk_account, session: session_for(subscriber_id)
-          expect(session.to_h).to_not include(session_for(subscriber_id))
-        end
-
-        context "when email-alert-api returns a new session ID" do
-          let(:new_session_id) { "new-session-id" }
-
-          it "includes a new session ID in the response headers" do
-            get :process_govuk_account
-            expect(response.headers["GOVUK-Account-Session"]).to eq(new_session_id)
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
We're now having email-alert-api create a new Subscriber if a user
logs in via their GOV.UK Account and they haven't used Notifications
before.

See also https://github.com/alphagov/email-alert-api/pull/1643

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)
