### PR TITLE
Account layout for email management pages

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/components/input';
 @import 'govuk_publishing_components/components/inset-text';
 @import 'govuk_publishing_components/components/label';
+@import 'govuk_publishing_components/components/phase-banner';
 @import 'govuk_publishing_components/components/radio';
 @import 'govuk_publishing_components/components/success-alert';
 @import 'govuk_publishing_components/components/title';

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :authenticated?
 
+  helper_method :use_govuk_account_layout?
+
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),
@@ -24,6 +26,10 @@ class ApplicationController < ActionController::Base
 
   def authenticated?
     session["authentication"].present?
+  end
+
+  def use_govuk_account_layout?
+    false
   end
 
   slimmer_template :gem_layout

--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -1,8 +1,11 @@
 class SubscriptionsManagementController < ApplicationController
+  include Slimmer::Headers
+  include Slimmer::Template
   before_action :require_authentication
   before_action :get_subscription_details
   before_action :set_account_change_email_url
   before_action :set_back_url
+  before_action :use_govuk_account_layout?
 
   def index; end
 
@@ -83,6 +86,13 @@ class SubscriptionsManagementController < ApplicationController
       nil
     end
     redirect_to list_subscriptions_path
+  end
+
+  helper_method def use_govuk_account_layout?
+    if session.dig("authentication", "linked_to_govuk_account")
+      set_slimmer_headers(template: "gem_layout_account_manager", remove_search: true, show_accounts: "signed-in")
+      true
+    end
   end
 
 private

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -1,35 +1,31 @@
 <% content_for :title, t("content_item_signups.confirm.title") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("content_item_signups.confirm.title"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("content_item_signups.confirm.title"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6
+} %>
 
-    <p class="govuk-body">
-      <%= t("content_item_signups.confirm.description") %>
-    </p>
+<p class="govuk-body">
+  <%= t("content_item_signups.confirm.description") %>
+</p>
 
-    <p class="govuk-body govuk-!-margin-bottom-8">
-      <strong><%= @content_item['title'] %></strong>
-    </p>
+<p class="govuk-body govuk-!-margin-bottom-8">
+  <strong><%= @content_item['title'] %></strong>
+</p>
 
-    <%= form_tag(action: :create) do %>
-      <%= hidden_field_tag 'link', @content_item['base_path'] %>
-      <%= render 'govuk_publishing_components/components/button', {
-        text: 'Continue',
-        margin_bottom: true,
-        data_attributes: {
-          module: 'gem-track-click',
-          track_category: 'email_subscriptions',
-          track_action: 'new_frequency',
-          track_label: @content_item['title'],
-        },
-      } %>
-    <% end %>
-  </div>
-</div>
+<%= form_tag(action: :create) do %>
+  <%= hidden_field_tag 'link', @content_item['base_path'] %>
+  <%= render 'govuk_publishing_components/components/button', {
+    text: 'Continue',
+    margin_bottom: true,
+    data_attributes: {
+      module: 'gem-track-click',
+      track_category: 'email_subscriptions',
+      track_action: 'new_frequency',
+      track_label: @content_item['title'],
+    },
+  } %>
+<% end %>

--- a/app/views/content_item_signups/taxon.html.erb
+++ b/app/views/content_item_signups/taxon.html.erb
@@ -1,60 +1,55 @@
 <% content_for :title, t("content_item_signups.taxon.title") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<% if flash[:error] %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: t('content_item_signups.taxon.general_problem'),
+    items: [
+      {
+        text: flash[:error],
+        href: "#topic",
+      }
+    ]
+  } %>
+<% end %>
 
-    <% if flash[:error] %>
-      <%= render "govuk_publishing_components/components/error_summary", {
-        title: t('content_item_signups.taxon.general_problem'),
-        items: [
-          {
-            text: flash[:error],
-            href: "#topic",
-          }
-        ]
-      } %>
-    <% end %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("content_item_signups.taxon.title"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("content_item_signups.taxon.title"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= form_tag({ action: :confirm },
+             method: "get",
+             data: {
+               module: "track-email-alert-signup-choices",
+               track_action: "new_topic",
+               track_category: "email_subscriptions",
+             }) do %>
 
-    <%= form_tag({ action: :confirm },
-                 method: "get",
-                 data: {
-                   module: "track-email-alert-signup-choices",
-                   track_action: "new_topic",
-                   track_category: "email_subscriptions",
-                 }) do %>
+  <%
+     radio_items = taxon_children(@content_item).map do |taxon|
+       { :value => taxon['base_path'], :text => taxon['title'] }
+     end
+  %>
 
-      <%
-         radio_items = taxon_children(@content_item).map do |taxon|
-           { :value => taxon['base_path'], :text => taxon['title'] }
-         end
-      %>
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "topic",
+    id_prefix: "topic",
+    error_message: flash[:error],
+    items: radio_items + [
+      :or,
+      {
+        value: @content_item['base_path'],
+        text: "#{@content_item['title']} (all topics)",
+      }
+    ]
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "topic",
-        id_prefix: "topic",
-        error_message: flash[:error],
-        items: radio_items + [
-          :or,
-          {
-            value: @content_item['base_path'],
-            text: "#{@content_item['title']} (all topics)",
-          }
-        ]
-      } %>
+  <%= hidden_field_tag "link", @content_item['base_path'] %>
 
-      <%= hidden_field_tag "link", @content_item['base_path'] %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Continue",
-        margin_bottom: true
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Continue",
+    margin_bottom: true
+  } %>
+<% end %>

