### PR TITLE
Remove jQuery from the app

### DIFF
--- a/app/assets/javascripts/modules/track-email-alert-signup-choices.js
+++ b/app/assets/javascripts/modules/track-email-alert-signup-choices.js
@@ -4,10 +4,11 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 (function (Modules) {
   'use strict'
 
-  function TrackEmailAlertSignupChoices () { }
+  function TrackEmailAlertSignupChoices (element) {
+    this.form = element
+  }
 
-  TrackEmailAlertSignupChoices.prototype.start = function ($module) {
-    this.form = $module[0]
+  TrackEmailAlertSignupChoices.prototype.init = function () {
     this.form.addEventListener('submit', this.handleSubmit.bind(this))
   }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "standardx": {
     "env": {
       "browser": true,
-      "jquery": true,
       "jasmine": true
     },
     "globals": [

--- a/spec/javascripts/modules/track-email-alert-signup-choices.spec.js
+++ b/spec/javascripts/modules/track-email-alert-signup-choices.spec.js
@@ -23,8 +23,8 @@ describe('Email alert sign up tracking', function () {
 
     document.body.appendChild(container)
     var element = document.querySelector('[data-module="track-email-alert-signup-choices"]')
-    tracker = new GOVUK.Modules.TrackEmailAlertSignupChoices()
-    tracker.start($(element))
+    tracker = new GOVUK.Modules.TrackEmailAlertSignupChoices(element)
+    tracker.init()
   })
 
   afterEach(function () {


### PR DESCRIPTION
Trello: https://trello.com/c/NtyIMawD/563-remove-jquery-from-email-alert-frontend

This app had a very low dependency on jQuery already, so it only needed
the initialisation function changing on the sole module.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
