### PR TITLE
Various frontend changes for accounts

### DIFF
--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -51,6 +51,8 @@ class SubscriberAuthenticationController < ApplicationController
     render :confirm_your_govuk_account
   end
 
+private
+
   helper_method def confirm_govuk_account_url
     ENV.fetch("GOVUK_ACCOUNT_CONFIRM_EMAIL_URL")
   end
@@ -58,8 +60,6 @@ class SubscriberAuthenticationController < ApplicationController
   helper_method def govuk_account_auth_enabled?
     ENV["FEATURE_FLAG_GOVUK_ACCOUNT"] == "enabled"
   end
-
-private
 
   def token
     @token ||= AuthToken.new(params.require(:token))

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -39,7 +39,7 @@ class SubscriberAuthenticationController < ApplicationController
     head :not_found and return unless govuk_account_auth_enabled?
     reauthenticate_govuk_account and return if account_session_header.blank?
 
-    api_response = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(govuk_account_session: account_session_header)
+    api_response = GdsApi.email_alert_api.link_subscriber_to_govuk_account(govuk_account_session: account_session_header)
     set_account_session_header(api_response["govuk_account_session"])
     authenticate_subscriber(api_response.dig("subscriber", "id"), linked_to_govuk_account: true)
     redirect_to list_subscriptions_path

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -15,6 +15,8 @@ class SubscriberAuthenticationController < ApplicationController
     @address = params.require(:address)
     VerifySubscriberEmailService.call(@address)
     render :check_email
+  rescue GdsApi::HTTPForbidden
+    render :use_your_govuk_account
   rescue GdsApi::HTTPUnprocessableEntity
     flash.now[:error] = :invalid_email
     render :sign_in

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -36,7 +36,7 @@ class SubscriberAuthenticationController < ApplicationController
   end
 
   def process_govuk_account
-    head :not_found and return unless ENV["FEATURE_FLAG_GOVUK_ACCOUNT"] == "enabled"
+    head :not_found and return unless govuk_account_auth_enabled?
     reauthenticate_govuk_account and return if account_session_header.blank?
 
     api_response = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(govuk_account_session: account_session_header)
@@ -49,6 +49,10 @@ class SubscriberAuthenticationController < ApplicationController
     deauthenticate_subscriber
     set_account_session_header(JSON.parse(e.http_body)["govuk_account_session"])
     render plain: "This GOV.UK account does not have a verified email address."
+  end
+
+  helper_method def govuk_account_auth_enabled?
+    ENV["FEATURE_FLAG_GOVUK_ACCOUNT"] == "enabled"
   end
 
 private

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -48,7 +48,11 @@ class SubscriberAuthenticationController < ApplicationController
   rescue GdsApi::HTTPForbidden => e
     deauthenticate_subscriber
     set_account_session_header(JSON.parse(e.http_body)["govuk_account_session"])
-    render plain: "This GOV.UK account does not have a verified email address."
+    render :confirm_your_govuk_account
+  end
+
+  helper_method def confirm_govuk_account_url
+    ENV.fetch("GOVUK_ACCOUNT_CONFIRM_EMAIL_URL")
   end
 
   helper_method def govuk_account_auth_enabled?

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -41,7 +41,7 @@ class SubscriberAuthenticationController < ApplicationController
 
     api_response = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(govuk_account_session: account_session_header)
     set_account_session_header(api_response["govuk_account_session"])
-    authenticate_subscriber(api_response.dig("subscriber", "id"))
+    authenticate_subscriber(api_response.dig("subscriber", "id"), linked_to_govuk_account: true)
     redirect_to list_subscriptions_path
   rescue GdsApi::HTTPUnauthorized
     reauthenticate_govuk_account

--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -1,6 +1,7 @@
 class SubscriptionsManagementController < ApplicationController
   before_action :require_authentication
   before_action :get_subscription_details
+  before_action :set_account_change_email_url
   before_action :set_back_url
 
   def index; end
@@ -36,10 +37,14 @@ class SubscriptionsManagementController < ApplicationController
   end
 
   def update_address
+    redirect_to @account_change_email_url and return if @account_change_email_url
+
     @address = @subscriber["address"]
   end
 
   def change_address
+    redirect_to @account_change_email_url and return if @account_change_email_url
+
     @address = @subscriber["address"]
 
     if params[:new_address].blank?
@@ -81,6 +86,12 @@ class SubscriptionsManagementController < ApplicationController
   end
 
 private
