### PR TITLE
Fix accessibility issue (link purpose in context) – subscriptions management page

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -77,12 +77,18 @@
     <p class="govuk-body">
       <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
       <br>
-      <%= link_to "Change how often you get updates",
+      <% change_frequency_link_text = capture do %>
+        Change how often you get updates <span class="govuk-visually-hidden"> about <%= subscription['subscriber_list']['title'] %></span>
+      <% end %>
+      <%= link_to change_frequency_link_text,
                   update_frequency_path(id: subscription['id']),
                   class: %w[govuk-link govuk-link--no-visited-state] %>
     </p>
     <p class="govuk-body">
-      <%= link_to "Unsubscribe",
+      <% unsubscribe_link_text = capture do %>
+        Unsubscribe <span class="govuk-visually-hidden"> from <%= subscription['subscriber_list']['title'] %></span>
+      <% end %>
+      <%= link_to unsubscribe_link_text,
                   confirm_unsubscribe_path(id: subscription['id']),
                   class: %w[govuk-link govuk-link--no-visited-state] %>
     </p>

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature "Unsubscribe" do
   end
 
   def and_i_click_on_unsubscribe
-    click_on "Unsubscribe"
+    find("a[href='#{confirm_unsubscribe_path(@subscription_id)}']").click
   end
 
   def and_i_confirm_to_unsubscribe

--- a/spec/views/subscriptions_management/index.html.erb_spec.rb
+++ b/spec/views/subscriptions_management/index.html.erb_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe "subscriptions_management/index" do
           "id" => 1,
           "frequency" => frequency,
           "created_at" => Time.zone.now.to_s,
-          "subscriber_list" => {},
+          "subscriber_list" => {
+            "title" => "A thing to subscribe to",
+          },
         }
 
         assign(:subscriptions, { subscription["id"] => subscription })
@@ -22,6 +24,10 @@ RSpec.describe "subscriptions_management/index" do
         expect(rendered).to have_content(
           I18n.t!("subscriptions_management.index.flashes.subscription.#{frequency}"),
         )
+        expect(rendered).to have_css("a[href='#{confirm_unsubscribe_path(subscription['id'])}'] .govuk-visually-hidden", text: "from #{subscription['subscriber_list']['title']}")
+        expect(rendered).to have_css("a[href='#{update_frequency_path(subscription['id'])}'] .govuk-visually-hidden", text: "about #{subscription['subscriber_list']['title']}")
+        expect(rendered).to have_content("Change how often you get updates about #{subscription['subscriber_list']['title']}", normalize_ws: true)
+        expect(rendered).to have_content("Unsubscribe from #{subscription['subscriber_list']['title']}", normalize_ws: true)
       end
     end
   end


### PR DESCRIPTION
The "manage your email subscriptions" page lists all the email notifications a user is currently subscribed to. 
Each of the items on the list has a "Change how often you get emails" link and "Unsubscribe" link. 
The links do not specify which topic they are connected to, therefore to a user navigating the page using a screen reader, it would not be so clear what the purpose of the links is.
This adds some hidden text to the links which references which page/topic they are related to. This way, the page will remain unchanged for sighted users, while improving the experience for screen reader users.


https://trello.com/c/VpmI0ix1

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
