### PR TITLE
Fix "not subscribed" content

### DIFF
--- a/app/views/subscriber_authentication/no_subscriber.html.erb
+++ b/app/views/subscriber_authentication/no_subscriber.html.erb
@@ -7,15 +7,15 @@
   margin_bottom: 6,
 } %>
 
-<div class="govuk-body">
-  <%= t("subscriber_authentication.no_subscriber.description", email: @address) %>
-</div>
+<p class="govuk-body">
+  <%= t("subscriber_authentication.no_subscriber.description_html", email: @address) %>
+</p>
 
-<div class="govuk-body">
+<p class="govuk-body">
   <a class="govuk-link" href=<%= sign_in_path %>>
-    <strong><%= t("subscriber_authentication.no_subscriber.retry_link_text") %></strong>
+    <%= t("subscriber_authentication.no_subscriber.retry_link_text") %>
   </a>
-</div>
+</p>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: t("subscriber_authentication.no_subscriber.how_to_get_updates_heading"),
@@ -24,12 +24,10 @@
   margin_bottom: 6,
 } %>
 
-<div class="govuk-body">
-  <%= t("subscriber_authentication.no_subscriber.how_to_get_updates_description") %>
-</div>
+<%= t("subscriber_authentication.no_subscriber.how_to_get_updates_description_html") %>
 
-<div class="govuk-body">
+<p class="govuk-body">
   <a class="govuk-link" href="https://www.gov.uk">
     <%= t("subscriber_authentication.no_subscriber.how_to_get_updates_link_text") %>
   </a>
-</div>
+</p>

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -38,8 +38,10 @@ en:
         <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="%{process_govuk_account_path}">Sign in to your account</a>.</p>
     no_subscriber:
       heading: You’re not subscribed to emails about updates to GOV.UK
-      description: "You’re not currently getting emails about updates to GOV.UK at this email address: %{email}"
+      description_html: "You’re not currently getting emails about updates to GOV.UK at this email address: <strong>%{email}</strong>"
       retry_link_text: Try a different email address
       how_to_get_updates_heading: How to get emails about updates to GOV.UK
-      how_to_get_updates_description: You can use that link to subscribe to pages or topics you’re interested in.
+      how_to_get_updates_description_html: |
+        <p class="govuk-body">Some GOV.UK pages have a link to ‘get emails’.</p>
+        <p class="govuk-body">You can use that link to subscribe to pages or topics you’re interested in.</p>
       how_to_get_updates_link_text: Go to the GOV.UK homepage


### PR DESCRIPTION
This page doesn't match the designs: the email address is not
bold (and the link following it is), and the first sentence under the
"How to get emails about updates to GOV.UK" heading is missing.

I've also changed the `<div>`s to `<p>`s.

<img width="724" alt="Screenshot 2021-11-01 at 11 05 49" src="https://user-images.githubusercontent.com/75235/139662369-209adb32-df2c-45ab-bdfe-d133b066906e.png">

---

[Trello card](https://trello.com/c/5ZoujfPL/1115-implement-email-management-account-sniffer-logic)