--- a/app/views/email_alert_signups/new.html.erb
+++ b/app/views/email_alert_signups/new.html.erb
@@ -1,28 +1,23 @@
 <% content_for :title, t("email_alert_signups.new.title") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("email_alert_signups.new.title"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("email_alert_signups.new.title"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<p class="govuk-body">
+  <%= t("email_alert_signups.new.description") %>
+</p>
 
-    <p class="govuk-body">
-      <%= t("email_alert_signups.new.description") %>
-    </p>
+<p class="govuk-body govuk-!-margin-bottom-8">
+  <strong><%= email_alert_signup.title %></strong>
+</p>
 
-    <p class="govuk-body govuk-!-margin-bottom-8">
-      <strong><%= email_alert_signup.title %></strong>
-    </p>
-
-    <%= form_tag(action: :create) do %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Continue",
-        margin_bottom: true,
-      } %>
-    <% end %>
-  </div>
-</div>
+<%= form_tag(action: :create) do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Continue",
+    margin_bottom: true,
+  } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,12 +14,26 @@
   </head>
   <body class="govuk-template__body">
     <div class="govuk-width-container" id="wrapper">
-      <%= yield :back_link %>
-      <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" role="main" id="content">
-        <div id="email-alert-frontend">
+      <% if use_govuk_account_layout? %>
+        <% content_for :before_content do %>
+          <%= yield :back_link %>
+        <% end %>
+        <%= yield :before_content %>
+        <main role="main" id="content">
           <%= yield %>
-        </div>
-      </main>
+        </main>
+      <% else %>
+        <%= yield :back_link %>
+        <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" role="main" id="content">
+          <div id="email-alert-frontend">
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-two-thirds">
+                <%= yield %>
+              </div>
+            </div>
+          </div>
+        </main>
+      <% end %>
     </div>
     <%= javascript_include_tag 'application' %>
   </body>

