### PR TITLE
Add a confirmation page for creating an account subscription

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class AccountSubscriptionsController < ApplicationController
+  include AccountHelper
+  include FrequenciesHelper
+  include GovukPersonalisation::ControllerConcern
+
+  DEFAULT_FREQUENCY = "daily"
+  SUCCESS_FLASH = "email-subscription-success"
+
+  before_action do
+    head :not_found unless govuk_account_auth_enabled?
+  end
+
+  before_action do
+    @topic_id = subscription_parameters.fetch(:topic_id)
+    @subscriber_list = GdsApi.email_alert_api.get_subscriber_list(slug: @topic_id).to_h.fetch("subscriber_list")
+    @frequency = subscription_parameters.fetch(:frequency, DEFAULT_FREQUENCY)
+
+    unless valid_frequencies.include?(@frequency)
+      redirect_with_analytics confirm_account_subscription_path(
+        topic_id: @topic_id,
+        return_to_url: @return_to_url,
+      )
+    end
+  end
+
+  rescue_from GdsApi::HTTPUnauthorized, with: :reauthenticate_user
+  rescue_from GdsApi::HTTPForbidden, with: :reauthenticate_user
+
+  def confirm
+    response = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(
+      govuk_account_session: account_session_header,
+    )
+    set_account_session_header(response["govuk_account_session"])
+    subscriber = response.to_h.fetch("subscriber")
+
+    @address = subscriber.fetch("address")
+
+    @unlinked_subscriptions =
+      if subscriber["govuk_account_id"]
+        []
+      else
+        GdsApi.email_alert_api.get_subscriptions(id: subscriber.fetch("id")).to_h.fetch("subscriptions", [])
+      end
+  end
+
+  def create
+    response = GdsApi.email_alert_api.link_subscriber_to_govuk_account(
+      govuk_account_session: account_session_header,
+    )
+    set_account_session_header(response["govuk_account_session"])
+    subscriber = response.to_h.fetch("subscriber")
+
+    GdsApi.email_alert_api.subscribe(
+      subscriber_list_id: @subscriber_list.fetch("id"),
+      address: subscriber.fetch("address"),
+      frequency: @frequency,
+    )
+
+    account_flash_add SUCCESS_FLASH
+
+    if subscription_parameters[:return_to_url].blank? || @subscriber_list["url"].blank?
+      redirect_to process_govuk_account_path
+    else
+      redirect_to @subscriber_list["url"]
+    end
+  end
+
+private
+
+  def subscription_parameters
+    params.permit(:topic_id, :frequency, :return_to_url)
+  end
+
+  def reauthenticate_user
+    logout!
+
+    redirect_with_analytics GdsApi.account_api.get_sign_in_url(
+      redirect_path: confirm_account_subscription_path(
+        topic_id: @topic_id,
+        frequency: @frequency,
+        return_to_url: @return_to_url,
+      ),
+    )["auth_uri"]
+  end
+end

--- a/app/views/account_subscriptions/confirm.html.erb
+++ b/app/views/account_subscriptions/confirm.html.erb
@@ -1,0 +1,59 @@
+<% content_for :title, t("account_subscriptions.confirm.title") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("account_subscriptions.confirm.title"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 6
+} %>
+
+<p class="govuk-body">
+  <%= t("account_subscriptions.confirm.description") %>
+</p>
+
+<p class="govuk-body">
+  <strong><%= @subscriber_list["title"] %></strong>
+</p>
+
+<%= form_tag(action: :create) do %>
+  <%= hidden_field_tag "topic_id", params[:topic_id] %>
+  <%= hidden_field_tag "frequency", params[:frequency] %>
+  <%= hidden_field_tag "return_to_url", params[:return_to_url] %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("account_subscriptions.confirm.confirm"),
+    margin_bottom: 4,
+    data_attributes: {
+      module: "gem-track-click",
+      track_category: "email_subscriptions",
+      track_action: "new_account",
+      track_label: @subscriber_list["title"],
+    },
+  } %>
+<% end %>
+
+<p class="govuk-body">
+  <a href="/" class="govuk-link"><%= t("account_subscriptions.confirm.cancel") %></a>
+</p>
+
+<% unless @unlinked_subscriptions.empty? %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: t("account_subscriptions.confirm.unlinked_subscriptions.title"),
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 4
+  } %>
+
+  <%= t("account_subscriptions.confirm.unlinked_subscriptions.before_html", address: @address) %>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <% @unlinked_subscriptions.each do |subscription| %>
+      <li>
+        <%= subscription.dig("subscriber_list", "title") %>
+      </li>
+    <% end %>
+  </ul>
+
+  <p class="govuk-body">
+    <%= t("account_subscriptions.confirm.unlinked_subscriptions.after") %>
+  </p>
+<% end %>

