### PR TITLE
Update link styles and swap to `gem_layout`

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,4 @@
-$govuk-typography-use-rem: false;
-$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
@@ -19,10 +18,3 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/title';
-
-.govuk-link,
-.govuk-back-link {
-  &:focus {
-    @include govuk-template-link-focus-override;
-  }
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,12 +19,6 @@ $govuk-use-legacy-palette: false;
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/title';
 
-.app-email-option {
-  @include govuk-font(24, $line-height: 1.5);
-  margin-top: govuk-spacing(3);
-  margin-bottom: govuk-spacing(3);
-}
-
 .govuk-link,
 .govuk-back-link {
   &:focus {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 $govuk-typography-use-rem: false;
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';

--- a/app/assets/stylesheets/mixins/_govuk-template-link-focus-override.scss
+++ b/app/assets/stylesheets/mixins/_govuk-template-link-focus-override.scss
@@ -1,9 +1,0 @@
-// TODO: Remove when appropriate
-// govuk_template overrides the styles set by
-// govuk-frontend 3.0.0. This mixin is intended as a temporary fix
-// to ensure focus styles are as expected in apps using govuk_template
-
-@mixin govuk-template-link-focus-override {
-  @include govuk-focused-text;
-  color: govuk-colour("black") !important; // stylelint-disable-line declaration-no-important
-}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,8 @@ class ApplicationController < ActionController::Base
     session["authentication"].present?
   end
 
+  slimmer_template :gem_layout
+
 private
 
   def set_cache_control_header

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,6 @@
           <%= yield %>
         </div>
       </main>
-      <%= render 'govuk_publishing_components/components/feedback' %>
     </div>
     <%= javascript_include_tag 'application' %>
   </body>


### PR DESCRIPTION
### What
Update link styles and swap to `gem_layout`

### Why
For consistency across frontend applications.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