--- a/app/views/subscriber_authentication/check_email.html.erb
+++ b/app/views/subscriber_authentication/check_email.html.erb
@@ -1,21 +1,17 @@
 <% content_for :title, t("subscriber_authentication.check_email.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriber_authentication.check_email.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriber_authentication.check_email.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <div class="govuk-body">
-      <%= t("subscriber_authentication.check_email.description_html", address: @address) %>
-    </div>
-
-    <%= render("govuk_publishing_components/components/details",
-               title: t("subscriber_authentication.check_email.delay_title")) do %>
-      <%= t("subscriber_authentication.check_email.delay_html") %>
-    <% end %>
-  </div>
+<div class="govuk-body">
+  <%= t("subscriber_authentication.check_email.description_html", address: @address) %>
 </div>
+
+<%= render("govuk_publishing_components/components/details",
+           title: t("subscriber_authentication.check_email.delay_title")) do %>
+  <%= t("subscriber_authentication.check_email.delay_html") %>
+<% end %>

--- a/app/views/subscriber_authentication/confirm_your_govuk_account.html.erb
+++ b/app/views/subscriber_authentication/confirm_your_govuk_account.html.erb
@@ -1,16 +1,12 @@
 <% content_for :title, t("subscriber_authentication.confirm_your_govuk_account.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriber_authentication.confirm_your_govuk_account.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriber_authentication.confirm_your_govuk_account.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <div class="govuk-body">
-      <%= t("subscriber_authentication.confirm_your_govuk_account.description_html", address: @address, confirm_govuk_account_url: confirm_govuk_account_url) %>
-    </div>
-  </div>
+<div class="govuk-body">
+  <%= t("subscriber_authentication.confirm_your_govuk_account.description_html", address: @address, confirm_govuk_account_url: confirm_govuk_account_url) %>
 </div>

--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -1,57 +1,53 @@
 <% content_for :title, t("subscriber_authentication.sign_in.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriber_authentication.sign_in.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriber_authentication.sign_in.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <% if flash[:error] %>
-      <%= render 'govuk_publishing_components/components/error_summary', {
-        title: t("subscriber_authentication.sign_in.#{flash[:error]}.title"),
-        items: [{
-          text: t("subscriber_authentication.sign_in.#{flash[:error]}.description"),
-          href: '#email-address-input'
-        }]
-      } %>
-    <% end %>
+<% if flash[:error] %>
+  <%= render 'govuk_publishing_components/components/error_summary', {
+    title: t("subscriber_authentication.sign_in.#{flash[:error]}.title"),
+    items: [{
+      text: t("subscriber_authentication.sign_in.#{flash[:error]}.description"),
+      href: '#email-address-input'
+    }]
+  } %>
+<% end %>
 
-    <% if govuk_account_auth_enabled? %>
-      <%= t("subscriber_authentication.sign_in.account_description_html", process_govuk_account_path: process_govuk_account_path) %>
+<% if govuk_account_auth_enabled? %>
+  <%= t("subscriber_authentication.sign_in.account_description_html", process_govuk_account_path: process_govuk_account_path) %>
 
-      <%= render "govuk_publishing_components/components/heading", {
-        text: t("subscriber_authentication.sign_in.account_unlinked_heading"),
-        heading_level: 2,
-        font_size: "m",
-        margin_bottom: 3,
-      } %>
-    <% end %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("subscriber_authentication.sign_in.account_unlinked_heading"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 3,
+  } %>
+<% end %>
 
-    <p class="govuk-body"><%= t("subscriber_authentication.sign_in.description") %></p>
+<p class="govuk-body"><%= t("subscriber_authentication.sign_in.description") %></p>
 
-    <%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate"  do %>
-      <%= render 'govuk_publishing_components/components/input', {
-        error_message: flash[:error] &&
-          t("subscriber_authentication.sign_in.#{flash[:error]}.message"),
-        id: 'email-address-input',
-        label: { text: t("subscriber_authentication.sign_in.email_input") },
-        name: :address,
-        type: 'email',
-        value: @address,
-      } %>
+<%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate"  do %>
+  <%= render 'govuk_publishing_components/components/input', {
+    error_message: flash[:error] &&
+      t("subscriber_authentication.sign_in.#{flash[:error]}.message"),
+    id: 'email-address-input',
+    label: { text: t("subscriber_authentication.sign_in.email_input") },
+    name: :address,
+    type: 'email',
+    value: @address,
+  } %>
 
-      <%= render 'govuk_publishing_components/components/button', {
-        text: 'Continue',
-        margin_bottom: true,
-        data_attributes: {
-          module: 'auto-track-event',
-          track_category: 'email_subscriptions',
-          track_action: 'authenticate',
-        },
-      } %>
-    <%- end -%>
-  </div>
-</div>
+  <%= render 'govuk_publishing_components/components/button', {
+    text: 'Continue',
+    margin_bottom: true,
+    data_attributes: {
+      module: 'auto-track-event',
+      track_category: 'email_subscriptions',
+      track_action: 'authenticate',
+    },
+  } %>
+<%- end -%>

--- a/app/views/subscriber_authentication/use_your_govuk_account.html.erb
+++ b/app/views/subscriber_authentication/use_your_govuk_account.html.erb
@@ -1,16 +1,12 @@
 <% content_for :title, t("subscriber_authentication.use_your_govuk_account.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriber_authentication.use_your_govuk_account.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriber_authentication.use_your_govuk_account.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <div class="govuk-body">
-      <%= t("subscriber_authentication.use_your_govuk_account.description_html", address: @address, process_govuk_account_path: process_govuk_account_path) %>
-    </div>
-  </div>
+<div class="govuk-body">
+  <%= t("subscriber_authentication.use_your_govuk_account.description_html", address: @address, process_govuk_account_path: process_govuk_account_path) %>
 </div>

--- a/app/views/subscription_authentication/expired.html.erb
+++ b/app/views/subscription_authentication/expired.html.erb
@@ -1,15 +1,10 @@
 <% content_for :title, t("subscription_authentication.expired.title") %>
 <% content_for :meta_description, t("subscription_authentication.expired.description") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<%= render "govuk_publishing_components/components/title", {
+  title: t("subscription_authentication.expired.title")
+} %>
 
-    <%= render "govuk_publishing_components/components/title", {
-      title: t("subscription_authentication.expired.title")
-    } %>
-
-    <p class="govuk-body">
-      <%= t("subscription_authentication.expired.description") %>
-    </p>
-  </div>
-</div>
+<p class="govuk-body">
+  <%= t("subscription_authentication.expired.description") %>
+</p>

--- a/app/views/subscriptions/check_email.html.erb
+++ b/app/views/subscriptions/check_email.html.erb
@@ -1,34 +1,30 @@
 <% content_for :title, t("subscriptions.check_email.title") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriptions.check_email.title"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriptions.check_email.title"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <p class="govuk-body">
-      <%= t("subscriptions.check_email.description_html", address: @address) %>
-    </p>
+<p class="govuk-body">
+  <%= t("subscriptions.check_email.description_html", address: @address) %>
+</p>
 
-    <p class="govuk-body">
-      <%= t("subscriptions.check_email.instruction") %>
-    </p>
+<p class="govuk-body">
+  <%= t("subscriptions.check_email.instruction") %>
+</p>
 
-    <p class="govuk-body">
-      <strong><%= @subscriber_list["title"] %></strong>
-    </p>
+<p class="govuk-body">
+  <strong><%= @subscriber_list["title"] %></strong>
+</p>
 
-    <p class="govuk-body">
-      <%= t("subscriptions.check_email.expiry") %>
-    </p>
+<p class="govuk-body">
+  <%= t("subscriptions.check_email.expiry") %>
+</p>
 
-    <%= render "govuk_publishing_components/components/details", {
-      title: t("subscriptions.check_email.not_received_title"),
-    } do %>
-      <%= t("subscriptions.check_email.not_received_detail_html") %>
-    <% end %>
-  </div>
-</div>
+<%= render "govuk_publishing_components/components/details", {
+  title: t("subscriptions.check_email.not_received_title"),
+} do %>
+  <%= t("subscriptions.check_email.not_received_detail_html") %>
+<% end %>

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -1,50 +1,45 @@
 <% content_for :title, t("subscriptions.new_address.title") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<% if flash[:error] %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: t('subscriptions.new_address.general_problem'),
+    items: [
+      {
+        text: flash[:error],
+        href: "#email-address-input",
+      }
+    ]
+  } %>
+<% end %>
 
-    <% if flash[:error] %>
-      <%= render "govuk_publishing_components/components/error_summary", {
-        title: t('subscriptions.new_address.general_problem'),
-        items: [
-          {
-            text: flash[:error],
-            href: "#email-address-input",
-          }
-        ]
-      } %>
-    <% end %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriptions.new_address.title"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriptions.new_address.title"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
-  
-    <%= form_tag verify_subscription_path, method: :post, novalidate: "novalidate" do %>
-      <%= hidden_field_tag :topic_id, @topic_id %>
-      <%= hidden_field_tag :frequency, @frequency %>
+<%= form_tag verify_subscription_path, method: :post, novalidate: "novalidate" do %>
+  <%= hidden_field_tag :topic_id, @topic_id %>
+  <%= hidden_field_tag :frequency, @frequency %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        error_message: flash[:error],
-        id: "email-address-input",
-        name: :address,
-        type: "email",
-        value: @address,
-        autocomplete: "email",
-      } %>
+  <%= render "govuk_publishing_components/components/input", {
+    error_message: flash[:error],
+    id: "email-address-input",
+    name: :address,
+    type: "email",
+    value: @address,
+    autocomplete: "email",
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Continue",
-        margin_bottom: true,
-        data_attributes: {
-          module: 'gem-track-click',
-          track_category: 'email_subscriptions',
-          track_action: 'new_email_confirm',
-          track_label: "#{@topic_id} #{@frequency}",
-        },
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Continue",
+    margin_bottom: true,
+    data_attributes: {
+      module: 'gem-track-click',
+      track_category: 'email_subscriptions',
+      track_action: 'new_email_confirm',
+      track_label: "#{@topic_id} #{@frequency}",
+    },
+  } %>
+<% end %>

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -1,47 +1,42 @@
 <% content_for :title, t("subscriptions.new_frequency.title") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+<% if flash[:error] %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: t('subscriptions.new_frequency.general_problem'),
+    items: [
+      {
+        text: flash[:error],
+        href: "#email-frequency-input",
+      }
+    ]
+  } %>
+<% end %>
 
-  <% if flash[:error] %>
-      <%= render "govuk_publishing_components/components/error_summary", {
-        title: t('subscriptions.new_frequency.general_problem'),
-        items: [
-          {
-            text: flash[:error],
-            href: "#email-frequency-input",
-          }
-        ]
-      } %>
-    <% end %>
+<%= form_tag(subscription_frequency_path,
+  class: "checklist-email-signup",
+  data: {
+    module: "track-email-alert-signup-choices",
+    track_category: "email_subscriptions",
+    track_action: 'new_address',
+  }) do %>
+  <%= hidden_field_tag :topic_id, @topic_id %>
 
-    <%= form_tag(subscription_frequency_path,
-      class: "checklist-email-signup",
-      data: {
-        module: "track-email-alert-signup-choices",
-        track_category: "email_subscriptions",
-        track_action: 'new_address',
-      }) do %>
-      <%= hidden_field_tag :topic_id, @topic_id %>
+  <%= render "govuk_publishing_components/components/radio", {
+    name: "frequency",
+    id: "email-frequency-input",
+    heading: t("subscriptions.new_frequency.title"),
+    heading_level: 1,
+    heading_size: "l",
+    error_message: flash[:error],
+    items: frequencies
+  } %>
 
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "frequency",
-        id: "email-frequency-input",
-        heading: t("subscriptions.new_frequency.title"),
-        heading_level: 1,
-        heading_size: "l",
-        error_message: flash[:error],
-        items: frequencies
-      } %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Continue",
+    margin_bottom: true
+  } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Continue",
-        margin_bottom: true
-      } %>
-
-      <p class="govuk-body">
-        <%= t("subscriptions.new_frequency.unsubscribe_html") %>
-      </p>
-    <% end %>
-  </div>
-</div>
+  <p class="govuk-body">
+    <%= t("subscriptions.new_frequency.unsubscribe_html") %>
+  </p>
+<% end %>

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -6,31 +6,27 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriptions_management.confirm_unsubscribe_all.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriptions_management.confirm_unsubscribe_all.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <p class="govuk-body"><%= t("subscriptions_management.confirm_unsubscribe_all.description") %></p>
+<p class="govuk-body"><%= t("subscriptions_management.confirm_unsubscribe_all.description") %></p>
 
