### PR TITLE
Clarify that you can only manage existing subscriptions here

### DIFF
--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -28,7 +28,9 @@
   } %>
 <% end %>
 
-<p class="govuk-body"><%= t("subscriber_authentication.sign_in.description") %></p>
+<div class="govuk-body">
+  <%= t("subscriber_authentication.sign_in.description_html") %>
+</div>
 
 <%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate"  do %>
   <%= render 'govuk_publishing_components/components/input', {

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -2,7 +2,10 @@ en:
   subscriber_authentication:
     sign_in:
       heading: Change your email preferences
-      description: For security, we need you to confirm your email address.
+      description_html: |
+        <p>If you are subscribed to GOV.UK email updates, you can unsubscribe or change the frequency at which you receive emails here.</p>
+        <p>You cannot use this page to set up new email subscriptions.  You can set up new subscriptions on topic pages or search pages.</p>
+        <p>For security, we need you to confirm your email address before you can manage your existing subscriptions.</p>
       email_input: Email address
       account_description_html: |
         <p class="govuk-body">We’ve introduced GOV.UK accounts as a new way to manage your notifications.</p>


### PR DESCRIPTION
We frequently get support tickets along the lines of "I've entered my
email address on this page a dozen times and got not emails!  Your
system is preventing me from signing up to notifications on XYZ!"

But the problem is that you can't sign up to new notifications from
this page.  The text on this page doesn't say that, and the text on
the next page says to contact support.  So, users who find this page
first get frustrated.

So, really emphasise that this is for *existing* subscriptions, not
new ones.

---

<img width="749" alt="Screenshot 2021-08-23 at 09 57 10" src="https://user-images.githubusercontent.com/75235/130419751-c39bdefa-dbda-49c2-b458-30796bdb2888.png">
