### PR TITLE
Add Feature: Sign up with Accounts

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -1,0 +1,59 @@
+class AccountSubscriptionsController < ApplicationController
+  include GovukPersonalisation::ControllerConcern
+  include AccountHelper
+  before_action :enforce_feature_flag
+  before_action :assign_content_item
+  before_action :assign_list_params
+
+  def new
+    @sign_in_or_create_path = logged_in? ? new_account_subscription_path : "/sign-in"
+    @auth_status = logged_in? ? "logged_in" : "logged_out"
+  end
+
+  def create
+    redirect_to(new_account_subscription_path(permitted_parameters)) and return unless logged_in?
+
+    subscriber_list = GdsApi.email_alert_api.find_or_create_subscriber_list(@list_params)["subscriber_list"]
+    GdsApi.account_api.put_email_subscription(
+      govuk_account_session: @account_session_header,
+      name: @content_item["content_id"],
+      topic_slug: subscriber_list["slug"],
+    )
+    redirect_to(@content_item_path)
+  end
+
+private
+
+  def permitted_parameters
+    params.permit(:link, :topic).to_h
+  end
+
+  def sign_in_url
+    GdsApi.account_api.get_sign_in_url(
+      redirect_path: new_account_subscription_path(permitted_parameters),
+      level_of_authentication: "level0",
+    ).to_h["auth_uri"]
+  end
+
+  def enforce_feature_flag
+    head :not_found and return unless govuk_account_auth_enabled?
+  end
+
+  def assign_content_item
+    # NOTE: the "topic" param has historically appeared in external links
+    @content_item_path = params[:topic] || params[:link]
+
+    return bad_request unless @content_item_path.to_s.starts_with?("/")
+    return bad_request unless URI.parse(@content_item_path).relative?
+
+    @content_item ||= GdsApi.content_store.content_item(@content_item_path)
+  rescue URI::InvalidURIError
+    bad_request
+  end
+
+  def assign_list_params
+    @list_params = GenerateSubscriberListParamsService.call(@content_item.to_h)
+  rescue GenerateSubscriberListParamsService::UnsupportedContentItemError
+    bad_request
+  end
+end

--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -1,6 +1,8 @@
 class AccountSubscriptionsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
   include AccountHelper
+  include ContentItemNotifications
+
   before_action :enforce_feature_flag
   before_action :assign_content_item
   before_action :assign_list_params
@@ -37,23 +39,5 @@ private
 
   def enforce_feature_flag
     head :not_found and return unless govuk_account_auth_enabled?
-  end
-
-  def assign_content_item
-    # NOTE: the "topic" param has historically appeared in external links
-    @content_item_path = params[:topic] || params[:link]
-
-    return bad_request unless @content_item_path.to_s.starts_with?("/")
-    return bad_request unless URI.parse(@content_item_path).relative?
-
-    @content_item ||= GdsApi.content_store.content_item(@content_item_path)
-  rescue URI::InvalidURIError
-    bad_request
-  end
-
-  def assign_list_params
-    @list_params = GenerateSubscriberListParamsService.call(@content_item.to_h)
-  rescue GenerateSubscriberListParamsService::UnsupportedContentItemError
-    bad_request
   end
 end

--- a/app/controllers/concerns/content_item_notifications.rb
+++ b/app/controllers/concerns/content_item_notifications.rb
@@ -1,0 +1,21 @@
+module ContentItemNotifications
+  extend ActiveSupport::Concern
+
+  def assign_content_item
+    # NOTE: the "topic" param has historically appeared in external links
+    @content_item_path = params[:topic] || params[:link]
+
+    return bad_request unless @content_item_path.to_s.starts_with?("/")
+    return bad_request unless URI.parse(@content_item_path).relative?
+
+    @content_item ||= GdsApi.content_store.content_item(@content_item_path)
+  rescue URI::InvalidURIError
+    bad_request
+  end
+
+  def assign_list_params
+    @list_params = GenerateSubscriberListParamsService.call(@content_item.to_h)
+  rescue GenerateSubscriberListParamsService::UnsupportedContentItemError
+    bad_request
+  end
+end

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -4,6 +4,7 @@
 # finder_email_signup content item.
 class ContentItemSignupsController < ApplicationController
   include TaxonsHelper
+  include ContentItemNotifications
 
   protect_from_forgery except: [:create]
   before_action :assign_content_item
@@ -42,23 +43,5 @@ private
     return error_not_found if destination_path.nil?
 
     redirect_to(new_content_item_signup_path(link: destination_path))
-  end
-
-  def assign_content_item
-    # NOTE: the "topic" param has historically appeared in external links
-    content_item_path = params[:topic] || params[:link]
-
-    return bad_request unless content_item_path.to_s.starts_with?("/")
-    return bad_request unless URI.parse(content_item_path).relative?
-
-    @content_item ||= GdsApi.content_store.content_item(content_item_path)
-  rescue URI::InvalidURIError
-    bad_request
-  end
-
-  def assign_list_params
-    @list_params = GenerateSubscriberListParamsService.call(@content_item.to_h)
-  rescue GenerateSubscriberListParamsService::UnsupportedContentItemError
-    bad_request
   end
 end