-    <%= form_tag(action: :confirmed_unsubscribe_all) do %>
-      <%= hidden_field_tag(:from, @from) %>
-      <%= render 'govuk_publishing_components/components/button', {
-        text: 'Unsubscribe',
-        margin_bottom: true,
-        data_attributes: {
-          module: 'auto-track-event',
-          track_category: 'email_subscriptions',
-          track_action: 'unsubscribe_all',
-        },
-      } %>
-    <% end %>
-    <p class="govuk-body">
-      <%= link_to "Cancel", @back_url, class: %w[govuk-link govuk-link--no-visited-state] %>
-    </p>
-  </div>
-</div>
+<%= form_tag(action: :confirmed_unsubscribe_all) do %>
+  <%= hidden_field_tag(:from, @from) %>
+  <%= render 'govuk_publishing_components/components/button', {
+    text: 'Unsubscribe',
+    margin_bottom: true,
+    data_attributes: {
+      module: 'auto-track-event',
+      track_category: 'email_subscriptions',
+      track_action: 'unsubscribe_all',
+    },
+  } %>
+<% end %>
+<p class="govuk-body">
+  <%= link_to "Cancel", @back_url, class: %w[govuk-link govuk-link--no-visited-state] %>
+</p>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -1,107 +1,103 @@
 <% content_for :title, t("subscriptions_management.heading") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if flash[:success] %>
