### PR TITLE
Make h1 on the email subscriptions management page smaller

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -42,7 +42,7 @@
 <%= render "govuk_publishing_components/components/heading", {
   text: t("subscriptions_management.heading"),
   heading_level: 1,
-  font_size: "xl",
+  font_size: "l",
   margin_bottom: 6,
 } %>
 


### PR DESCRIPTION
We increased the size of this heading to `xl`, but that is too large.
Change the heading back to `l` size.

https://trello.com/c/pPJCeMT9/1157-make-email-subscriptions-management-page-heading-smaller

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
