### PR TITLE
Implement subscriber account authentication

### DIFF
--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -21,7 +21,7 @@
   <%= t("subscriber_authentication.sign_in.description_html") %>
 </div>
 
-<%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate"  do %>
+<%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate", :"data-module" => "explicit-cross-domain-links" do %>
   <%= render 'govuk_publishing_components/components/input', {
     error_message: flash[:error] &&
       t("subscriber_authentication.sign_in.#{flash[:error]}.message"),

--- a/app/views/subscriber_authentication/use_your_govuk_account.html.erb
+++ b/app/views/subscriber_authentication/use_your_govuk_account.html.erb
@@ -1,12 +1,16 @@
 <% content_for :title, t("subscriber_authentication.use_your_govuk_account.heading") %>
 
 <%= render "govuk_publishing_components/components/heading", {
-  text: t("subscriber_authentication.use_your_govuk_account.heading"),
+  text: yield(:title),
   heading_level: 1,
   font_size: "l",
   margin_bottom: 6,
 } %>
 
-<div class="govuk-body">
-  <%= t("subscriber_authentication.use_your_govuk_account.description_html", address: @address, process_govuk_account_path: process_govuk_account_path) %>
-</div>
+<p class="govuk-body"><%= t("subscriber_authentication.use_your_govuk_account.description") %></p>
+
+<%= form_tag process_govuk_account_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("subscriber_authentication.use_your_govuk_account.continue"),
+  } %>
+<% end %>

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -31,11 +31,9 @@ en:
         <p>If you do not receive an email soon, check your spam or junk folder.</p>
         <p>If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/contact/govuk">contact GOV.UK</a> for help.</p>
     use_your_govuk_account:
-      heading: "Sign in with your GOV.UK account"
-      description_html: |
-        <p class="govuk-body">You’ve set up a GOV.UK account for <strong>%{address}</strong></p>
-        <p class="govuk-body">You now need to use your email address and password to manage your notifications.</p>
-        <p class="govuk-body"><a class="govuk-link govuk-link--no-visited-state" href="%{process_govuk_account_path}">Sign in to your account</a>.</p>
+      heading: You have a GOV.UK account
+      description: Sign in to see and manage your GOV.UK emails.
+      continue: Continue to sign in to your account
     no_subscriber:
       heading: You’re not subscribed to emails about updates to GOV.UK
       description_html: "You’re not currently getting emails about updates to GOV.UK at this email address: <strong>%{email}</strong>"

--- a/spec/services/verify_subscriber_email_service_spec.rb
+++ b/spec/services/verify_subscriber_email_service_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe VerifySubscriberEmailService do
+  include GdsApi::TestHelpers::AccountApi
   include GdsApi::TestHelpers::EmailAlertApi
 
   describe ".call" do
@@ -14,7 +15,7 @@ RSpec.describe VerifySubscriberEmailService do
     end
 
     it "makes an API call to send a verification email" do
-      described_class.call(address)
+      expect(described_class.call(address)).to eq(:email)
       expect(request).to have_been_requested
     end
 
@@ -48,6 +49,62 @@ RSpec.describe VerifySubscriberEmailService do
 
       expect { described_class.call(address) }
         .to raise_error(described_class::RatelimitExceededError)
+    end
+
+    context "when GOV.UK accounts auth is enabled" do
+      around do |example|
+        ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+          example.run
+        end
+      end
+
+      let!(:match_request) do
+        stub_account_api_match_user_by_email_does_not_exist(email: address)
+      end
+
+      it "makes an API call to check if the address is associated with an account" do
+        described_class.call(address)
+        expect(match_request).to have_been_requested
+      end
+
+      it "makes an API call to send a verification email" do
+        expect(described_class.call(address)).to eq(:email)
+        expect(request).to have_been_requested
+      end
+
+      context "the email address is associated with a GOV.UK account" do
+        let!(:match_request) do
+          stub_account_api_match_user_by_email_does_not_match(email: address)
+        end
+
+        it "reauthenticates the user" do
+          expect(described_class.call(address)).to eq(:account_reauthenticate)
+        end
+
+        it "does not make an API call to send a verification email" do
+          described_class.call(address)
+          expect(match_request).to have_been_requested
+          expect(request).not_to have_been_requested
+        end
+
+        context "a GOV.UK account session is provided" do
+          let(:session_id) { "session-id" }
+
+          it "reauthenticates the user" do
+            expect(described_class.call(address, govuk_account_session: session_id)).to eq(:account_reauthenticate)
+          end
+
+          context "the provided session matches the email address" do
+            let!(:match_request) do
+              stub_account_api_match_user_by_email_matches(email: address)
+            end
+
+            it "authenticates the user" do
+              expect(described_class.call(address, govuk_account_session: session_id)).to eq(:account)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When a user comes to `/email/manage/authenticate`, they enter an email
address in a form.  We want to then:

- just log them in to email-alert-frontend, if they're logged into a
GOV.UK account and that GOV.UK account has the same email address; or

- tell them to sign in with their account, if there is a GOV.UK
account with the same email address but they're not logged into it; or

- fall back to the current magic link journey if the email address
does not belong to a GOV.UK account.

<img width="637" alt="Screenshot 2021-11-02 at 12 42 47" src="https://user-images.githubusercontent.com/75235/139848626-e69843e2-bc88-4c10-83c1-b2fe4933a2e4.png">

---

[Trello card](https://trello.com/c/5ZoujfPL/1115-implement-email-management-account-sniffer-logic)
