### PR TITLE
Pass topic_id of single-page subscription to account confirm page

### DIFF
--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -33,6 +33,6 @@ end %>
     text: t("single_page_subscriptions.create_or_sign_in_description")
   } %>
 
-  <%= hidden_field_tag(:base_path, @base_path) %>
+  <%= hidden_field_tag(:topic_id, @topic_id) %>
 
 <% end %>


### PR DESCRIPTION
The confirmation page expects a `topic_id` parameter, which is the
slug of the `SubscriberList`.

This commit has a slight change of behaviour: previously we wouldn't
call email-alert-api to find-or-create the `SubscriberList` if the
user were logged out.  Now we do, so that we can get the slug.

I also changed some `[]`s into `fetch`es where the values are
required, and removed a redundant `rescue` (which is handled by a
`rescue_from` in the `ApplicationController`).

---

[Trello card](https://trello.com/c/05BtVxFZ/1100-prep-to-qa-single-page-notifications-journeys)
