### PR TITLE
Fix references to `return_to_url` instance var

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -15,6 +15,7 @@ class AccountSubscriptionsController < ApplicationController
     @topic_id = subscription_parameters.fetch(:topic_id)
     @subscriber_list = GdsApi.email_alert_api.get_subscriber_list(slug: @topic_id).to_h.fetch("subscriber_list")
     @frequency = subscription_parameters.fetch(:frequency, DEFAULT_FREQUENCY)
+    @return_to_url = params[:return_to_url]
 
     unless valid_frequencies.include?(@frequency)
       redirect_with_analytics confirm_account_subscription_path(
@@ -51,7 +52,7 @@ class AccountSubscriptionsController < ApplicationController
     account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
     set_account_session_header(result[:govuk_account_session])
 
-    if subscription_parameters[:return_to_url].blank? || @subscriber_list["url"].blank?
+    if @return_to_url.blank? || @subscriber_list["url"].blank?
       redirect_to process_govuk_account_path
     else
       redirect_to @subscriber_list["url"]

--- a/app/views/account_subscriptions/confirm.html.erb
+++ b/app/views/account_subscriptions/confirm.html.erb
@@ -16,9 +16,9 @@
 </p>
 
 <%= form_tag(action: :create) do %>
-  <%= hidden_field_tag "topic_id", params[:topic_id] %>
-  <%= hidden_field_tag "frequency", params[:frequency] %>
-  <%= hidden_field_tag "return_to_url", params[:return_to_url] %>
+  <%= hidden_field_tag "topic_id", @topic_id %>
+  <%= hidden_field_tag "frequency", @frequency %>
+  <%= hidden_field_tag "return_to_url", @return_to_url %>
   <%= render "govuk_publishing_components/components/button", {
     text: t("account_subscriptions.confirm.confirm"),
     margin_bottom: 4,


### PR DESCRIPTION
We use this in a couple of places, but it's not actually set by the
`before_action`.

---

[Trello card](https://trello.com/c/GKKcketU/1132-qa-snag-list)
