### PR TITLE
Show last update date for single page subscriptions

### DIFF
--- a/app/helpers/subscriptions_helper.rb
+++ b/app/helpers/subscriptions_helper.rb
@@ -1,0 +1,8 @@
+module SubscriptionsHelper
+  def get_updated_at_from_subscription(subscription)
+    base_path = subscription["subscriber_list"]["url"]
+    content_item = GdsApi.content_store.content_item(base_path)
+
+    content_item["public_updated_at"]
+  end
+end

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -100,7 +100,7 @@
 
     <% if is_single_page_subscription?(subscription) %>
       <p class="govuk-body">
-        <%= get_updated_at_from_subscription(subscription).to_datetime.strftime("This page was last updated on %-d %B %Y") %>
+        <%= get_updated_at_from_subscription(subscription).to_datetime.strftime(t("subscriptions_management.index.last_updated")) %>
       </p>
     <% end %>
 

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -98,6 +98,12 @@
       margin_bottom: 4
     } %>
 
+    <% if is_single_page_subscription?(subscription) %>
+      <p class="govuk-body">
+        <%= get_updated_at_from_subscription(subscription).to_datetime.strftime("This page was last updated on %-d %B %Y") %>
+      </p>
+    <% end %>
+
     <p class='govuk-body'>
       <%= subscription['created_at'].to_datetime.strftime("Created on %-d %B %Y at %-I:%M%P") %>
     </p>

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -15,6 +15,7 @@ en:
           immediately: "You’ll get an email from GOV.UK each time we add or update a page about:"
           daily: "You’ll get one email a day from GOV.UK about:"
           weekly: "You’ll get one email a week from GOV.UK about:"
+      last_updated: "This page was last updated on %-d %B %Y"
     no_subscriptions_warning_html: |
       <p class="govuk-body">You’re not currently getting emails about updates to GOV.UK.</p>
       <p class="govuk-body">Some GOV.UK pages have a link to ‘get emails’. You can use that link to subscribe to pages or topics you’re interested in.</p>

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe SubscriptionsManagementController do
   include GdsApi::TestHelpers::EmailAlertApi
+  include GdsApi::TestHelpers::ContentStore
   include GovukPersonalisation::TestHelpers::Requests
   include SessionHelper
 
@@ -49,6 +50,30 @@ RSpec.describe SubscriptionsManagementController do
         get :index, session: session
         expect(response.body).to include("Some thing")
         expect(response.body).to include("Created on 16 September 2019 at 2:08am")
+      end
+
+      context "when the subscription is to a single page" do
+        let(:content_base_path) { "/some-thing" }
+
+        before do
+          stub_email_alert_api_has_subscriber_subscriptions(
+            subscriber_id,
+            subscriber_address,
+            subscriptions: [
+              {
+                "id" => subscription_id,
+                "created_at" => "2019-09-16 02:08:08 01:00",
+                "subscriber_list" => { "title" => "Some thing", "url" => content_base_path, "content_id" => "abc123" },
+              },
+            ],
+          )
+          stub_content_store_has_item(content_base_path)
+        end
+
+        it "displays the date the page was last updated" do
+          get :index, session: session
+          expect(response.body).to include("This page was last updated on ")
+        end
       end
     end
 

--- a/spec/helpers/subscriptions_helper_spec.rb
+++ b/spec/helpers/subscriptions_helper_spec.rb
@@ -1,0 +1,25 @@
+describe SubscriptionsHelper do
+  include GdsApi::TestHelpers::ContentStore
+
+  describe "#get_updated_at_from_subscription" do
+    let(:url) { "/some-page" }
+    let(:subscription) do
+      {
+        "id" => 12_345,
+        "subscriber_list" => {
+          "id" => "abc123",
+          "url" => url,
+        },
+      }
+    end
+
+    before do
+      stub_content_store_has_item(url)
+    end
+
+    it "gets the last updated date from the content store" do
+      updated = get_updated_at_from_subscription(subscription)
+      expect(updated).to eq("2014-05-06T12:01:00+00:00")
+    end
+  end
+end


### PR DESCRIPTION
Since these subscriptions are for a single page, we can show the user
the last time they were updated so they can see if and when they would
have received an email about it.

This does call the content store once per single page subscription the
user has which could cause performance problems if a user has many
subscriptions. It should be fine for now but it's something we should
keep an eye on.

[Trello](https://trello.com/c/Z9b4Ar5z/1156-update-email-subscriptions-management-page-content)
[Figma](https://www.figma.com/file/9RzsNFl3iYBXM5QfKO2HkE/Single-page-notifications-feature?node-id=4%3A2237)

Screenshot with the new text: 
![image](https://user-images.githubusercontent.com/6362602/142042523-f04432af-45e3-44ea-a575-dc8030afc06d.png)


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
