### PR TITLE
Single page handler

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -1,0 +1,52 @@
+class SinglePageSubscriptionsController < ApplicationController
+  include AccountHelper
+  include GovukPersonalisation::ControllerConcern
+
+  before_action do
+    head :not_found unless govuk_account_auth_enabled?
+  end
+
+  skip_before_action :verify_authenticity_token, only: [:show]
+
+  def show
+    content_item = GdsApi.content_store.content_item(topic).to_h
+    return unless logged_in?
+
+    subscriber_list = GdsApi.email_alert_api.find_or_create_subscriber_list(
+      {
+        url: topic,
+        name: content_item["title"],
+        content_id: content_item["content_id"],
+      },
+    ).to_h.fetch("subscriber_list")
+
+    result = CreateAccountSubscriptionService.call(subscriber_list, "daily", @account_session_header)
+    account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
+    set_account_session_header(result[:govuk_account_session])
+
+    redirect_to topic
+  rescue GdsApi::ContentStore::ItemNotFound
+    head :not_found
+  rescue GdsApi::HTTPUnauthorized
+    logout!
+    redirect_with_analytics single_page_session_path
+  end
+
+  def edit
+    redirect_with_analytics single_page_session_path
+  end
+
+private
+
+  def topic
+    @topic ||= params.fetch(:topic)
+  end
+
+  def single_page_session_path
+    redirect_path = "#{confirm_account_subscription_path}?topic=#{topic}"
+
+    GdsApi.account_api.get_sign_in_url(
+      redirect_path: redirect_path,
+    )["auth_uri"]
+  end
+end

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -18,3 +18,24 @@ See the <%= link_to "README",
               govuk_publishing_components.component_guide_path,
               class: "govuk-link" %>.
 </p>
+
+<h3>Single page notifications</h3>
+
+  <p class="govuk-body">
+    The single page notification feature starts with a POST request to this app.
+    It then performs some conditional checks, and either subscribes the user or
+    shows them an inforamtional page and asks them to take further action.
+  </p>
+
+  <p class="govuk-body">
+    To test this page manually you can use the button below.
+  </p>
+
+  <%= form_tag "/email/subscriptions/single-page/new", method: :post do %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Subscribe to single page notification"
+    } %>
+
+    <%= hidden_field_tag(:topic, "/guidance/keeping-a-pet-pig-or-micropig") %>
+
+  <% end %>

--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for :title, t("single_page_subscriptions.title") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("single_page_subscriptions.title"),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6
+} %>
+
+<p class="govuk-body">
+  <%= t("single_page_subscriptions.account_required_description") %>
+</p>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("single_page_subscriptions.subheading"),
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 6
+} %>
+
+<%= t("single_page_subscriptions.accounts_are_new_description_html") %>
+
+<%= render "govuk_publishing_components/components/inset_text", {
+} do
+  t("single_page_subscriptions.inset_description")
+end %>
+
+<%= t("single_page_subscriptions.usage_description_html") %>
+
+<%= form_tag single_page_new_session_path method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("single_page_subscriptions.create_or_sign_in_description")
+  } %>
+
+  <%= hidden_field_tag(:topic, @topic) %>
+
+<% end %>

--- a/config/locales/single_page_subscriptions.yml
+++ b/config/locales/single_page_subscriptions.yml
@@ -1,0 +1,13 @@
+en:
+  single_page_subscriptions:
+    title: The way you subscribe to emails from GOV.UK is changing
+    account_required_description: You need a GOV.UK account to get these emails.
+    subheading: GOV.​UK accounts are new
+    accounts_are_new_description_html: |
+      <p class="govuk-body">They are a first step towards creating a single account where you can access all your government services.</p>
+      <p class="govuk-body">GOV.UK accounts will eventually replace all other government accounts.</p>
+    inset_description: At the moment, GOV.UK accounts are separate from other government accounts (for example Government Gateway or Universal Credit).
+    usage_description_html: |
+      <p class="govuk-body">Currently you can only use a GOV.UK account to manage your GOV.UK email subscriptions.</p>
+      <p class="govuk-body">We’ll be adding more features and services in the next few months.</p>
+    create_or_sign_in_description: Create a GOV.UK account or sign in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,8 @@ Rails.application.routes.draw do
       post "/verify" => "subscriptions#verify", as: :verify_subscription
       post "/verify/account" => "subscriptions#verify_account", as: :verify_subscription_account
       get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
