### PR TITLE
Add /sign-in link to inset on interrupt page

### DIFF
--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -22,7 +22,7 @@
 
 <%= render "govuk_publishing_components/components/inset_text", {
 } do
-  t("single_page_subscriptions.inset_description")
+  t("single_page_subscriptions.inset_description_html")
 end %>
 
 <%= t("single_page_subscriptions.usage_description_html") %>

--- a/config/locales/single_page_subscriptions.yml
+++ b/config/locales/single_page_subscriptions.yml
@@ -6,7 +6,8 @@ en:
     accounts_are_new_description_html: |
       <p class="govuk-body">They are a first step towards creating a single account where you can access all your government services.</p>
       <p class="govuk-body">GOV.UK accounts will eventually replace all other government accounts.</p>
-    inset_description: At the moment, GOV.UK accounts are separate from other government accounts (for example Government Gateway or Universal Credit).
+    inset_description_html: |
+      At the moment, GOV.UK accounts are separate from <a href="/sign-in" class="govuk-link">other government accounts</a> (for example Government Gateway or Universal Credit).
     usage_description_html: |
       <p class="govuk-body">Currently you can only use a GOV.UK account to manage your GOV.UK email subscriptions.</p>
       <p class="govuk-body">We’ll be adding more features and services in the next few months.</p>


### PR DESCRIPTION
## What

The interrupt page is intended to give users more information before
signing up or registering to a linked GOV.UK Account and notification.

We've recently launched the /sign-in page that is intended to help users
navigate through account confusion. We can link to that page here, so
users can explore onwards if they are confused at this point, and return
to this journey later.

## Screenshot
![image](https://user-images.githubusercontent.com/3694062/140339270-b80d64bb-9a4e-4550-a949-477ec266b7c6.png)