+
+  def set_account_change_email_url
+    if session.dig("authentication", "linked_to_govuk_account")
+      @account_change_email_url = ENV.fetch("GOVUK_ACCOUNT_CHANGE_EMAIL_URL")
+    end
+  end
 
   def get_subscription_details
     subscription_details = GdsApi.email_alert_api.get_subscriptions(

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,7 +1,8 @@
 module SessionsHelper
-  def authenticate_subscriber(subscriber_id)
+  def authenticate_subscriber(subscriber_id, linked_to_govuk_account: false)
     session["authentication"] = {
       "subscriber_id" => subscriber_id,
+      "linked_to_govuk_account" => linked_to_govuk_account,
     }
   end
 

--- a/app/views/subscriber_authentication/confirm_your_govuk_account.html.erb
+++ b/app/views/subscriber_authentication/confirm_your_govuk_account.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, t("subscriber_authentication.confirm_your_govuk_account.heading") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriber_authentication.confirm_your_govuk_account.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+
+    <div class="govuk-body">
+      <%= t("subscriber_authentication.confirm_your_govuk_account.description_html", address: @address, confirm_govuk_account_url: confirm_govuk_account_url) %>
+    </div>
+  </div>
+</div>

--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -19,6 +19,17 @@
       } %>
     <% end %>
 
+    <% if govuk_account_auth_enabled? %>
+      <%= t("subscriber_authentication.sign_in.account_description_html", process_govuk_account_path: process_govuk_account_path) %>
+
+      <%= render "govuk_publishing_components/components/heading", {
+        text: t("subscriber_authentication.sign_in.account_unlinked_heading"),
+        heading_level: 2,
+        font_size: "m",
+        margin_bottom: 3,
+      } %>
+    <% end %>
+
     <p class="govuk-body"><%= t("subscriber_authentication.sign_in.description") %></p>
 
     <%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate"  do %>

