### PR TITLE
Things are changing

### DIFF
--- a/app/controllers/link_accounts_controller.rb
+++ b/app/controllers/link_accounts_controller.rb
@@ -1,0 +1,10 @@
+class LinkAccountsController < ApplicationController
+  include GovukPersonalisation::ControllerConcern
+  include AccountHelper
+
+  def show
+    head :not_found and return unless govuk_account_auth_enabled?
+
+    @link_or_sign_in = logged_in? ? "signed_in" : "signed_out"
+  end
+end

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -1,5 +1,6 @@
 class SubscriberAuthenticationController < ApplicationController
   include GovukPersonalisation::ControllerConcern
+  include AccountHelper
   include SessionsHelper
 
   def sign_in
@@ -55,10 +56,6 @@ private
 
   helper_method def confirm_govuk_account_url
     ENV.fetch("GOVUK_ACCOUNT_CONFIRM_EMAIL_URL")
-  end
-
-  helper_method def govuk_account_auth_enabled?
-    ENV["FEATURE_FLAG_GOVUK_ACCOUNT"] == "enabled"
   end
 
   def token

--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -1,0 +1,5 @@
+module AccountHelper
+  def govuk_account_auth_enabled?
+    ENV["FEATURE_FLAG_GOVUK_ACCOUNT"] == "enabled"
+  end
+end

--- a/app/views/link_accounts/show.html.erb
+++ b/app/views/link_accounts/show.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, t("link_accounts.things_are_changing.heading") %>
+
+<div class="govuk-grid-row">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("link_accounts.things_are_changing.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+  <%= sanitize(t("link_accounts.things_are_changing.description")) %>
+
+    <%= form_tag(process_govuk_account_path) do %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("link_accounts.things_are_changing.action_button.#{@link_or_sign_in}"),
+        margin_bottom: true,
+        data_attributes: {
+          module: 'auto-track-event',
+          track_category: 'things_are_changing',
+          track_action: t("link_accounts.things_are_changing.tracking.action_button.#{@link_or_sign_in}"),
+        },
+      } %>
+  <% end %>
+</div>

--- a/config/locales/link_accounts.yml
+++ b/config/locales/link_accounts.yml
@@ -1,0 +1,15 @@
+en:
+  link_accounts:
+    things_are_changing:
+      heading: The way you set up email updates are changing
+      description: |
+        <p class="govuk-body">You can now do this through your GOV.UK account</p>
+        <p class="govuk-body">We will merge the two accounts</p>
+      action_button:
+        signed_in: "Link account"
+        signed_out: "Sign in"
+      tracking:
+        action_button:
+          signed_in: "link-account"
+          signed_out: "sign-in"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ Rails.application.routes.draw do
       post "/authenticate" => "subscriber_authentication#verify", as: :verify_subscriber
       get "/authenticate/process" => "subscriber_authentication#process_sign_in_token", as: :process_sign_in_token
       get "/authenticate/account" => "subscriber_authentication#process_govuk_account", as: :process_govuk_account
+      post "/authenticate/account" => "subscriber_authentication#process_govuk_account"
+
+      get "/things-are-changing" => "link_accounts#show", as: :things_are_changing
     end
 
     scope "/subscriptions" do

--- a/spec/controllers/link_accounts_controller_spec.rb
+++ b/spec/controllers/link_accounts_controller_spec.rb
@@ -1,0 +1,81 @@
+RSpec.describe LinkAccountsController do
+  include GovukPersonalisation::TestHelpers::Requests
+
+  context "When GOV.UK accounts is not enabled" do
+    describe "GET /email/manage/things-are-changing" do
+      it "returns 404" do
+        get :show
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context "When GOV.UK accounts is enabled" do
+    render_views
+
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+        example.run
+      end
+    end
+
+    describe "GET /email/manage/things-are-changing" do
+      before { get :show }
+
+      let(:html) { Nokogiri.parse(response.body) }
+
+      it "returns 200" do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "has the expected title" do
+        expect(html.title).to eq("#{I18n.t('link_accounts.things_are_changing.heading')} - GOV.UK")
+      end
+
+      it "has the expected heading" do
+        expect(html.css("h1").text).to eq(I18n.t("link_accounts.things_are_changing.heading"))
+      end
+
+      it "renders a button with the correct tracking category" do
+        expect(html.at(".govuk-button").attr("data-track-category")).to eq("things_are_changing")
+      end
+
+      it "renders a button with the correct data module" do
+        expect(html.at(".govuk-button").attr("data-module")).to eq("auto-track-event")
+      end
+
+      describe "when logged out" do
+        it "renders logged out content on the button" do
+          expect(html.at(".govuk-button").text).to eq(I18n.t("link_accounts.things_are_changing.action_button.signed_out"))
+        end
+
+        it "contains process_govuk_account_path as the form action" do
+          expect(html.at("form")["action"]).to eq(process_govuk_account_path)
+        end
+
+        it "renders logged out tracking values on the button" do
+          expect(html.at(".govuk-button").attr("data-track-action")).to eq(I18n.t("link_accounts.things_are_changing.tracking.action_button.signed_out"))
+        end
+      end
+
+      describe "when logged in" do
+        before do
+          mock_logged_in_session("new-session-id")
+          get :show
+        end
+
+        it "renders logged in content on the button" do
+          expect(html.at(".govuk-button").text).to eq(I18n.t("link_accounts.things_are_changing.action_button.signed_in"))
+        end
+
+        it "contains process_govuk_account_path as the form action" do
+          expect(html.at("form")["action"]).to eq(process_govuk_account_path)
+        end
+
+        it "renders logged in tracking values on the button" do
+          expect(html.at(".govuk-button").attr("data-track-action")).to eq(I18n.t("link_accounts.things_are_changing.tracking.action_button.signed_in"))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/WSFGT2rz/941-implement-basic-things-are-changing-screen-with-placeholder-content)

**Draft pending final content**

Add a new page, hidden behnd the account feature flag.
Creates a  page with:
- A header
- Some descriptive paragraphs
- A call to action button

The button varies it's content based on if the user is logged in or not.
In either case the user is directed to the same path, as it will start an authenticated request that will send the user down the sign in journey if they are not logged in.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
