### PR TITLE
Accounts frontend changes from QA session

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@ $govuk-new-link-styles: true;
 @import 'govuk_publishing_components/govuk_frontend_support';
 @import 'govuk_publishing_components/component_support';
 @import 'govuk_publishing_components/components/back-link';
+@import 'govuk_publishing_components/components/breadcrumbs';
 @import 'govuk_publishing_components/components/button';
 @import 'govuk_publishing_components/components/details';
 @import 'govuk_publishing_components/components/error-message';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,8 @@
     <meta name="robots" content="noindex, nofollow">
   </head>
   <body class="govuk-template__body">
-    <div class="govuk-width-container" id="wrapper">
-      <% if use_govuk_account_layout? %>
+    <% if use_govuk_account_layout? %>
+      <div id="wrapper">
         <% content_for :before_content do %>
           <%= yield :back_link %>
         <% end %>
@@ -22,7 +22,9 @@
         <main role="main" id="content">
           <%= yield %>
         </main>
-      <% else %>
+      </div>
+    <% else %>
+      <div class="govuk-width-container" id="wrapper">
         <%= yield :back_link %>
         <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" role="main" id="content">
           <div id="email-alert-frontend">
@@ -33,8 +35,8 @@
             </div>
           </div>
         </main>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
     <%= javascript_include_tag 'application' %>
   </body>
 </html>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -25,38 +25,76 @@
   <% end %>
 <% end %>
 
+<% if use_govuk_account_layout? %>
+  <% content_for :before_content do %>
+    <%= render "govuk_publishing_components/components/breadcrumbs", {
+      collapse_on_mobile: true,
+      breadcrumbs: [
+        {
+          title: t("subscriptions_management.account_breadcrumb"),
+          url: GovukPersonalisation::Urls.your_account,
+        },
+      ]
+    } %>
+    <% end %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: t("subscriptions_management.heading"),
   heading_level: 1,
-  font_size: "l",
+  font_size: "xl",
   margin_bottom: 6,
 } %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Subscriptions for #{@subscriber['address']}",
-  heading_level: 2,
-  font_size: "m",
-  margin_bottom: 4,
-} %>
+<% unless use_govuk_account_layout? %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Subscriptions for #{@subscriber['address']}",
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 4,
+  } %>
 
-<p class="govuk-body">
-  <%= link_to "Change email address",
-              @account_change_email_url || update_address_path,
-              class: %w[govuk-link govuk-link--no-visited-state] %>
-</p>
+  <p class="govuk-body">
+    <%= link_to "Change email address",
+                update_address_path,
+                class: %w[govuk-link govuk-link--no-visited-state] %>
+  </p>
 
-<hr class="govuk-section-break govuk-section-break--l">
+  <hr class="govuk-section-break govuk-section-break--l">
+<% end %>
 
 <% if @subscriptions.empty? %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <%= t("subscriptions_management.no_subscriptions_warning_html") %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 <% else %>
+  <% unsubscribe_all_text = capture do %>
+    <p class="govuk-body">
+      <%= link_to "Unsubscribe from everything",
+                  confirm_unsubscribe_all_path,
+                  class: %w[govuk-link govuk-link--no-visited-state] %>
+    </p>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: unsubscribe_all_text
+  } %>
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
   <% @subscriptions.each do |_key, subscription| %>
+    <span class="govuk-body govuk-!-margin-bottom-3">
+      <% if is_single_page_subscription?(subscription) %>
+        Page
+      <% else %>
+        Topic
+      <% end %>
+    </span>
+
     <%= render "govuk_publishing_components/components/heading", {
       text: subscription['subscriber_list']['title'],
-      heading_level: 3,
-      font_size: "s",
+      heading_level: use_govuk_account_layout? ? 2 : 3,
+      font_size: "m",
       margin_bottom: 4
     } %>
 
@@ -75,7 +113,7 @@
       <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
       <br>
       <% change_frequency_link_text = capture do %>
-        Change how often you get updates <span class="govuk-visually-hidden"> about <%= subscription['subscriber_list']['title'] %></span>
+        Change how often you get emails <span class="govuk-visually-hidden"> about <%= subscription['subscriber_list']['title'] %></span>
       <% end %>
       <%= link_to change_frequency_link_text,
                   update_frequency_path(id: subscription['id']),
@@ -89,18 +127,7 @@
                   confirm_unsubscribe_path(id: subscription['id']),
                   class: %w[govuk-link govuk-link--no-visited-state] %>
     </p>
-    <hr class="govuk-section-break govuk-section-break--m">
-  <% end %>
 
-  <% unsubscribe_all_text = capture do %>
-    <p class="govuk-body">
-      <%= link_to "Unsubscribe from everything",
-                  confirm_unsubscribe_all_path,
-                  class: %w[govuk-link govuk-link--no-visited-state] %>
-    </p>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   <% end %>
-
-  <%= render "govuk_publishing_components/components/inset_text", {
-    text: unsubscribe_all_text
-  } %>
 <% end %>

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -1,6 +1,7 @@
 en:
   subscriptions_management:
