### PR TITLE
Fix arguments to sign in form

### DIFF
--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -27,7 +27,7 @@ end %>
 
 <%= t("single_page_subscriptions.usage_description_html") %>
 
-<%= form_tag single_page_new_session_path method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+<%= form_tag single_page_new_session_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
 
   <%= render "govuk_publishing_components/components/button", {
     text: t("single_page_subscriptions.create_or_sign_in_description")


### PR DESCRIPTION
The comma was missing which meant the extra parameters were passed to
`single_page_new_session_path` and ended up as parameters in the action
URL, rather than attributes in the rendered HTML.

[Trello](https://trello.com/c/3NvEng3t/1159-fix-passing-ga-cookie-consent-parameters-from-email-subscriptions-the-way-you-subscribe-page-to-di)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
