### PR TITLE
Update content for a user without any subscriptions

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -48,12 +48,9 @@
 <hr class="govuk-section-break govuk-section-break--l">
 
 <% if @subscriptions.empty? %>
-  <p class="govuk-body">
-    You aren’t subscribed to any topics on GOV.UK.
-    <%= link_to "Find out how to subscribe",
-                "/help/get-emails-about-updates-to-govuk",
-                class: "govuk-link" %>.
-  </p>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <%= t("subscriptions_management.no_subscriptions_warning_html") %>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 <% else %>
   <% @subscriptions.each do |_key, subscription| %>
     <%= render "govuk_publishing_components/components/heading", {

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -1,6 +1,6 @@
 en:
   subscriptions_management:
-    heading: Change your email preferences
+    heading: Manage your GOV.UK emails
     index:
       subscription:
         immediately: "You get updates as soon as they happen."
@@ -14,6 +14,9 @@ en:
           immediately: "You’ll get an email from GOV.UK each time we add or update a page about:"
           daily: "You’ll get one email a day from GOV.UK about:"
           weekly: "You’ll get one email a week from GOV.UK about:"
+    no_subscriptions_warning_html: |
+      <p class="govuk-body">You’re not currently getting emails about updates to GOV.UK.</p>
+      <p class="govuk-body">Some GOV.UK pages have a link to ‘get emails’. You can use that link to subscribe to pages or topics you’re interested in.</p>
     update_address:
       heading: Change your email address
       current_email: "Your current email address is %{address}"
@@ -35,3 +38,4 @@ en:
     confirmed_unsubscribe_all:
       success_message: You have been unsubscribed from all your subscriptions.
       success_description: It can take up to an hour for this change to take effect.
+

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe SubscriptionsManagementController do
 
       it "renders a message" do
         get :index, session: session_with_no_subscriptions
-        expect(response.body).to include("You aren’t subscribed to any topics on GOV.UK.")
+        expect(response.body).to include(I18n.t("subscriptions_management.heading"))
       end
     end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/HTCfiPd3/1052-update-content-for-manage-your-emails-page)
[Figma](https://www.figma.com/file/9RzsNFl3iYBXM5QfKO2HkE/Single-page-notifications-feature?node-id=539%3A20698)

We are adjusting this across the journey and want to ensure it is
consistent with the latest designs.

## What it looks like
![new_content](https://user-images.githubusercontent.com/3694062/135492923-b8c58869-936e-4d65-aaef-ff1cbab69d94.jpg)


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