-      <%= render 'govuk_publishing_components/components/success_alert', {
-        message: flash[:success]["message"],
-        description: flash[:success]["description"],
-      } %>
+<% if flash[:success] %>
+  <%= render 'govuk_publishing_components/components/success_alert', {
+    message: flash[:success]["message"],
+    description: flash[:success]["description"],
+  } %>
+<% end %>
+
+<% if flash[:subscription] %>
+  <% subscription = @subscriptions[flash[:subscription]['id']] %>
+
+  <% if subscription %>
+    <% description = capture do %>
+      <p class="govuk-body">
+        <%= t("subscriptions_management.index.flashes.subscription.#{subscription['frequency']}") %>
+      </p>
+      <p><strong><%= subscription['subscriber_list']['title'] %></strong></p>
     <% end %>
 
-    <% if flash[:subscription] %>
-      <% subscription = @subscriptions[flash[:subscription]['id']] %>
+    <%= render 'govuk_publishing_components/components/success_alert', {
+      message: flash[:subscription]['message'],
+      description: description
+    } %>
+  <% end %>
+<% end %>
 
-      <% if subscription %>
-        <% description = capture do %>
-          <p class="govuk-body">
-            <%= t("subscriptions_management.index.flashes.subscription.#{subscription['frequency']}") %>
-          </p>
-          <p><strong><%= subscription['subscriber_list']['title'] %></strong></p>
-        <% end %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriptions_management.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-        <%= render 'govuk_publishing_components/components/success_alert', {
-          message: flash[:subscription]['message'],
-          description: description
-        } %>
-      <% end %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Subscriptions for #{@subscriber['address']}",
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 4,
+} %>
+
+<p class="govuk-body">
+  <%= link_to "Change email address",
+              @account_change_email_url || update_address_path,
+              class: %w[govuk-link govuk-link--no-visited-state] %>
+</p>
+
+<hr class="govuk-section-break govuk-section-break--l">
+
+<% if @subscriptions.empty? %>
+  <p class="govuk-body">
+    You aren’t subscribed to any topics on GOV.UK.
+    <%= link_to "Find out how to subscribe",
+                "/help/get-emails-about-updates-to-govuk",
+                class: "govuk-link" %>.
+  </p>
+<% else %>
+  <% @subscriptions.each do |_key, subscription| %>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: subscription['subscriber_list']['title'],
+      heading_level: 3,
+      font_size: "s",
+      margin_bottom: 4
+    } %>
+
+    <p class='govuk-body'>
+      <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
+    </p>
+    <% if subscription['subscriber_list']['url'] =~ %r{transition-check/results} ||
+      subscription['subscriber_list']['url'] =~ %r{get-ready-brexit-check/results} %>
+      <p class="govuk-body">
+        <%= link_to 'You can view a copy of your results on GOV.UK',
+                    subscription['subscriber_list']['url'],
+                    class: %w[govuk-link govuk-link--no-visited-state] %>
+      </p>
     <% end %>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriptions_management.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
