### PR TITLE
Update content on email management pages

### DIFF
--- a/app/helpers/subscriptions_helper.rb
+++ b/app/helpers/subscriptions_helper.rb
@@ -5,4 +5,12 @@ module SubscriptionsHelper
 
     content_item["public_updated_at"]
   end
+
+  def get_heading_content(subscription)
+    if subscription.dig("subscriber_list", "content_id").present?
+      link_to subscription["subscriber_list"]["title"], subscription["subscriber_list"]["url"], class: "govuk-link"
+    else
+      subscription["subscriber_list"]["title"]
+    end
+  end
 end

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -105,7 +105,7 @@
     <% end %>
 
     <p class='govuk-body'>
-      <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
+      <%= subscription['created_at'].to_datetime.strftime(t("subscriptions_management.index.you_subscribed")) %>
     </p>
     <% if subscription['subscriber_list']['url'] =~ %r{transition-check/results} ||
       subscription['subscriber_list']['url'] =~ %r{get-ready-brexit-check/results} %>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -92,7 +92,7 @@
     </span>
 
     <%= render "govuk_publishing_components/components/heading", {
-      text: subscription['subscriber_list']['title'],
+      text: get_heading_content(subscription),
       heading_level: use_govuk_account_layout? ? 2 : 3,
       font_size: "m",
       margin_bottom: 4

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -16,6 +16,7 @@ en:
           daily: "You’ll get one email a day from GOV.UK about:"
           weekly: "You’ll get one email a week from GOV.UK about:"
       last_updated: "This page was last updated on %-d %B %Y"
+      you_subscribed: "You subscribed on %-d %B %Y at %-I:%M%P"
     no_subscriptions_warning_html: |
       <p class="govuk-body">You’re not currently getting emails about updates to GOV.UK.</p>
       <p class="govuk-body">Some GOV.UK pages have a link to ‘get emails’. You can use that link to subscribe to pages or topics you’re interested in.</p>

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe SubscriptionsManagementController do
       it "renders the subscriber's subscriptions" do
         get :index, session: session
         expect(response.body).to include("Some thing")
-        expect(response.body).to include("Created on 16 September 2019 at 2:08am")
+        expect(response.body).to include("You subscribed on 16 September 2019 at 2:08am")
       end
 
       context "when the subscription is to a single page" do

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -147,6 +147,28 @@ RSpec.describe SubscriptionsManagementController do
         get :index
         expect(response.body).not_to include("Change email address")
       end
+
+      context "when the subscriber has a single page subscription" do
+        before do
+          stub_email_alert_api_has_subscriber_subscriptions(
+            subscriber_id,
+            subscriber_address,
+            subscriptions: [
+              {
+                "id" => subscription_id,
+                "created_at" => "2019-09-16 02:08:08 01:00",
+                "subscriber_list" => { "title" => "Some thing", "url" => "/some-thing", "content_id" => "abc123" },
+              },
+            ],
+          )
+          stub_content_store_has_item("/some-thing")
+        end
+
+        it "makes the heading a link to the page" do
+          get :index
+          expect(response.body).to include('href="/some-thing"')
+        end
+      end
     end
   end
 

--- a/spec/helpers/subscriptions_helper_spec.rb
+++ b/spec/helpers/subscriptions_helper_spec.rb
@@ -22,4 +22,40 @@ describe SubscriptionsHelper do
       expect(updated).to eq("2014-05-06T12:01:00+00:00")
     end
   end
+
+  describe "#get_heading_content" do
+    let(:subscription) do
+      {
+        "id" => 12_345,
+        "subscriber_list" => {
+          "id" => "abc123",
+          "title" => "A list title",
+        },
+      }
+    end
+    it "returns the list title for a topic subscription" do
+      result = get_heading_content(subscription)
+      expect(result).to eq("A list title")
+    end
+
+    context "when the subscription is for a single page" do
+      let(:subscription) do
+        {
+          "id" => 12_345,
+          "subscriber_list" => {
+            "id" => "abc123",
+            "title" => "A single page subscription",
+            "content_id" => "def456",
+            "url" => "/a-single-page",
+          },
+        }
+      end
+
+      it "returns a link to the page" do
+        result = get_heading_content(subscription)
+        expect(result).to include('href="/a-single-page"')
+        expect(result).to include("A single page subscription")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Make the heading a link for single page subscriptions and change 'created on' to 'you subscribed on' to match our designs.

[Trello](https://trello.com/c/Z9b4Ar5z/1156-update-email-subscriptions-management-page-content)
[Figma](https://www.figma.com/file/9RzsNFl3iYBXM5QfKO2HkE/Single-page-notifications-feature?node-id=4%3A2237)

There's a third item on the linked Trello card - the change for that will come in a separate PR.

The new page with a single page subscription:
![image](https://user-images.githubusercontent.com/6362602/142033033-e91e1b91-ddcc-4880-85a7-d06abe42fb10.png)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
