### PR TITLE
Don't send confirmation emails for GOV.UK account users

### DIFF
--- a/app/services/create_account_subscription_service.rb
+++ b/app/services/create_account_subscription_service.rb
@@ -26,6 +26,7 @@ class CreateAccountSubscriptionService < ApplicationService
       subscriber_list_id: subscriber_list.fetch("id"),
       address: subscriber.fetch("address"),
       frequency: frequency,
+      skip_confirmation_email: true,
     )
 
     { govuk_account_session: response["govuk_account_session"] }

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -187,6 +187,7 @@ RSpec.describe AccountSubscriptionsController do
             subscriber_list_id: subscriber_list_id,
             address: address,
             frequency: created_frequency,
+            skip_confirmation_email: true,
           )
         end
 

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe SinglePageSubscriptionsController do
             address: user_email,
             frequency: "daily",
             returned_subscription_id: "subscription-id",
-            skip_confirmation_email: false,
+            skip_confirmation_email: true,
             subscriber_id: subscriber_id,
           )
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -127,6 +127,7 @@ RSpec.describe SubscriptionsController do
               subscriber_list_id: subscriber_list_id,
               address: address,
               frequency: frequency,
+              skip_confirmation_email: true,
             )
           end
 


### PR DESCRIPTION
If someone is signed into a GOV.UK account, they must have already
confirmed their email address when they created the account. They also
will have clicked a button or gone through a form to sign up to the email
notifications.

This means we don't need to send them an additional confirmation email
like we do for people who aren't using a GOV.UK account.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