-
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Subscriptions for #{@subscriber['address']}",
-      heading_level: 2,
-      font_size: "m",
-      margin_bottom: 4,
-    } %>
-
     <p class="govuk-body">
-      <%= link_to "Change email address",
-                  @account_change_email_url || update_address_path,
+      <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
+      <br>
+      <%= link_to "Change how often you get updates",
+                  update_frequency_path(id: subscription['id']),
                   class: %w[govuk-link govuk-link--no-visited-state] %>
     </p>
+    <p class="govuk-body">
+      <%= link_to "Unsubscribe",
+                  confirm_unsubscribe_path(id: subscription['id']),
+                  class: %w[govuk-link govuk-link--no-visited-state] %>
+    </p>
+    <hr class="govuk-section-break govuk-section-break--m">
+  <% end %>
 
-    <hr class="govuk-section-break govuk-section-break--l">
+  <% unsubscribe_all_text = capture do %>
+    <p class="govuk-body">
+      <%= link_to "Unsubscribe from everything",
+                  confirm_unsubscribe_all_path,
+                  class: %w[govuk-link govuk-link--no-visited-state] %>
+    </p>
+  <% end %>
 
-    <% if @subscriptions.empty? %>
-      <p class="govuk-body">
-        You aren’t subscribed to any topics on GOV.UK.
-        <%= link_to "Find out how to subscribe",
-                    "/help/get-emails-about-updates-to-govuk",
-                    class: "govuk-link" %>.
-      </p>
-    <% else %>
-      <% @subscriptions.each do |_key, subscription| %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: subscription['subscriber_list']['title'],
-          heading_level: 3,
-          font_size: "s",
-          margin_bottom: 4
-        } %>
-
-        <p class='govuk-body'>
-          <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
-        </p>
-        <% if subscription['subscriber_list']['url'] =~ %r{transition-check/results} ||
-          subscription['subscriber_list']['url'] =~ %r{get-ready-brexit-check/results} %>
-          <p class="govuk-body">
-            <%= link_to 'You can view a copy of your results on GOV.UK',
-                        subscription['subscriber_list']['url'],
-                        class: %w[govuk-link govuk-link--no-visited-state] %>
-          </p>
-        <% end %>
-        <p class="govuk-body">
-          <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
-          <br>
-          <%= link_to "Change how often you get updates",
-                      update_frequency_path(id: subscription['id']),
-                      class: %w[govuk-link govuk-link--no-visited-state] %>
-        </p>
-        <p class="govuk-body">
-          <%= link_to "Unsubscribe",
-                      confirm_unsubscribe_path(id: subscription['id']),
-                      class: %w[govuk-link govuk-link--no-visited-state] %>
-        </p>
-        <hr class="govuk-section-break govuk-section-break--m">
-      <% end %>
-
-      <% unsubscribe_all_text = capture do %>
-        <p class="govuk-body">
-          <%= link_to "Unsubscribe from everything",
-                      confirm_unsubscribe_all_path,
-                      class: %w[govuk-link govuk-link--no-visited-state] %>
-        </p>
-      <% end %>
-
-      <%= render "govuk_publishing_components/components/inset_text", {
-        text: unsubscribe_all_text
-      } %>
-    <% end %>
-  </div>
-</div>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: unsubscribe_all_text
+  } %>
+<% end %>

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -6,60 +6,56 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriptions_management.update_address.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriptions_management.update_address.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <% if flash[:error] %>
-      <%= render 'govuk_publishing_components/components/error_summary', {
-        title: t("subscriptions_management.update_address.error_title"),
-        items: [
-          {
-            text: t("subscriptions_management.update_address.error_description"),
-            href: '#email-address-input',
-          }
-        ]
-      } %>
-    <% end %>
+<% if flash[:error] %>
+  <%= render 'govuk_publishing_components/components/error_summary', {
+    title: t("subscriptions_management.update_address.error_title"),
+    items: [
+      {
+        text: t("subscriptions_management.update_address.error_description"),
+        href: '#email-address-input',
+      }
+    ]
+  } %>
+<% end %>
 
