### PR TITLE
Fix invocation of find_or_create_subscriber_list

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -50,7 +50,7 @@ private
     @subscriber_list = GdsApi.email_alert_api.find_or_create_subscriber_list(
       {
         url: @content_item.fetch("base_path"),
-        name: @content_item.fetch("title"),
+        title: @content_item.fetch("title"),
         content_id: @content_item.fetch("content_id"),
       },
     ).to_h.fetch("subscriber_list")


### PR DESCRIPTION
The parameter is called "title", not "name".  Previously this was
obscured by this call not being made if the user is logged out.

---

[Trello card](https://trello.com/c/GKKcketU/1132-qa-snag-list)
