### PR TITLE
Fix descriptive text for single-page subscription confirmation

### DIFF
--- a/app/views/account_subscriptions/confirm.html.erb
+++ b/app/views/account_subscriptions/confirm.html.erb
@@ -8,7 +8,11 @@
 } %>
 
 <p class="govuk-body">
-  <%= t("account_subscriptions.confirm.description") %>
+  <% if @subscriber_list["content_id"].present? %>
+    <%= t("account_subscriptions.confirm.description.page") %>
+  <% else %>
+    <%= t("account_subscriptions.confirm.description.topic") %>
+  <% end %>
 </p>
 
 <p class="govuk-body">

--- a/config/locales/account_subscriptions.yml
+++ b/config/locales/account_subscriptions.yml
@@ -2,7 +2,9 @@ en:
   account_subscriptions:
     confirm:
       title: Confirm you want to get emails
-      description: "You’ll get emails when there are updates or new pages about:"
+      description:
+        page: "You’ll get emails when there are updates to:"
+        topic: "You’ll get emails when there are updates or new pages about:"
       confirm: Confirm
       cancel: Cancel and go to the GOV.UK homepage
       unlinked_subscriptions:

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -82,6 +82,11 @@ RSpec.describe AccountSubscriptionsController do
             ]
           end
 
+          it "shows the topic sign-up description" do
+            get :confirm, params: { topic_id: topic_id }
+            expect(response.body).to include(I18n.t("account_subscriptions.confirm.description.topic"))
+          end
+
           it "lists them" do
             get :confirm, params: { topic_id: topic_id }
             expect(response.body).to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
@@ -99,6 +104,21 @@ RSpec.describe AccountSubscriptionsController do
               active_subscriptions.each do |subscription|
                 expect(response.body).not_to include(subscription.dig(:subscriber_list, :title))
               end
+            end
+          end
+
+          context "when the subscriberlist is for a single page" do
+            let(:subscriber_list_attributes) do
+              {
+                id: subscriber_list_id,
+                title: subscriber_list_title,
+                content_id: SecureRandom.uuid,
+              }
+            end
+
+            it "shows the page sign-up description" do
+              get :confirm, params: { topic_id: topic_id }
+              expect(response.body).to include(I18n.t("account_subscriptions.confirm.description.page"))
             end
           end
         end


### PR DESCRIPTION
Page:

<img width="686" alt="Screenshot 2021-11-23 at 13 41 11" src="https://user-images.githubusercontent.com/75235/143034976-d9353796-00f7-4dda-a427-5fc01ade07a3.png">

Topic:

<img width="723" alt="Screenshot 2021-11-23 at 13 42 07" src="https://user-images.githubusercontent.com/75235/143034979-b5d2e37c-36ed-4f32-9a6b-b7076339315a.png">