--- a/app/views/subscriber_authentication/use_your_govuk_account.html.erb
+++ b/app/views/subscriber_authentication/use_your_govuk_account.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, t("subscriber_authentication.use_your_govuk_account.heading") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("subscriber_authentication.use_your_govuk_account.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+
+    <div class="govuk-body">
+      <%= t("subscriber_authentication.use_your_govuk_account.description_html", address: @address, process_govuk_account_path: process_govuk_account_path) %>
+    </div>
+  </div>
+</div>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -43,7 +43,7 @@
 
     <p class="govuk-body">
       <%= link_to "Change email address",
-                  update_address_path,
+                  @account_change_email_url || update_address_path,
                   class: %w[govuk-link govuk-link--no-visited-state] %>
     </p>
 

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -37,3 +37,9 @@ en:
         <p class="govuk-body">You’ve set up a GOV.UK account for <strong>%{address}</strong></p>
         <p class="govuk-body">You now need to use your email address and password to manage your notifications.</p>
         <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="%{process_govuk_account_path}">Sign in to your account</a>.</p>
+    confirm_your_govuk_account:
+      heading: "You must confirm your GOV.UK account to continue"
+      description_html: |
+        <p class="govuk-body">You’ve set up a GOV.UK account for <strong>%{address}</strong></p>
+        <p class="govuk-body">Before you can manage your notifications, you need to confirm the email address for that account.</p>
+        <p class="govuk-body">If you haven’t received the confirmation email, you can <a class="govuk-link govuk-link--no-visited-state" href="%{confirm_govuk_account_url}">request another one</a>.</p>

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -4,6 +4,10 @@ en:
       heading: Change your email preferences
       description: For security, we need you to confirm your email address.
       email_input: Email address
+      account_description_html: |
+        <p class="govuk-body">We’ve introduced GOV.UK accounts as a new way to manage your notifications.</p>
+        <p class="govuk-body">If you’ve set up a GOV.UK account, you need to <a class="govuk-link govuk-link--no-visited-state" href="%{process_govuk_account_path}">sign in</a>.</p>
+      account_unlinked_heading: "I don’t have a GOV.UK account"
       missing_email:
         title: There is a problem
         description: "Enter your email address"

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -27,3 +27,9 @@ en:
         <p>Emails sometimes take a few minutes to arrive.</p>
         <p>If you do not receive an email soon, check your spam or junk folder.</p>
         <p>If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/contact/govuk">contact GOV.UK</a> for help.</p>
+    use_your_govuk_account:
+      heading: "Sign in with your GOV.UK account"
+      description_html: |
+        <p class="govuk-body">You’ve set up a GOV.UK account for <strong>%{address}</strong></p>
+        <p class="govuk-body">You now need to use your email address and password to manage your notifications.</p>
+        <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="%{process_govuk_account_path}">Sign in to your account</a>.</p>

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe SubscriberAuthenticationController do
       end
     end
 
+    context "when the email address is linked to a GOV.UK Account" do
+      before do
+        stub_email_alert_api_subscriber_verification_email_linked_to_govuk_account
+      end
+
+      it "renders an error message" do
+        post :verify, params: { address: subscriber_address }
+        expect(response.body).to include(I18n.t!("subscriber_authentication.use_your_govuk_account.heading"))
+      end
+    end
+
     context "when a valid address is provided and the subscriber doesn't exist" do
       before do
         stub_email_alert_api_subscriber_verification_email_no_subscriber

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe SubscriberAuthenticationController do
       end
 
       before do
-        stub_email_alert_api_authenticate_subscriber_by_govuk_account(session_id, subscriber_id, subscriber_address, new_govuk_account_session: new_session_id)
+        stub_email_alert_api_link_subscriber_to_govuk_account(session_id, subscriber_id, subscriber_address, new_govuk_account_session: new_session_id)
       end
 
       let(:new_session_id) { nil }
@@ -226,7 +226,7 @@ RSpec.describe SubscriberAuthenticationController do
 
       context "when the user's session is invalid" do
         before do
-          stub_email_alert_api_authenticate_subscriber_by_govuk_account_session_invalid(session_id)
+          stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
           stub_account_api_get_sign_in_url(redirect_path: "/email/manage/authenticate/account", auth_uri: auth_uri)
         end
 
@@ -250,7 +250,7 @@ RSpec.describe SubscriberAuthenticationController do
 
       context "when the account email address is unverified" do
         before do
-          stub_email_alert_api_authenticate_subscriber_by_govuk_account_email_unverified(session_id, new_govuk_account_session: new_session_id)
+          stub_email_alert_api_link_subscriber_to_govuk_account_email_unverified(session_id, new_govuk_account_session: new_session_id)
         end
 
         it "renders an error response" do

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -249,13 +249,19 @@ RSpec.describe SubscriberAuthenticationController do
       end
 
       context "when the account email address is unverified" do
+        around do |example|
+          ClimateControl.modify GOVUK_ACCOUNT_CONFIRM_EMAIL_URL: "https://www.gov.uk" do
+            example.run
+          end
+        end
+
         before do
           stub_email_alert_api_link_subscriber_to_govuk_account_email_unverified(session_id, new_govuk_account_session: new_session_id)
         end
 
         it "renders an error response" do
           get :process_govuk_account
-          expect(response.body).to eq("This GOV.UK account does not have a verified email address.")
+          expect(response.body).to include(I18n.t!("subscriber_authentication.confirm_your_govuk_account.heading"))
         end
 
         it "clears any existing session" do

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe SubscriberAuthenticationController do
 
       it "creates a session for the subscriber" do
         get :process_govuk_account
-        expect(session.to_h).to include(session_for(subscriber_id))
+        expect(session.to_h).to include(session_for(subscriber_id, linked_to_govuk_account: true))
       end
 
       it "sets the Vary response header" do

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -22,6 +22,24 @@ RSpec.describe SubscriberAuthenticationController do
         get :sign_in
         expect(response.body).to include(%(action="#{verify_subscriber_path}"))
       end
+
+      it "doesn't mention the GOV.UK Account" do
+        get :sign_in
+        expect(response.body).not_to include(I18n.t!("subscriber_authentication.sign_in.account_unlinked_heading"))
+      end
+
+      context "when the accounts feature flag is enabled" do
+        around do |example|
+          ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+            example.run
+          end
+        end
+
+        it "mentions the GOV.UK Account" do
+          get :sign_in
+          expect(response.body).to include(I18n.t!("subscriber_authentication.sign_in.account_unlinked_heading"))
+        end
+      end
     end
   end
 

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -1,8 +1,9 @@
 module SessionHelper
-  def session_for(subscriber_id)
+  def session_for(subscriber_id, linked_to_govuk_account: false)
     {
       "authentication": {
         "subscriber_id": subscriber_id,
+        "linked_to_govuk_account": linked_to_govuk_account,
       },
     }.with_indifferent_access
   end


### PR DESCRIPTION
Various frontend changes for account-based email management.  None of these words or screens have been reviewed by a designer, this is just so we can get something working up on staging (it's behind the feature flag) and then iterate.

---

[Trello card](https://trello.com/c/Vzd8so2T/874-implement-designs-for-managing-your-email-notifications-via-the-account)