### PR TITLE
Add bundle folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ log
 yarn-error.log
 public/assets
 coverage
+.bundle


### PR DESCRIPTION
`git status` is unhappy about it and we already do this on [other repos](https://github.com/alphagov/account-api/blob/main/.gitignore#L8)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