-
+      post "/single-page/new" => "single_page_subscriptions#show"
+      post "/single-page/new-session" => "single_page_subscriptions#edit", as: :single_page_new_session
       scope "/account" do
         get "/confirm" => "account_subscriptions#confirm", as: :confirm_account_subscription
         post "/" => "account_subscriptions#create"

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -1,0 +1,115 @@
+RSpec.describe SinglePageSubscriptionsController do
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::AccountApi
+  include GdsApi::TestHelpers::EmailAlertApi
+  include GovukPersonalisation::TestHelpers::Requests
+
+  render_views
+
+  let(:topic) { "/test" }
+  let(:topic_slug) { SecureRandom.uuid }
+  let(:topic_name) { "Test" }
+  let(:redirect_path) { "/email/subscriptions/account/confirm?topic=#{topic}" }
+  let(:auth_provider) { "http://auth/provider" }
+  let(:params) { { topic: topic } }
+
+  describe "when feature flag is not 'enabled'" do
+    it "POST /email/subscriptions/single-page/new-session returns 404" do
+      post :edit
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "POST /email/subscriptions/single-page/new" do
+      post :show
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context "when the feature is on" do
+    around do |example|
+      ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+        example.run
+      end
+    end
+
+    describe "POST /email/subscriptions/single-page/new-session" do
+      before { stub_account_api_get_sign_in_url(auth_uri: auth_provider, redirect_path: redirect_path) }
+
+      it "redirects to sign in with a redirect_path param" do
+        post :edit, params: params
+        expect(response).to redirect_to(auth_provider.to_s)
+      end
+
+      it "redirects with _ga param and cookie_consent if present in the request params" do
+        post :edit, params: params.merge({ _ga: "abc123", cookie_consent: "accept" })
+        expect(response).to redirect_to("#{auth_provider}?_ga=abc123&cookie_consent=accept")
+      end
+    end
+
+    describe "POST /email/subscriptions/single-page/new" do
+      before do
+        stub_content_store_has_item(topic)
+      end
+
+      it "404s when a content item can't be found" do
+        stub_content_store_does_not_have_item(topic)
+        get :show, params: params
+        expect(response).to have_http_status(:not_found)
+      end
+
+      context "when a user is not logged in" do
+        it "renders the view with a sign in link including the topic" do
+          get :show, params: params
+          expect(response.body).to include(single_page_new_session_path)
+        end
+      end
+
+      context "when a user is logged in" do
+        let(:session_id) { "session-id" }
+        let(:user_id) { "user-id" }
+        let(:subscriber_id) { "subscriber-id" }
+        let(:user_email) { "test@gov.uk" }
+        let(:subscription_list_id) { "subscription-list-id" }
+
+        before do
+          mock_logged_in_session(session_id)
+          stub_account_api_get_sign_in_url(auth_uri: auth_provider, redirect_path: redirect_path)
+
+          stub_email_alert_api_creates_subscriber_list({
+            url: topic,
+            title: topic_name,
+            slug: topic_slug,
+            id: subscription_list_id,
+          })
+
+          stub_email_alert_api_creates_a_subscription(
+            subscriber_list_id: subscription_list_id,
+            address: user_email,
+            frequency: "daily",
+            returned_subscription_id: "subscription-id",
+            skip_confirmation_email: false,
+            subscriber_id: subscriber_id,
+          )
+
+          stub_email_alert_api_link_subscriber_to_govuk_account(
+            session_id,
+            subscriber_id,
+            user_email,
+            govuk_account_id: user_id,
+          )
+        end
+
+        it "logs the user out if the session is invalid" do
+          stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
+          post :show, params: params
+          expect(response).to redirect_to(auth_provider.to_s)
+        end
+
+        it "subscribes them and redirects back to the page" do
+          post :show, params: params
+          expect(response).to redirect_to("http://test.host#{topic}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/DsqzirDG/1065-implement-single-page-notifications-button-handling-page)
[Figma](https://www.figma.com/file/9RzsNFl3iYBXM5QfKO2HkE/Single-page-notifications-feature?node-id=1433%3A21852)

## What
Adds logic and tests for logic that signs users up to single page notifications.
Including a informational screen for logged out users.

## Why

We'll need to ensure users have a valid logged in session, with linked accounts before creating a subscription.
We can do those checks automatically for logged in users.

For logged out users we'll need to give them some information, and present a button that posts to DI's Single Sign on/up form, with the right params to return them and sign them up afterwards.

## What does it look like

![image](https://user-images.githubusercontent.com/3694062/139920206-ef905371-5595-46cd-8c32-480a2fac316c.png)