-    heading: Manage your GOV.UK emails
+    heading: Manage your GOV.UK email subscriptions
+    account_breadcrumb: Go back to your account
     index:
       subscription:
         immediately: "You get updates as soon as they happen."

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe SubscriptionsManagementController do
 
     context "when the subscriber is logged in through a GOV.UK Account" do
       around do |example|
-        ClimateControl.modify(FEATURE_FLAG_GOVUK_ACCOUNT: "enabled", GOVUK_PERSONALISATION_MANAGE_URI: "https://www.gov.uk/change-your-password") do
+        ClimateControl.modify(FEATURE_FLAG_GOVUK_ACCOUNT: "enabled") do
           example.run
         end
       end
@@ -118,9 +118,9 @@ RSpec.describe SubscriptionsManagementController do
 
       let(:session_id) { "session-id" }
 
-      it "points the 'change email' link to the account" do
+      it "does not show the 'change email' link" do
         get :index
-        expect(response.body).to include(ENV.fetch("GOVUK_PERSONALISATION_MANAGE_URI"))
+        expect(response.body).not_to include("Change email address")
       end
     end
   end
@@ -198,7 +198,7 @@ RSpec.describe SubscriptionsManagementController do
 
       context "when the subscriber is logged in through a GOV.UK Account" do
         around do |example|
-          ClimateControl.modify(FEATURE_FLAG_GOVUK_ACCOUNT: "enabled", GOVUK_PERSONALISATION_MANAGE_URI: "https://www.gov.uk/change-your-password") do
+          ClimateControl.modify(FEATURE_FLAG_GOVUK_ACCOUNT: "enabled") do
             example.run
           end
         end
@@ -210,9 +210,9 @@ RSpec.describe SubscriptionsManagementController do
 
         let(:session_id) { "session-id" }
 
-        it "redirects to the account" do
+        it "returns a 404" do
           get :update_address
-          expect(response).to redirect_to(ENV.fetch("GOVUK_PERSONALISATION_MANAGE_URI"))
+          expect(response).to have_http_status(:not_found)
         end
       end
     end
@@ -221,7 +221,7 @@ RSpec.describe SubscriptionsManagementController do
   describe "POST /email/manage/address/change" do
     context "when the subscriber is logged in through a GOV.UK Account" do
       around do |example|
-        ClimateControl.modify(FEATURE_FLAG_GOVUK_ACCOUNT: "enabled", GOVUK_PERSONALISATION_MANAGE_URI: "https://www.gov.uk/change-your-password") do
+        ClimateControl.modify(FEATURE_FLAG_GOVUK_ACCOUNT: "enabled") do
           example.run
         end
       end
@@ -233,9 +233,9 @@ RSpec.describe SubscriptionsManagementController do
 
       let(:session_id) { "session-id" }
 
-      it "redirects to the account" do
+      it "returns a 404" do
         post :change_address
-        expect(response).to redirect_to(ENV.fetch("GOVUK_PERSONALISATION_MANAGE_URI"))
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/features/change_email_frequency_spec.rb
+++ b/spec/features/change_email_frequency_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature "Change email frequency" do
   end
 
   def when_i_click_to_change_how_often_i_get_updates
-    click_on "Change how often you get updates"
+    click_on "Change how often you get emails"
   end
 
   def and_i_select_once_a_week

--- a/spec/views/subscriptions_management/index.html.erb_spec.rb
+++ b/spec/views/subscriptions_management/index.html.erb_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe "subscriptions_management/index" do
   before do
     assign(:subscriber, {})
+    allow(view).to receive(:use_govuk_account_layout?).and_return(false)
+    allow(view).to receive(:is_single_page_subscription?).and_return(false)
   end
 
   %w[daily weekly immediately].each do |frequency|
@@ -26,7 +28,7 @@ RSpec.describe "subscriptions_management/index" do
         )
         expect(rendered).to have_css("a[href='#{confirm_unsubscribe_path(subscription['id'])}'] .govuk-visually-hidden", text: "from #{subscription['subscriber_list']['title']}")
         expect(rendered).to have_css("a[href='#{update_frequency_path(subscription['id'])}'] .govuk-visually-hidden", text: "about #{subscription['subscriber_list']['title']}")
-        expect(rendered).to have_content("Change how often you get updates about #{subscription['subscriber_list']['title']}", normalize_ws: true)
+        expect(rendered).to have_content("Change how often you get emails about #{subscription['subscriber_list']['title']}", normalize_ws: true)
         expect(rendered).to have_content("Unsubscribe from #{subscription['subscriber_list']['title']}", normalize_ws: true)
       end
     end


### PR DESCRIPTION
See commits for details.

But this isn't quite right currently:

1. The dividers between subscriptions aren't showing up.  There are `<hr>`s in the source (and were before I changed anything), so I guess some CSS is missing somewhere.
2. I don't know how to style the "topic" and "page" headers in the last commit to look like our designs, so I've just added them here to be styled.

<img width="1055" alt="Screenshot 2021-11-12 at 10 27 44" src="https://user-images.githubusercontent.com/75235/141452207-e7bb6201-db50-4bc9-b68a-a5ee224f9dc4.png">

---

[Trello card](https://trello.com/c/4MKj7G4o/1135-govuk-account-email-subscriptions-page-design-amends)