-    <p class="govuk-body"><%= t("subscriptions_management.update_address.current_email", address: @address) %></p>
+<p class="govuk-body"><%= t("subscriptions_management.update_address.current_email", address: @address) %></p>
 
-    <%= form_tag change_address_path, method: :post do %>
-      <%= render 'govuk_publishing_components/components/input', {
-        error_message: flash[:error],
-        id: 'email-address-input',
-        label: { text: t("subscriptions_management.update_address.new_email_label") },
-        name: :new_address,
-        type: 'email',
-        value: @new_address,
-      } %>
-      <% unless @new_address.nil? %>
-        <p class="govuk-body">
-          <%= t("subscriptions_management.update_address.description", address: @new_address) %>
-          <%= link_to "contact us",
-                      "/contact/govuk",
-                      class: %w[govuk-link govuk-link--no-visited-state] %>.
-        </p>
-      <% end %>
-      <%= render 'govuk_publishing_components/components/button', {
-        text: 'Save',
-        margin_bottom: true,
-        data_attributes: {
-          module: 'auto-track-event',
-          track_category: 'email_subscriptions',
-          track_action: 'update_address',
-        },
-      } %>
-    <%- end -%>
+<%= form_tag change_address_path, method: :post do %>
+  <%= render 'govuk_publishing_components/components/input', {
+    error_message: flash[:error],
+    id: 'email-address-input',
+    label: { text: t("subscriptions_management.update_address.new_email_label") },
+    name: :new_address,
+    type: 'email',
+    value: @new_address,
+  } %>
+  <% unless @new_address.nil? %>
     <p class="govuk-body">
-      <%= link_to "Cancel",
-                  @back_url,
-                  class: %w[govuk-link govuk-link--no-visited-state] %>
+      <%= t("subscriptions_management.update_address.description", address: @new_address) %>
+      <%= link_to "contact us",
+                  "/contact/govuk",
+                  class: %w[govuk-link govuk-link--no-visited-state] %>.
     </p>
