### PR TITLE
RESTore sign up routes

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -8,11 +8,10 @@ class SinglePageSubscriptionsController < ApplicationController
     head :not_found unless govuk_account_auth_enabled?
   end
 
-  skip_before_action :verify_authenticity_token, only: [:show]
+  skip_before_action :verify_authenticity_token, only: [:create]
+  before_action :fetch_subscriber_list, only: %i[create]
 
-  before_action :fetch_subscriber_list, only: %i[show]
-
-  def show
+  def create
     return unless logged_in?
 
     subscriber = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(

--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -10,10 +10,14 @@ class SinglePageSubscriptionsController < ApplicationController
 
   skip_before_action :verify_authenticity_token, only: [:create]
   before_action :fetch_subscriber_list, only: %i[create]
-  before_action :not_found_without_topic_id, only: %i[edit]
+  before_action :not_found_without_topic_id, only: %i[edit show]
+
+  def show; end
 
   def create
-    return unless logged_in?
+    unless logged_in?
+      redirect_to new_single_page_subscription_path(topic_id: @topic_id) and return
+    end
 
     subscriber = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(
       govuk_account_session: @account_session_header,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
       post "/verify" => "subscriptions#verify", as: :verify_subscription
       post "/verify/account" => "subscriptions#verify_account", as: :verify_subscription_account
       get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
+      post "/single-page/new" => "single_page_subscriptions#create"
       post "/single-page/new" => "single_page_subscriptions#show"
       post "/single-page/new-session" => "single_page_subscriptions#edit", as: :single_page_new_session
       scope "/account" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
       post "/verify/account" => "subscriptions#verify_account", as: :verify_subscription_account
       get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
       post "/single-page/new" => "single_page_subscriptions#create"
-      post "/single-page/new" => "single_page_subscriptions#show"
+      get "/single-page/new" => "single_page_subscriptions#show", as: :new_single_page_subscription
       post "/single-page/new-session" => "single_page_subscriptions#edit", as: :single_page_new_session
       scope "/account" do
         get "/confirm" => "account_subscriptions#confirm", as: :confirm_account_subscription

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe SinglePageSubscriptionsController do
         post :edit, params: params.merge({ _ga: "abc123", cookie_consent: "accept" })
         expect(response).to redirect_to("#{auth_provider}?_ga=abc123&cookie_consent=accept")
       end
+
+      it "returns 404 if no topic_id parameter is provided" do
+        post :edit
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
     describe "POST /email/subscriptions/single-page/new" do

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe SinglePageSubscriptionsController do
       post :create
       expect(response).to have_http_status(:not_found)
     end
+
+    it "GET /email/subscriptions/single-page/new" do
+      get :show
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   context "when the feature is on" do
@@ -76,9 +81,9 @@ RSpec.describe SinglePageSubscriptionsController do
       end
 
       context "when a user is not logged in" do
-        it "renders the view with a sign in link including the base_path" do
-          get :show, params: params
-          expect(response.body).to include(single_page_new_session_path)
+        it "redirects to show and renders a sign in link including the topic_id" do
+          post :create, params: params
+          expect(response).to redirect_to(new_single_page_subscription_path(topic_id: topic_slug))
         end
       end
 
@@ -162,6 +167,20 @@ RSpec.describe SinglePageSubscriptionsController do
             expect(unsubscribe_stub).to have_been_made
           end
         end
+      end
+    end
+
+    describe "GET /email/subscriptions/single-page/new" do
+      let(:params) { { topic_id: topic_slug } }
+
+      it "returns 404 if no topic_id parameter is provided" do
+        get :show
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 200 if a topic_id parameter is provided and renders an information page" do
+        get :show, params: params
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SinglePageSubscriptionsController do
     end
 
     it "POST /email/subscriptions/single-page/new" do
-      post :show
+      post :create
       expect(response).to have_http_status(:not_found)
     end
   end
@@ -66,7 +66,7 @@ RSpec.describe SinglePageSubscriptionsController do
 
       it "404s when a content item can't be found" do
         stub_content_store_does_not_have_item(base_path)
-        get :show, params: params
+        post :create, params: params
         expect(response).to have_http_status(:not_found)
       end
 
@@ -118,12 +118,12 @@ RSpec.describe SinglePageSubscriptionsController do
 
         it "logs the user out if the session is invalid" do
           stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
-          post :show, params: params
+          post :create, params: params
           expect(response).to redirect_to(auth_provider.to_s)
         end
 
         it "subscribes them and redirects back to the page" do
-          post :show, params: params
+          post :create, params: params
           expect(response).to redirect_to("http://test.host#{base_path}")
         end
 
@@ -152,7 +152,7 @@ RSpec.describe SinglePageSubscriptionsController do
           it "unsubscribes them and redirects back to the page" do
             unsubscribe_stub = stub_email_alert_api_unsubscribes_a_subscription(subscription_id)
 
-            post :show, params: params
+            post :create, params: params
             expect(response).to redirect_to("http://test.host#{base_path}")
             expect(unsubscribe_stub).to have_been_made
           end


### PR DESCRIPTION
[Trello](https://trello.com/c/GptIhNbO/1160-refactor-single-page-notifications-controller-to-display-sign-in-page-using-two-requests)

We were fighting the RESTful framework when we wrote this.

In a perfect world the user is logged in and the initail POST request, goes and changes the state of their email subscriptions. However if they are not logged in we can't do that and we drop them out into an information screen with a request to log in or sign up.

Initially we had this screen being returned as a result of the POST request.
The more REST-y thing to do is to create a separate :show method on it's own GET route.

So that's what we're doing here.

Along the way I refactor out a bit of the topic_id stuff to safeguard against it not being there when we need it during :edit or :show journeys.