--- a/app/services/generate_subscriber_list_params_service.rb
+++ b/app/services/generate_subscriber_list_params_service.rb
@@ -1,4 +1,6 @@
 class GenerateSubscriberListParamsService < ApplicationService
+  include AccountHelper
+
   def initialize(content_item)
     super()
     @content_item = content_item
@@ -37,7 +39,11 @@ private
     when "service_manual_service_standard"
       single_link(key: "parent")
     else
-      raise UnsupportedContentItemError
+      if govuk_account_auth_enabled?
+        single_link(key: content_item_type)
+      else
+        raise UnsupportedContentItemError
+      end
     end
   end
 

--- a/app/views/account_subscriptions/new.html.erb
+++ b/app/views/account_subscriptions/new.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title, t("account_subscriptions.new.#{@auth_status}.title") %>
+
+<div class="govuk-grid-row">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: t("account_subscriptions.new.#{@auth_status}.heading"),
+      heading_level: 1,
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+
+  <p class="govuk-body">
+    <%= sanitize(t("account_subscriptions.new.#{@auth_status}.description")) %>
+  </p>
+
+    <%= form_tag(@sign_in_or_create_path) do %>
+      <% if @auth_status == "logged_in" %>
+        <% if @permitted_parameters.present? %>
+          <% @permitted_parameters.each do |param| %>
+            <%= tag.input(type: "hidden", name: param[0], value: param[1]) %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= tag.input(type: "hidden", name: "redirect_to", value: new_account_subscription_path(@permitted_parameters)) %>
+      <% end %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: t("account_subscriptions.new.#{@auth_status}.action_button_text"),
+        margin_bottom: true,
+        data_attributes: {
+          module: 'auto-track-event',
+          track_category: 'account-email-subscription',
+          track_action: t("account_subscriptions.new.#{@auth_status}.tracking"),
+        },
+      } %>
+  <% end %>
+</div>

--- a/config/locales/account_subscriptions.yml
+++ b/config/locales/account_subscriptions.yml
@@ -1,0 +1,16 @@
+en:
+  account_subscriptions:
+    new:
+      logged_in:
+        title: Create your email subscription
+        heading: Create your email subscription
+        description: Click to finish creating your subscription
+        action_button_text: "Create subscription"
+        tracking: "create-subscription"
+      logged_out:
+        title: Sign in to your GOV.UK account
+        heading: You need a GOV.UK account to get email updates
+        description: Click to be signed in to your GOV.UK account and finish subscribing
+        action_button_text: "Sign in"
+        tracking: "sign-in-to-create-subscription"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
       post "/frequency" => "subscriptions#frequency", as: :subscription_frequency
       post "/verify" => "subscriptions#verify", as: :verify_subscription
       get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
+      get "/account" => "account_subscriptions#new", as: :new_account_subscription
+      post "/account" => "account_subscriptions#create", as: :create_account_subscription
     end
 
     # DEPRECATED: legacy route in emails from GOV.UK

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe AccountSubscriptionsController do
           stub_account_api_get_sign_in_url(
             redirect_path: new_account_subscription_path(base_path),
             level_of_authentication: "level0",
-            auth_uri: auth_uri,
           )
           get :new, params: { link: base_path }
         end

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -133,13 +133,13 @@ RSpec.describe AccountSubscriptionsController do
           mock_logged_in_session("new-session-id")
           stub_email_alert_api_creates_subscriber_list(
             {
-              "title" => "Salary sacrifice",
-              "slug" => "abc123",
-              "links" => { "detailed_guide" => %w[c9e77115-22aa-45a2-8c0d-827d92462758] },
-              "url" => "/guidance/salary-sacrifice-and-the-effects-on-paye",
+              "title" => content_item["title"],
+              "slug" => content_item["slug"],
+              "links" => content_item["links"],
+              "url" => content_item["url"],
             },
           )
