### PR TITLE
Fix single page unsubscriptions

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -21,7 +21,7 @@ class SinglePageSubscriptionsController < ApplicationController
 
     subscriptions = GdsApi.email_alert_api.get_subscriptions(id: subscriber.fetch("id")).to_h.fetch("subscriptions", [])
 
-    subscription = subscriptions.find { |s| s["subscriber_list_id"] == @subscriber_list["id"] }
+    subscription = subscriptions.find { |s| s["subscriber_list"]["id"] == @subscriber_list["id"] }
 
     if subscription
       GdsApi.email_alert_api.unsubscribe(subscription["id"])

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -147,12 +147,14 @@ RSpec.describe SinglePageSubscriptionsController do
                 },
               ],
             )
-            stub_email_alert_api_unsubscribes_a_subscription(subscription_id)
           end
 
           it "unsubscribes them and redirects back to the page" do
+            unsubscribe_stub = stub_email_alert_api_unsubscribes_a_subscription(subscription_id)
+
             post :show, params: params
             expect(response).to redirect_to("http://test.host#{base_path}")
+            expect(unsubscribe_stub).to have_been_made
           end
         end
       end


### PR DESCRIPTION
The key `subscriber_list_id` doesn't exist in the subscription hash, so
the unsubscribe path was never reached. Instead look for the ID in the
subscriber list object.

Also refactor the tests slightly so we assert the unsubscribe stub has
been called.

[Trello](https://trello.com/c/2NZWTfeo/1154-work-out-why-the-button-doesnt-unsubscribe-people-fix)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
