### PR TITLE
Implement account-based topic subscriptions

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -6,7 +6,6 @@ class AccountSubscriptionsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
 
   DEFAULT_FREQUENCY = "daily"
-  SUCCESS_FLASH = "email-subscription-success"
 
   before_action do
     head :not_found unless govuk_account_auth_enabled?
@@ -49,7 +48,7 @@ class AccountSubscriptionsController < ApplicationController
     result = CreateAccountSubscriptionService.call(@subscriber_list, @frequency, account_session_header)
     reauthenticate_user and return unless result
 
-    account_flash_add SUCCESS_FLASH
+    account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
     set_account_session_header(result[:govuk_account_session])
 
     if subscription_parameters[:return_to_url].blank? || @subscriber_list["url"].blank?

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,6 @@
 class SubscriptionsController < ApplicationController
   include FrequenciesHelper
+  include GovukPersonalisation::ControllerConcern
   before_action :assign_attributes
 
   def new
@@ -16,14 +17,27 @@ class SubscriptionsController < ApplicationController
     if @frequency.present?
       return frequency_form_redirect unless valid_frequency
 
-      redirect_to new_subscription_path(
-        topic_id: @topic_id,
-        frequency: @frequency,
-      )
+      result = CreateAccountSubscriptionService.call(@subscriber_list, @frequency, account_session_header)
+      if result
+        account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
+        set_account_session_header(result[:govuk_account_session])
+        redirect_to process_govuk_account_path
+      else
+        redirect_to new_subscription_path(
+          topic_id: @topic_id,
+          frequency: @frequency,
+        )
+      end
     else
       flash.now[:error] = t("subscriptions.new_frequency.missing_frequency")
       render :new_frequency
     end
+  rescue GdsApi::HTTPUnauthorized
+    logout!
+    redirect_to new_subscription_path(
+      topic_id: @topic_id,
+      frequency: @frequency,
+    )
   end
 
   def verify

--- a/app/services/create_account_subscription_service.rb
+++ b/app/services/create_account_subscription_service.rb
@@ -3,6 +3,8 @@
 class CreateAccountSubscriptionService < ApplicationService
   include AccountHelper
 
+  SUCCESS_FLASH = "email-subscription-success"
+
   def initialize(subscriber_list, frequency, govuk_account_session)
     super()
     @subscriber_list = subscriber_list

--- a/app/services/create_account_subscription_service.rb
+++ b/app/services/create_account_subscription_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CreateAccountSubscriptionService < ApplicationService
+  include AccountHelper
+
+  def initialize(subscriber_list, frequency, govuk_account_session)
+    super()
+    @subscriber_list = subscriber_list
+    @frequency = frequency
+    @govuk_account_session = govuk_account_session
+  end
+
+  def call
+    return false unless govuk_account_auth_enabled?
+    return false unless @govuk_account_session
+
+    response = GdsApi.email_alert_api.link_subscriber_to_govuk_account(
+      govuk_account_session: govuk_account_session,
+    )
+
+    subscriber = response.to_h.fetch("subscriber")
+
+    GdsApi.email_alert_api.subscribe(
+      subscriber_list_id: subscriber_list.fetch("id"),
+      address: subscriber.fetch("address"),
+      frequency: frequency,
+    )
+
+    { govuk_account_session: response["govuk_account_session"] }
+  end
+
+private
+
+  attr_reader :subscriber_list, :frequency, :govuk_account_session
+end

--- a/app/views/subscriptions/use_your_govuk_account.html.erb
+++ b/app/views/subscriptions/use_your_govuk_account.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, t("subscriptions.use_your_govuk_account.heading") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: yield(:title),
+  heading_level: 1,
+  font_size: "l",
+  margin_bottom: 6,
+} %>
+
+<p class="govuk-body"><%= t("subscriptions.use_your_govuk_account.description") %></p>
+
+<p class="govuk-body"><strong><%= @subscriber_list["title"] %></strong></p>
+
+<%= form_tag confirm_account_subscription_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("subscriptions.use_your_govuk_account.continue"),
+  } %>
+<% end %>

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -20,3 +20,7 @@ en:
         <p>Emails sometimes take a few minutes to arrive.</p>
         <p>If you do not receive an email soon, check your spam or junk folder.</p>
         <p>If this does not work, <a class="govuk-link" href="https://www.gov.uk/contact/govuk">contact GOV.UK</a> for help.</p>
+    use_your_govuk_account:
+      heading: You have a GOV.UK account
+      description: "Sign in to subscribe to emails about:"
+      continue: Continue to sign in to your account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
       get "/new" => "subscriptions#new", as: :new_subscription
       post "/frequency" => "subscriptions#frequency", as: :subscription_frequency
       post "/verify" => "subscriptions#verify", as: :verify_subscription
