### PR TITLE
Update content on sign in page

### DIFF
--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -19,6 +19,10 @@
 
 <div class="govuk-body">
   <%= t("subscriber_authentication.sign_in.description_html") %>
+
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: t("subscriber_authentication.sign_in.cannot_setup_new")
+  } %>
 </div>
 
 <%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate", :"data-module" => "explicit-cross-domain-links" do %>

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -1,11 +1,16 @@
 en:
   subscriber_authentication:
     sign_in:
-      heading: Change your email preferences
+      heading: Manage your GOV.UK email subscriptions
       description_html: |
-        <p>If you are subscribed to GOV.UK email updates, you can unsubscribe or change the frequency at which you receive emails here.</p>
-        <p>You cannot use this page to set up new email subscriptions.  You can set up new subscriptions on topic pages or search pages.</p>
-        <p>For security, we need you to confirm your email address before you can manage your existing subscriptions.</p>
+        <p>Sign in to see and manage the emails you get about updates to GOV.UK.</p>
+        <p>You can:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>unsubscribe from emails you get from GOV.UK</li>
+          <li>change how often you get emails</li>
+          <li>update your email address</li>
+        </ul>
+      cannot_setup_new: "You cannot set up new email subscriptions here. Use the link to ‘get emails’ on the page or topic you want to subscribe to."
       email_input: Email address
       missing_email:
         title: There is a problem


### PR DESCRIPTION
So it's clearer to users what they can and can't do when managing their
email subscriptions.

[Trello](https://trello.com/c/pHKLRXYy/1161-update-text-on-the-sniffer-page-change-your-email-preferences)

### Desktop:
![image](https://user-images.githubusercontent.com/6362602/142617443-2e8016f0-14f7-44c4-869b-76d1e64fe9c2.png)

### Mobile:
![image](https://user-images.githubusercontent.com/6362602/142617539-f83752d2-14a1-4b0c-b464-87135ec87543.png)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
