### PR TITLE
Send confirmation email when creating an account subscription

### DIFF
--- a/app/services/create_account_subscription_service.rb
+++ b/app/services/create_account_subscription_service.rb
@@ -26,7 +26,6 @@ class CreateAccountSubscriptionService < ApplicationService
       subscriber_list_id: subscriber_list.fetch("id"),
       address: subscriber.fetch("address"),
       frequency: frequency,
-      skip_confirmation_email: true,
     )
 
     { govuk_account_session: response["govuk_account_session"] }

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -187,7 +187,6 @@ RSpec.describe AccountSubscriptionsController do
             subscriber_list_id: subscriber_list_id,
             address: address,
             frequency: created_frequency,
-            skip_confirmation_email: true,
           )
         end
 

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -100,7 +100,6 @@ RSpec.describe SinglePageSubscriptionsController do
             address: user_email,
             frequency: "daily",
             returned_subscription_id: "subscription-id",
-            skip_confirmation_email: true,
             subscriber_id: subscriber_id,
           )
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -127,7 +127,6 @@ RSpec.describe SubscriptionsController do
               subscriber_list_id: subscriber_list_id,
               address: address,
               frequency: frequency,
-              skip_confirmation_email: true,
             )
           end
 


### PR DESCRIPTION
We don't send these for brexit checker subscriptions created through
account-api, but for normal subscriptions created through this app, we
do want them.