-          stub_account_api_put_email_subscription(name: "c9e77115-22aa-45a2-8c0d-827d92462758", topic_slug: "abc123")
+          stub_account_api_put_email_subscription(name: content_item["content_id"], topic_slug: content_item["slug"])
           get :create, params: { link: base_path }
           expect(response).to redirect_to(base_path)
         end

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -1,0 +1,150 @@
+RSpec.describe AccountSubscriptionsController do
+  include GovukContentSchemaExamples
+
+  include GdsApi::TestHelpers::AccountApi
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::EmailAlertApi
+  include GovukPersonalisation::TestHelpers::Requests
+
+  context "When GOV.UK accounts is not enabled" do
+    describe "GET /email/subscriptions/account" do
+      it "returns 404" do
+        get :new
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
+  context "When GOV.UK accounts is enabled" do
+    render_views
+
+    let(:auth_uri) { "/sign-in" }
+    let(:content_item) { govuk_content_schema_example("detailed_guide", "detailed_guide") }
+    let(:base_path) { content_item["base_path"] }
+    let(:html) { Nokogiri.parse(response.body) }
+
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+        example.run
+      end
+    end
+
+    before do
+      stub_content_store_has_item(base_path, content_item.to_json)
+    end
+
+    describe "GET /email/subscriptions/account" do
+      context "when logged in" do
+        before do
+          mock_logged_in_session("new-session-id")
+          get :new, params: { link: base_path }
+        end
+
+        it "returns 200" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders logged in content on the title" do
+          expect(html.at("title").text).to eq("#{I18n.t('account_subscriptions.new.logged_in.title')} - GOV.UK")
+        end
+
+        it "renders logged in content on the header" do
+          expect(html.at("h1").text).to eq(I18n.t("account_subscriptions.new.logged_in.heading"))
+        end
+
+        it "renders logged in content on the description" do
+          expect(response.body).to include(I18n.t("account_subscriptions.new.logged_in.description"))
+        end
+
+        it "adds logged in tracking values to the button" do
+          expect(html.at(".govuk-button")["data-track-action"]).to eq(I18n.t("account_subscriptions.new.logged_in.tracking"))
+        end
+
+        it "renders logged in content on the button" do
+          expect(html.at(".govuk-button").text).to eq(I18n.t("account_subscriptions.new.logged_in.action_button_text"))
+        end
+
+        it "contains create_account_subscription_path as the form action" do
+          expect(html.at("form")["action"]).to eq(create_account_subscription_path)
+        end
+      end
+
+      context "when logged out" do
+        before do
+          stub_account_api_get_sign_in_url(
+            redirect_path: new_account_subscription_path(base_path),
+            level_of_authentication: "level0",
+            auth_uri: auth_uri,
+          )
+          get :new, params: { link: base_path }
+        end
+
+        it "returns 400 if no link or topic parameter is present" do
+          get :new
+          expect(response).to have_http_status(:bad_request)
+        end
+
+        it "returns 200 if a link parameter is present" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders logged out content on the title" do
+          expect(html.at("title").text).to eq("#{I18n.t('account_subscriptions.new.logged_out.title')} - GOV.UK")
+        end
+
+        it "renders logged out content on the header" do
+          expect(html.at("h1").text).to eq(I18n.t("account_subscriptions.new.logged_out.heading"))
+        end
+
+        it "renders logged out content on the description" do
+          expect(response.body).to include(I18n.t("account_subscriptions.new.logged_out.description"))
+        end
+
+        it "renders logged out content on the button" do
+          expect(html.at(".govuk-button").text).to eq(I18n.t("account_subscriptions.new.logged_out.action_button_text"))
+        end
+
+        it "adds logged out tracking values to the button" do
+          expect(html.at(".govuk-button")["data-track-action"]).to eq(I18n.t("account_subscriptions.new.logged_out.tracking"))
+        end
+
+        it "has form action pointing to authenticate endpoint" do
+          expect(html.at("form")["action"]).to eq("/sign-in")
+        end
+      end
+    end
+
+    describe "POST /email/subscriptions/account" do
+      context "when logged out" do
+        before do
+          get :create, params: { link: base_path }
+        end
+
+        it "returns 302" do
+          expect(response).to have_http_status(:redirect)
+        end
+
+        it "sends the user to new_account_subscription_path" do
+          response.should redirect_to(new_account_subscription_path({ link: base_path }))
+        end
+      end
+
+      context "when logged in" do
+        it "creates a subscriber list, links the subscription in accounts and redirects the user back to the content item" do
+          mock_logged_in_session("new-session-id")
+          stub_email_alert_api_creates_subscriber_list(
+            {
+              "title" => "Salary sacrifice",
+              "slug" => "abc123",
+              "links" => { "detailed_guide" => %w[c9e77115-22aa-45a2-8c0d-827d92462758] },
+              "url" => "/guidance/salary-sacrifice-and-the-effects-on-paye",
+            },
+          )
+          stub_account_api_put_email_subscription(name: "c9e77115-22aa-45a2-8c0d-827d92462758", topic_slug: "abc123")
+          get :create, params: { link: base_path }
+          expect(response).to redirect_to(base_path)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The provisional foundations for allowing sign up to a wider range of
notifications by content type, and enforcing the use of a GOV.UK Account
instead of creating a notifications specific account via email sign up.

The feature is currently gated behind a flag. We will need to add
finalised content before switching it on in production.

After this a follow up PR can remove code relating to the old sign up
routes.

---
[Trello](https://trello.com/c/HgavhWAU/940-implement-basic-account-y-email-subscription-sign-up-screen-with-placeholder-content)
