### PR TITLE
Reauthenticate user if they have no session

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -28,6 +28,8 @@ class AccountSubscriptionsController < ApplicationController
   rescue_from GdsApi::HTTPForbidden, with: :reauthenticate_user
 
   def confirm
+    reauthenticate_user and return unless logged_in?
+
     response = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(
       govuk_account_session: account_session_header,
     )

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -132,6 +132,24 @@ RSpec.describe AccountSubscriptionsController do
           end
         end
 
+        context "when the user has no session" do
+          before do
+            mock_logged_in_session(nil)
+            stub_account_api_get_sign_in_url(
+              redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
+              auth_uri: auth_uri,
+            )
+          end
+
+          let(:auth_uri) { "/sign-in" }
+
+          it "logs the user out and redirects to sign in" do
+            get :confirm, params: { topic_id: topic_id }
+            expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
+            expect(response).to redirect_to(auth_uri)
+          end
+        end
+
         context "when the user's session is invalid" do
           before do
             stub_email_alert_api_authenticate_subscriber_by_govuk_account_session_invalid(session_id)


### PR DESCRIPTION
`authenticate_subscriber_by_govuk_account` throws a 422 error if the
`govuk_account_session` parameter is not given, because it's
mandatory.

But the `rescue_from`s in this controller didn't handle that, and so
if an unauthenticated user got to this page somehow, they would be
served a 400 error.  This situation is unlikely (I only triggered it
by logging out and then manually visiting the URL) but still not
great.

So, gracefully handle this case, by checking if a session exists at
all before trying to use it.

---

[Trello card](https://trello.com/c/GKKcketU/1132-qa-snag-list)
