### PR TITLE
Fix target and fields for account topic subscriptions

### DIFF
--- a/app/views/subscriptions/use_your_govuk_account.html.erb
+++ b/app/views/subscriptions/use_your_govuk_account.html.erb
@@ -11,7 +11,10 @@
 
 <p class="govuk-body"><strong><%= @subscriber_list["title"] %></strong></p>
 
-<%= form_tag confirm_account_subscription_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+<%= form_tag verify_subscription_account_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+  <%= hidden_field_tag :topic_id, @topic_id %>
+  <%= hidden_field_tag :frequency, @frequency %>
+
   <%= render "govuk_publishing_components/components/button", {
     text: t("subscriptions.use_your_govuk_account.continue"),
   } %>


### PR DESCRIPTION
This should go to the `verify_subscription_account` route (which is
otherwise unreachable), as that's what redirects to the confirmation
page with the appropriate parameters.