+      post "/verify/account" => "subscriptions#verify_account", as: :verify_subscription_account
       get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
 
       scope "/account" do

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe AccountSubscriptionsController do
         it "creates the subscription with a default frequency, links the subscriber to the GOV.UK account, and redirects to the manage page" do
           post :create, params: { topic_id: topic_id }
           expect(response).to redirect_to(process_govuk_account_path)
-          expect(response.headers["GOVUK-Account-Session"]).to include(AccountSubscriptionsController::SUCCESS_FLASH)
+          expect(response.headers["GOVUK-Account-Session"]).to include(CreateAccountSubscriptionService::SUCCESS_FLASH)
           expect(create_stub).to have_been_made
         end
 
@@ -206,7 +206,7 @@ RSpec.describe AccountSubscriptionsController do
           it "creates the subscription with the correct frequency" do
             post :create, params: { topic_id: topic_id, frequency: frequency }
             expect(response).to redirect_to(process_govuk_account_path)
-            expect(response.headers["GOVUK-Account-Session"]).to include(AccountSubscriptionsController::SUCCESS_FLASH)
+            expect(response.headers["GOVUK-Account-Session"]).to include(CreateAccountSubscriptionService::SUCCESS_FLASH)
             expect(create_stub).to have_been_made
           end
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe SubscriptionsController do
+  include GdsApi::TestHelpers::AccountApi
   include GdsApi::TestHelpers::EmailAlertApi
   include GovukPersonalisation::TestHelpers::Requests
 
@@ -206,7 +207,7 @@ RSpec.describe SubscriptionsController do
         { topic_id: topic_id, frequency: frequency, address: address }
       end
 
-      let!(:request) do
+      let!(:verify_stub) do
         stub_email_alert_api_sends_subscription_verification_email(address, frequency, topic_id)
       end
 
@@ -218,7 +219,49 @@ RSpec.describe SubscriptionsController do
 
       it "sends a request to email-alert-api" do
         post :verify, params: params
-        expect(request).to have_been_requested
+        expect(verify_stub).to have_been_requested
+      end
+
+      context "when the user is logged in" do
+        before { mock_logged_in_session(session_id) }
+
+        let(:session_id) { "session-id" }
+
+        it "sends a request to email-alert-api" do
+          post :verify, params: params
+          expect(verify_stub).to have_been_requested
+        end
+
+        context "when GOV.UK accounts is enabled" do
+          around do |example|
+            ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "enabled" do
+              example.run
+            end
+          end
+
+          context "when there is an account with that email address" do
+            before do
+              stub_account_api_match_user_by_email_matches(email: address)
+            end
+
+            it "prompts the user to sign in to that account" do
+              post :verify, params: params
+              expect(response.body).to include(I18n.t!("subscriptions.use_your_govuk_account.heading"))
+              expect(verify_stub).not_to have_been_requested
+            end
+          end
+
+          context "when there is no account with that email address" do
+            before do
+              stub_account_api_match_user_by_email_does_not_exist(email: address)
+            end
+
+            it "sends a request to email-alert-api" do
+              post :verify, params: params
+              expect(verify_stub).to have_been_requested
+            end
+          end
+        end
       end
     end
 


### PR DESCRIPTION
We want to make two changes to the new topic subscription journey.  The current journey is like so:

1. User ends up on `/email/subscriptions/new?topic_id=...`, which shows a form which asks what frequency they want
2. User submits the frequency
3. User is asked for their email address
4. User submits the email address
5. User is sent an email with a link to click to approve the new subscription

**The first change happens between steps 2 and 3:**

If the user is logged in at this point, we don't ask for their email address.  We just link their notifications to their GOV.UK account (which will send an email if they had prior unlinked active subscriptions), create the subscription, and send them to the subscriptions management page.  This bypasses step 3 onwards.

If the session is invalid (email-alert-api returns a 401 in the linking step), we treat it as if the user were logged out.  So they proceed to the usual step 3..

**The second change happens between steps 4 and 5:**

If the email address the user entered belongs to an account, we render a page telling them that and asking them to sign in:

<img width="676" alt="Screenshot 2021-11-02 at 16 31 05" src="https://user-images.githubusercontent.com/75235/139906638-33327025-4eb2-41d8-8993-2fded9d769d8.png">

The user cannot create the subscription without doing this, so this replaces step 5.  After signing in, the user is sent to the account confirmation page added in #1156.

If the email address does not belong to an account, the user is sent an email with a magic link, as in the normal step 5.

---

[Trello card](https://trello.com/c/gYeVLFU4/1066-implement-account-logic-for-topic-subscriptions)