### PR TITLE
Change default single page notification frequency to immediately

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -27,7 +27,7 @@ class SinglePageSubscriptionsController < ApplicationController
       GdsApi.email_alert_api.unsubscribe(subscription["id"])
       account_flash_add UNSUBSCRIBE_FLASH
     else
-      result = CreateAccountSubscriptionService.call(@subscriber_list, "daily", @account_session_header)
+      result = CreateAccountSubscriptionService.call(@subscriber_list, "immediately", @account_session_header)
       account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
       set_account_session_header(result[:govuk_account_session])
     end

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe SinglePageSubscriptionsController do
           stub_email_alert_api_creates_a_subscription(
             subscriber_list_id: subscription_list_id,
             address: user_email,
-            frequency: "daily",
+            frequency: "immediately",
             returned_subscription_id: "subscription-id",
             subscriber_id: subscriber_id,
           )
@@ -138,7 +138,7 @@ RSpec.describe SinglePageSubscriptionsController do
                 {
                   "subscriber_id" => subscriber_id,
                   "subscriber_list_id" => subscription_list_id,
-                  "frequency" => "daily",
+                  "frequency" => "immediately",
                   "id" => subscription_id,
                   "subscriber_list" => {
                     "id" => subscription_list_id,


### PR DESCRIPTION
This is so it matches the information we give to users as they go through the subscription journey.

[Trello](https://trello.com/c/Goq1BJZP/1155-change-default-frequency-of-single-page-notifications-to-as-updates-happen)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
