### PR TITLE
Fix default email frequency for signed out users

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -3,6 +3,7 @@ class SinglePageSubscriptionsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
 
   UNSUBSCRIBE_FLASH = "email-unsubscribe-success".freeze
+  DEFAULT_FREQUENCY = "immediately".freeze
 
   before_action do
     head :not_found unless govuk_account_auth_enabled?
@@ -31,7 +32,7 @@ class SinglePageSubscriptionsController < ApplicationController
       GdsApi.email_alert_api.unsubscribe(subscription["id"])
       account_flash_add UNSUBSCRIBE_FLASH
     else
-      result = CreateAccountSubscriptionService.call(@subscriber_list, "immediately", @account_session_header)
+      result = CreateAccountSubscriptionService.call(@subscriber_list, DEFAULT_FREQUENCY, @account_session_header)
       account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
       set_account_session_header(result[:govuk_account_session])
     end
@@ -70,7 +71,7 @@ private
 
   def sign_in_and_confirm(topic_id)
     redirect_with_analytics GdsApi.account_api.get_sign_in_url(
-      redirect_path: confirm_account_subscription_path(topic_id: topic_id, return_to_url: true),
+      redirect_path: confirm_account_subscription_path(topic_id: topic_id, return_to_url: true, frequency: DEFAULT_FREQUENCY),
     )["auth_uri"]
   end
 end

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SinglePageSubscriptionsController do
   let(:base_path) { "/test" }
   let(:topic_slug) { SecureRandom.uuid }
   let(:topic_name) { "Test" }
-  let(:redirect_path) { "/email/subscriptions/account/confirm?return_to_url=true&topic_id=#{topic_slug}" }
+  let(:redirect_path) { "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=#{topic_slug}" }
   let(:auth_provider) { "http://auth/provider" }
 
   describe "when feature flag is not 'enabled'" do


### PR DESCRIPTION
In #1193 we changed the default email frequency from 'daily' to
'immediately'. However, we only changed it in the branch of the
`SinglePageSubscriptions#create` method for signed in users.
This meant that users who need to sign in and then return to
`AccountSubscriptionsController#confirm` were still getting the 'daily'
frequency.

Set the frequency parameter in the callback URL so it's passed through
to the other controller. Also take the opportunity to define it as a
variable in the controller to avoid repetition.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
