### PR TITLE
Update radio options for single page subscriptions

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -23,10 +23,14 @@ class SubscriptionsManagementController < ApplicationController
 
     GdsApi.email_alert_api.change_subscription(id: id, frequency: new_frequency)
 
-    subscription_title = @subscriptions[id]["subscriber_list"]["title"]
+    subscription = @subscriptions[id]
+
+    subscription_type = is_single_page_subscription?(subscription) ? "page" : "topic"
+
+    subscription_title = subscription["subscriber_list"]["title"]
 
     frequency_text = if new_frequency == "immediately"
-                       I18n.t!("frequencies.immediately").downcase
+                       I18n.t!("frequencies.#{subscription_type}.immediately").downcase
                      else
                        new_frequency
                      end

--- a/app/helpers/frequencies_helper.rb
+++ b/app/helpers/frequencies_helper.rb
@@ -1,6 +1,6 @@
 module FrequenciesHelper
   def valid_frequencies
-    t("frequencies").map { |frequency, _config| frequency.to_s }
+    t("frequencies.topic").map { |frequency, _config| frequency.to_s }
   end
 
   def frequencies(options = {})
@@ -13,9 +13,10 @@ module FrequenciesHelper
   end
 
   def frequency_item(key, options)
+    subscription_type = options[:is_single_page] ? "page" : "topic"
     {
       value: key.to_sym,
-      text: t("frequencies.#{key}"),
+      text: t("frequencies.#{subscription_type}.#{key}"),
       checked: (options[:checked_frequency] == key),
     }
   end

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -19,7 +19,7 @@
     <%= render 'govuk_publishing_components/components/radio', {
       name: 'new_frequency',
       heading: page_heading,
-      items: frequencies(:checked_frequency => @current_frequency)
+      items: frequencies(:checked_frequency => @current_frequency, :is_single_page => is_single_page_subscription?(@subscriptions[@subscription_id]))
     } %>
 
     <%= render 'govuk_publishing_components/components/button', {

--- a/config/locales/frequencies.yml
+++ b/config/locales/frequencies.yml
@@ -1,5 +1,10 @@
 en:
   frequencies:
-    immediately: Each time we add or update a page (you may get more than one email a day)
-    daily: Once a day
-    weekly: Once a week
+    topic:
+      immediately: Each time we add or update a page (you may get more than one email a day)
+      daily: Once a day
+      weekly: Once a week
+    page:
+      immediately: Each time there’s an update (you may get more than one email a day)
+      daily: Once a day
+      weekly: Once a week

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -187,6 +187,27 @@ RSpec.describe SubscriptionsManagementController do
       get :update_frequency, params: { id: subscription_id }, session: session
       expect(response).to have_http_status(:not_found)
     end
+
+    context "when the subscription is for a single page" do
+      before do
+        stub_email_alert_api_has_subscriber_subscriptions(
+          subscriber_id,
+          subscriber_address,
+          subscriptions: [
+            {
+              "id" => subscription_id,
+              "created_at" => "2019-09-16 02:08:08 01:00",
+              "subscriber_list" => { "title" => "Some thing", "url" => "/some-thing", "content_id" => "abc123" },
+            },
+          ],
+        )
+      end
+
+      it "displays the single page version of the content" do
+        get :update_frequency, params: { id: subscription_id }, session: session
+        expect(response.body).to include(I18n.t("frequencies.page.immediately"))
+      end
+    end
   end
 
   describe "POST /email/manage/frequency/:id/change" do


### PR DESCRIPTION
The text for the `immediate` frequency didn't make sense for single page
subscriptions because there will never be a case where a page is added
to a single page subscription.

[Trello](https://trello.com/c/ZZ3TEybY/1163-update-content-for-frequency-of-single-page-subscription-emails)

The new content for single page subscriptions:

![email-alert-frontend dev gov uk_email_manage_frequency_2517bf91-1a69-43fc-9a03-b79282e9a897(iPhone X)](https://user-images.githubusercontent.com/6362602/143574136-ffe479a7-e223-4143-9f85-89d48069c9a5.png)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