-  </div>
-</div>
+  <% end %>
+  <%= render 'govuk_publishing_components/components/button', {
+    text: 'Save',
+    margin_bottom: true,
+    data_attributes: {
+      module: 'auto-track-event',
+      track_category: 'email_subscriptions',
+      track_action: 'update_address',
+    },
+  } %>
+<%- end -%>
+<p class="govuk-body">
+  <%= link_to "Cancel",
+              @back_url,
+              class: %w[govuk-link govuk-link--no-visited-state] %>
+</p>

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -7,36 +7,32 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("subscriptions_management.heading"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscriptions_management.heading"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
+
+<%= form_tag change_frequency_path, method: :post do %>
+  <%= hidden_field_tag :id, @subscription_id %>
+    <%= render 'govuk_publishing_components/components/radio', {
+      name: 'new_frequency',
+      heading: page_heading,
+      items: frequencies(:checked_frequency => @current_frequency)
     } %>
 
-    <%= form_tag change_frequency_path, method: :post do %>
-      <%= hidden_field_tag :id, @subscription_id %>
-        <%= render 'govuk_publishing_components/components/radio', {
-          name: 'new_frequency',
-          heading: page_heading,
-          items: frequencies(:checked_frequency => @current_frequency)
-        } %>
-
-        <%= render 'govuk_publishing_components/components/button', {
-          text: 'Save',
-          margin_bottom: true,
-          data_attributes: {
-            module: 'auto-track-event',
-            track_category: 'email_subscriptions',
-            track_action: 'update_frequency',
-            track_label: @current_frequency,
-          }
-        } %>
-    <% end %>
-    <p class="govuk-body">
-      <%= link_to "Cancel", @back_url, class: %w[govuk-link govuk-link--no-visited-state] %>
-    </p>
-  </div>
-</div>
+    <%= render 'govuk_publishing_components/components/button', {
+      text: 'Save',
+      margin_bottom: true,
+      data_attributes: {
+        module: 'auto-track-event',
+        track_category: 'email_subscriptions',
+        track_action: 'update_frequency',
+        track_label: @current_frequency,
+      }
+    } %>
+<% end %>
+<p class="govuk-body">
+  <%= link_to "Cancel", @back_url, class: %w[govuk-link govuk-link--no-visited-state] %>
+</p>

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -8,38 +8,34 @@
   <% end %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("unsubscriptions.title.confirm"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("unsubscriptions.title.confirm"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <%= render "confirmation" %>
+<%= render "confirmation" %>
 
-    <%= form_tag(action: :confirmed) do %>
-      <%= hidden_field_tag :token, params[:token] %>
+<%= form_tag(action: :confirmed) do %>
+  <%= hidden_field_tag :token, params[:token] %>
 
-      <%= render 'govuk_publishing_components/components/button', {
-        text: 'Unsubscribe',
-        margin_bottom: true,
-        data_attributes: {
-          module: 'auto-track-event',
-          track_category: 'email_subscriptions',
-          track_action: 'unsubscribe_list',
-          track_label: @title,
-        },
-      } %>
-    <% end %>
+  <%= render 'govuk_publishing_components/components/button', {
+    text: 'Unsubscribe',
+    margin_bottom: true,
+    data_attributes: {
+      module: 'auto-track-event',
+      track_category: 'email_subscriptions',
+      track_action: 'unsubscribe_list',
+      track_label: @title,
+    },
+  } %>
+<% end %>
 
-    <% if authenticated? %>
-      <p class="govuk-body">
-        <%= link_to "Cancel",
-                    list_subscriptions_path,
-                    class: %w[govuk-link govuk-link--no-visited-state] %>
-      </p>
-    <% end %>
-  </div>
-</div>
+<% if authenticated? %>
+  <p class="govuk-body">
+    <%= link_to "Cancel",
+                list_subscriptions_path,
+                class: %w[govuk-link govuk-link--no-visited-state] %>
+  </p>
+<% end %>

--- a/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
+++ b/app/views/unsubscriptions/confirm_already_unsubscribed.html.erb
@@ -12,15 +12,11 @@ content_for :title, page_title
   <% end %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: page_title,
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: page_title,
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <%= render "confirmation" %>
-  </div>
-</div>
+<%= render "confirmation" %>

--- a/app/views/unsubscriptions/confirmed.html.erb
+++ b/app/views/unsubscriptions/confirmed.html.erb
@@ -1,14 +1,10 @@
 <% content_for :title, t("unsubscriptions.title.confirmed") %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: t("unsubscriptions.title.confirmed"),
-      heading_level: 1,
-      font_size: "l",
-      margin_bottom: 6,
-    } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("unsubscriptions.title.confirmed"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
 
-    <%= render "confirmation" %>
-  </div>
-</div>
+<%= render "confirmation" %>


### PR DESCRIPTION
The accounts team are working towards the goal of enabling users who have linked their email notifications address and their GOVUK Account to manage their email subscriptions through their account.

Part of this work is making the email management pages (which live in `email-alert-frontend`) look the same as the account manager when the user is authenticated with a linked account.

This PR reorganises some of the views and requests the `gem_layout_account_manager` from static which will automatically apply account page furniture to the email management pages when the user is logged in with a linked account.

(if you're going to review this I would highly recommend the "Hide whitespace changes option)

### What it looks like now
![Screenshot 2021-08-10 at 10 22 55](https://user-images.githubusercontent.com/7116819/128842558-49739906-a92f-4d54-82f6-ba4420ed6cb0.png)

### What it will look like when someone's logged in with a linked account
![Screenshot 2021-08-10 at 10 20 45](https://user-images.githubusercontent.com/7116819/128842626-dc574c35-dc2c-4caa-838a-e1b247adc9fa.png)



Dependent on: 
- https://github.com/alphagov/govuk_publishing_components/pull/2255
- https://github.com/alphagov/static/pull/2571

-------

https://trello.com/c/F0ZDY0RC

------

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️