### PR TITLE
Rename single-page subscriptions parameter to base_path

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -11,7 +11,7 @@ class SinglePageSubscriptionsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:show]
 
   def show
-    content_item = GdsApi.content_store.content_item(topic).to_h
+    content_item = GdsApi.content_store.content_item(base_path).to_h
     return unless logged_in?
 
     subscriber = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(
@@ -22,7 +22,7 @@ class SinglePageSubscriptionsController < ApplicationController
 
     subscriber_list = GdsApi.email_alert_api.find_or_create_subscriber_list(
       {
-        url: topic,
+        url: base_path,
         name: content_item["title"],
         content_id: content_item["content_id"],
       },
@@ -40,7 +40,7 @@ class SinglePageSubscriptionsController < ApplicationController
       set_account_session_header(result[:govuk_account_session])
     end
 
-    redirect_to topic
+    redirect_to base_path
   rescue GdsApi::ContentStore::ItemNotFound
     head :not_found
   rescue GdsApi::HTTPUnauthorized
@@ -54,12 +54,12 @@ class SinglePageSubscriptionsController < ApplicationController
 
 private
 
-  def topic
-    @topic ||= params.fetch(:topic)
+  def base_path
+    @base_path ||= params.fetch(:base_path)
   end
 
   def single_page_session_path
-    redirect_path = "#{confirm_account_subscription_path}?topic=#{topic}"
+    redirect_path = "#{confirm_account_subscription_path}?base_path=#{base_path}"
 
     GdsApi.account_api.get_sign_in_url(
       redirect_path: redirect_path,

--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -33,6 +33,6 @@ end %>
     text: t("single_page_subscriptions.create_or_sign_in_description")
   } %>
 
-  <%= hidden_field_tag(:topic, @topic) %>
+  <%= hidden_field_tag(:base_path, @base_path) %>
 
 <% end %>

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe SinglePageSubscriptionsController do
 
   render_views
 
-  let(:topic) { "/test" }
+  let(:base_path) { "/test" }
   let(:topic_slug) { SecureRandom.uuid }
   let(:topic_name) { "Test" }
-  let(:redirect_path) { "/email/subscriptions/account/confirm?topic=#{topic}" }
+  let(:redirect_path) { "/email/subscriptions/account/confirm?base_path=#{base_path}" }
   let(:auth_provider) { "http://auth/provider" }
-  let(:params) { { topic: topic } }
+  let(:params) { { base_path: base_path } }
 
   describe "when feature flag is not 'enabled'" do
     it "POST /email/subscriptions/single-page/new-session returns 404" do
@@ -48,17 +48,17 @@ RSpec.describe SinglePageSubscriptionsController do
 
     describe "POST /email/subscriptions/single-page/new" do
       before do
-        stub_content_store_has_item(topic)
+        stub_content_store_has_item(base_path)
       end
 
       it "404s when a content item can't be found" do
-        stub_content_store_does_not_have_item(topic)
+        stub_content_store_does_not_have_item(base_path)
         get :show, params: params
         expect(response).to have_http_status(:not_found)
       end
 
       context "when a user is not logged in" do
-        it "renders the view with a sign in link including the topic" do
+        it "renders the view with a sign in link including the base_path" do
           get :show, params: params
           expect(response.body).to include(single_page_new_session_path)
         end
@@ -89,7 +89,7 @@ RSpec.describe SinglePageSubscriptionsController do
           )
 
           stub_email_alert_api_creates_subscriber_list({
-            url: topic,
+            url: base_path,
             title: topic_name,
             slug: topic_slug,
             id: subscription_list_id,
@@ -120,10 +120,10 @@ RSpec.describe SinglePageSubscriptionsController do
 
         it "subscribes them and redirects back to the page" do
           post :show, params: params
-          expect(response).to redirect_to("http://test.host#{topic}")
+          expect(response).to redirect_to("http://test.host#{base_path}")
         end
 
-        context "when the user is already subscribed to that topic" do
+        context "when the user is already subscribed to that base_path" do
           let(:subscription_id) { "subscription-id" }
 
           before do
@@ -138,7 +138,7 @@ RSpec.describe SinglePageSubscriptionsController do
                   "id" => subscription_id,
                   "subscriber_list" => {
                     "id" => subscription_list_id,
-                    "slug" => topic,
+                    "slug" => base_path,
                   },
                 },
               ],
@@ -148,7 +148,7 @@ RSpec.describe SinglePageSubscriptionsController do
 
           it "unsubscribes them and redirects back to the page" do
             post :show, params: params
-            expect(response).to redirect_to("http://test.host#{topic}")
+            expect(response).to redirect_to("http://test.host#{base_path}")
           end
         end
       end


### PR DESCRIPTION
This is to be consistent with what we're calling the parameter in the
component and in account-api.

---

[Trello card](https://trello.com/c/oOpGMmxF/1126-put-the-single-page-signup-button-on-some-pages)
