### PR TITLE
Do not create a session cookie for account users

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -88,8 +88,8 @@ class SubscriptionsManagementController < ApplicationController
     redirect_to list_subscriptions_path
   end
 
-  helper_method def use_govuk_account_layout?
-    if session.dig("authentication", "linked_to_govuk_account")
+  def use_govuk_account_layout?
+    if authenticated_via_account?
       set_slimmer_headers(template: "gem_layout_account_manager", remove_search: true, show_accounts: "signed-in")
       true
     end
@@ -98,7 +98,7 @@ class SubscriptionsManagementController < ApplicationController
 private
 
   def set_account_change_email_url
-    if session.dig("authentication", "linked_to_govuk_account")
+    if authenticated_via_account?
       @account_change_email_url = GovukPersonalisation::Urls.manage
     end
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,8 +1,7 @@
 module SessionsHelper
-  def authenticate_subscriber(subscriber_id, linked_to_govuk_account: false)
+  def authenticate_subscriber(subscriber_id)
     session["authentication"] = {
       "subscriber_id" => subscriber_id,
-      "linked_to_govuk_account" => linked_to_govuk_account,
     }
   end
 

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -191,9 +191,14 @@ RSpec.describe SubscriberAuthenticationController do
         expect(response).to redirect_to(list_subscriptions_path)
       end
 
-      it "creates a session for the subscriber" do
+      it "does not create a new session" do
         get :process_govuk_account
-        expect(session.to_h).to include(session_for(subscriber_id, linked_to_govuk_account: true))
+        expect(session["authentication"]).to be_nil
+      end
+
+      it "clears any existing session" do
+        get :process_govuk_account, session: session_for(subscriber_id)
+        expect(session["authentication"]).to be_nil
       end
 
       it "sets the Vary response header" do
@@ -223,16 +228,6 @@ RSpec.describe SubscriberAuthenticationController do
           get :process_govuk_account
           expect(response).to redirect_to(auth_uri)
         end
-
-        it "sets the logout session header" do
-          get :process_govuk_account
-          expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
-        end
-
-        it "clears any existing session" do
-          get :process_govuk_account, session: session_for(subscriber_id)
-          expect(session.to_h).to_not include(session_for(subscriber_id))
-        end
       end
 
       context "when the user's session is invalid" do
@@ -251,11 +246,6 @@ RSpec.describe SubscriberAuthenticationController do
         it "sets the logout session header" do
           get :process_govuk_account
           expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
-        end
-
-        it "clears any existing session" do
-          get :process_govuk_account, session: session_for(subscriber_id)
-          expect(session.to_h).to_not include(session_for(subscriber_id))
         end
       end
 

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe SubscriptionsManagementController do
   include GdsApi::TestHelpers::EmailAlertApi
+  include GovukPersonalisation::TestHelpers::Requests
   include SessionHelper
 
   let(:subscriber_id) { 1 }
@@ -110,10 +111,15 @@ RSpec.describe SubscriptionsManagementController do
         end
       end
 
-      let(:session_linked_to_govuk_account) { session_for(subscriber_id, linked_to_govuk_account: true) }
+      before do
+        mock_logged_in_session(session_id)
+        stub_email_alert_api_link_subscriber_to_govuk_account(session_id, subscriber_id, subscriber_address)
+      end
+
+      let(:session_id) { "session-id" }
 
       it "points the 'change email' link to the account" do
-        get :index, session: session_linked_to_govuk_account
+        get :index
         expect(response.body).to include(ENV.fetch("GOVUK_PERSONALISATION_MANAGE_URI"))
       end
     end
@@ -197,10 +203,15 @@ RSpec.describe SubscriptionsManagementController do
           end
         end
 
-        let(:session_linked_to_govuk_account) { session_for(subscriber_id, linked_to_govuk_account: true) }
+        before do
+          mock_logged_in_session(session_id)
+          stub_email_alert_api_link_subscriber_to_govuk_account(session_id, subscriber_id, subscriber_address)
+        end
+
+        let(:session_id) { "session-id" }
 
         it "redirects to the account" do
-          get :update_address, session: session_linked_to_govuk_account
+          get :update_address
           expect(response).to redirect_to(ENV.fetch("GOVUK_PERSONALISATION_MANAGE_URI"))
         end
       end
@@ -215,10 +226,15 @@ RSpec.describe SubscriptionsManagementController do
         end
       end
 
-      let(:session_linked_to_govuk_account) { session_for(subscriber_id, linked_to_govuk_account: true) }
+      before do
+        mock_logged_in_session(session_id)
+        stub_email_alert_api_link_subscriber_to_govuk_account(session_id, subscriber_id, subscriber_address)
+      end
+
+      let(:session_id) { "session-id" }
 
       it "redirects to the account" do
-        post :change_address, session: session_linked_to_govuk_account
+        post :change_address
         expect(response).to redirect_to(ENV.fetch("GOVUK_PERSONALISATION_MANAGE_URI"))
       end
     end

--- a/spec/support/session_helper.rb
+++ b/spec/support/session_helper.rb
@@ -1,9 +1,8 @@
 module SessionHelper
-  def session_for(subscriber_id, linked_to_govuk_account: false)
+  def session_for(subscriber_id)
     {
       "authentication": {
         "subscriber_id": subscriber_id,
-        "linked_to_govuk_account": linked_to_govuk_account,
       },
     }.with_indifferent_access
   end


### PR DESCRIPTION
If a user is signing in to this app via their GOV.UK account, we don't
want to create a separate session cookie: if we do, we then have to
tie together deleting the email-alert-frontend session cookie when we
log a user out, and it's potentially confusing that the
email-alert-frontend session cookie will expire before the
`__Host-govuk_account_session` one

So, we change the authentication in this app to *preferentially* use
the GOV.UK account (see `authenticated_via_account?` ahead of
`session["authentication"}.present?` in the conditional).

When using account auth, no session cookie is created, we fall back to
linking with an email-alert-api subscriber on every request.  This
will be slower, but we can keep an eye on performance, as we expect a
gradual ramp-up of notifications users also using an account.

This does mean we have two totally separate authentication mechanisms
in the same app, until we migrate all notifications users over to the
GOV.UK account, which is a bit of a code smell.

---

[Trello card](https://trello.com/c/GKKcketU/1132-qa-snag-list)