--- a/config/locales/account_subscriptions.yml
+++ b/config/locales/account_subscriptions.yml
@@ -1,0 +1,13 @@
+en:
+  account_subscriptions:
+    confirm:
+      title: Confirm you want to get emails
+      description: "You’ll get emails when there are updates or new pages about:"
+      confirm: Confirm
+      cancel: Cancel and go to the GOV.UK homepage
+      unlinked_subscriptions:
+        title: Other emails you get from GOV.UK
+        before_html: |
+          <p class="govuk-body">There are more GOV.UK email subscriptions for <strong>%{address}</strong></p>
+          <p class="govuk-body">These will be moved to your new account:</p>
+        after: You’ll be able to use your account to unsubscribe or change how often you get these emails.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,11 @@ Rails.application.routes.draw do
       post "/frequency" => "subscriptions#frequency", as: :subscription_frequency
       post "/verify" => "subscriptions#verify", as: :verify_subscription
       get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
+
+      scope "/account" do
+        get "/confirm" => "account_subscriptions#confirm", as: :confirm_account_subscription
+        post "/" => "account_subscriptions#create"
+      end
     end
 
     # DEPRECATED: legacy route in emails from GOV.UK

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -1,0 +1,275 @@
+RSpec.describe AccountSubscriptionsController do
+  include GdsApi::TestHelpers::AccountApi
+  include GdsApi::TestHelpers::EmailAlertApi
+  include GovukPersonalisation::TestHelpers::Requests
+
+  let(:session_id) { "session-id" }
+  let(:subscriber_id) { 256 }
+  let(:address) { "email@example.com" }
+  let(:linked_govuk_account_id) { nil }
+  let(:topic_id) { "GOVUK123" }
+  let(:subscriber_list_title) { "My exciting list" }
+  let(:subscriber_list_id) { 10 }
+  let(:subscriber_list_attributes) do
+    {
+      id: subscriber_list_id,
+      title: subscriber_list_title,
+    }
+  end
+
+  render_views
+
+  before do
+    mock_logged_in_session(session_id)
+
+    stub_email_alert_api_has_subscriber_list_by_slug(
+      slug: topic_id,
+      returned_attributes: subscriber_list_attributes,
+    )
+  end
+
+  describe "GET /email/subscriptions/account/confirm" do
+    it "returns 404" do
+      get :confirm
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when the feature flag is enabled" do
+      before do
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account(
+          session_id,
+          subscriber_id,
+          address,
+          govuk_account_id: linked_govuk_account_id,
+        )
+
+        stub_email_alert_api_has_subscriber_subscriptions(
+          subscriber_id,
+          address,
+          subscriptions: active_subscriptions,
+        )
+      end
+
+      around do |example|
+        ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+          example.run
+        end
+      end
+
+      let(:active_subscriptions) { [] }
+
+      it "raises a parameter missing error" do
+        expect { get :confirm, params: {} }.to raise_error(ActionController::ParameterMissing)
+      end
+
+      context "when a topic is provided" do
+        it "returns 200" do
+          get :confirm, params: { topic_id: topic_id }
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "does not list any active subscriptions" do
+          get :confirm, params: { topic_id: topic_id }
+          expect(response.body).not_to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
+        end
+
+        context "when the user has active subscriptions" do
+          let(:active_subscriptions) do
+            [
+              { subscriber_list: { title: "First Subscription" } },
+              { subscriber_list: { title: "Second Subscription" } },
+              { subscriber_list: { title: "Third Subscription" } },
+            ]
+          end
+
+          it "lists them" do
+            get :confirm, params: { topic_id: topic_id }
+            expect(response.body).to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
+            active_subscriptions.each do |subscription|
+              expect(response.body).to include(subscription.dig(:subscriber_list, :title))
+            end
+          end
+
+          context "when the user is linked to a GOV.UK account" do
+            let(:linked_govuk_account_id) { "user-id" }
+
+            it "does not list them" do
+              get :confirm, params: { topic_id: topic_id }
+              expect(response.body).not_to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
+              active_subscriptions.each do |subscription|
+                expect(response.body).not_to include(subscription.dig(:subscriber_list, :title))
+              end
+            end
+          end
+        end
+
+        context "when a frequency is provided" do
+          let(:frequency) { "immediately" }
+
+          it "returns 200" do
+            get :confirm, params: { topic_id: topic_id, frequency: frequency }
+            expect(response).to have_http_status(:ok)
+          end
+
+          context "when the frequency is invalid" do
+            let(:frequency) { "foobar" }
+
+            it "redirects back without the frequency" do
+              get :confirm, params: { topic_id: topic_id, frequency: frequency }
+              expect(response).to redirect_to(confirm_account_subscription_url(topic_id: topic_id))
+            end
+          end
+        end
+
+        context "when the topic doesn't exist in Email Alert API" do
+          before do
+            stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: topic_id)
+          end
+
+          it "returns a 404" do
+            get :confirm, params: { topic_id: topic_id }
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+
+        context "when the user's session is invalid" do
+          before do
+            stub_email_alert_api_authenticate_subscriber_by_govuk_account_session_invalid(session_id)
+            stub_account_api_get_sign_in_url(
+              redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
+              auth_uri: auth_uri,
+            )
+          end
+
+          let(:auth_uri) { "/sign-in" }
+
+          it "logs the user out and redirects to sign in" do
+            get :confirm, params: { topic_id: topic_id }
+            expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
+            expect(response).to redirect_to(auth_uri)
+          end
+        end
+      end
+    end
+  end
+
+  describe "POST /email/subscriptions/account" do
+    it "returns 404" do
+      post :create
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when the feature flag is enabled" do
+      before do
+        stub_email_alert_api_link_subscriber_to_govuk_account(
+          session_id,
+          subscriber_id,
+          address,
+          govuk_account_id: linked_govuk_account_id,
+        )
+      end
+
+      around do |example|
+        ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+          example.run
+        end
+      end
+
+      let(:linked_govuk_account_id) { "user-id" }
+
+      it "raises a parameter missing error" do
+        expect { post :create, params: {} }.to raise_error(ActionController::ParameterMissing)
+      end
+
+      context "when a topic is provided" do
+        let!(:create_stub) do
+          stub_email_alert_api_creates_a_subscription(
+            subscriber_list_id: subscriber_list_id,
+            address: address,
+            frequency: created_frequency,
+          )
+        end
+
+        let(:created_frequency) { AccountSubscriptionsController::DEFAULT_FREQUENCY }
+
+        it "creates the subscription with a default frequency, links the subscriber to the GOV.UK account, and redirects to the manage page" do
+          post :create, params: { topic_id: topic_id }
+          expect(response).to redirect_to(process_govuk_account_path)
+          expect(response.headers["GOVUK-Account-Session"]).to include(AccountSubscriptionsController::SUCCESS_FLASH)
+          expect(create_stub).to have_been_made
+        end
+
+        context "when a frequency is provided" do
+          let(:frequency) { "immediately" }
+          let(:created_frequency) { frequency }
+
+          it "creates the subscription with the correct frequency" do
+            post :create, params: { topic_id: topic_id, frequency: frequency }
+            expect(response).to redirect_to(process_govuk_account_path)
+            expect(response.headers["GOVUK-Account-Session"]).to include(AccountSubscriptionsController::SUCCESS_FLASH)
+            expect(create_stub).to have_been_made
+          end
+
+          context "when the frequency is invalid" do
+            let(:frequency) { "foobar" }
+
+            it "redirects back without the frequency" do
+              post :create, params: { topic_id: topic_id, frequency: frequency }
+              expect(response).to redirect_to(confirm_account_subscription_url(topic_id: topic_id))
+              expect(create_stub).not_to have_been_made
+            end
+          end
+        end
+
+        context "when the topic has a URL" do
+          let(:subscriber_list_attributes) do
+            {
+              id: subscriber_list_id,
+              title: subscriber_list_title,
+              url: "/some/page",
+            }
+          end
+
+          it "redirects to the manage page when the return_to_url parameter is not given" do
+            post :create, params: { topic_id: topic_id }
+            expect(response).to redirect_to(process_govuk_account_path)
+          end
+
+          it "redirects to the manage page when the return_to_url parameter is given" do
+            post :create, params: { topic_id: topic_id, return_to_url: "1" }
+            expect(response).to redirect_to(subscriber_list_attributes[:url])
+          end
+        end
+
+        context "when the topic doesn't exist in Email Alert API" do
+          before do
+            stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: topic_id)
+          end
+
+          it "returns a 404" do
+            post :create, params: { topic_id: topic_id }
+            expect(response).to have_http_status(:not_found)
+          end
+        end
+
+        context "when the user's session is invalid" do
+          before do
+            stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
+            stub_account_api_get_sign_in_url(
+              redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
+              auth_uri: auth_uri,
+            )
+          end
+
+          let(:auth_uri) { "/sign-in" }
+
+          it "logs the user out and redirects to sign in" do
+            post :create, params: { topic_id: topic_id }
+            expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
+            expect(response).to redirect_to(auth_uri)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This page handles signing up to notifications connected to the
account, which means it also handles the "linking" of an account-api
`OidcUser` to an email-alert-api `Subscriber`.

If a user has subscriptions which pre-date their account, we'll list
them so that the user knows what is changing.  The linking process
also triggers an email in this case (email-alert-api does this).

This page is intentionally very generic: it's not just for single-page
notifications, or content item subscriptions, it's for topics in
general.  This is so we can use this page across different sorts of
email journeys.

---

The frontend for this isn't quite right, the spacing around the button looks weird and the previous subscriptions don't look like a list:

<img width="628" alt="Screenshot 2021-10-19 at 13 34 10" src="https://user-images.githubusercontent.com/75235/137926626-a7e07e11-f853-461b-94ef-1b54c46d3bc8.png">
<img width="750" alt="Screenshot 2021-10-19 at 13 37 51" src="https://user-images.githubusercontent.com/75235/137926630-b2b42944-4175-43e0-8342-1300f3ad6cf1.png">


---

[Trello card](https://trello.com/c/wUYJLuJ1/1064-implement-confirm-you-want-to-get-emails-page-account-linking-logic)
