### PR TITLE
Remove `govuk_account_auth_enabled?` feature flag

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 
 class AccountSubscriptionsController < ApplicationController
-  include AccountHelper
   include FrequenciesHelper
   include GovukPersonalisation::ControllerConcern
 
   DEFAULT_FREQUENCY = "daily"
-
-  before_action do
-    head :not_found unless govuk_account_auth_enabled?
-  end
 
   before_action do
     @topic_id = subscription_parameters.fetch(:topic_id)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   include GovukPersonalisation::ControllerConcern
-  include AccountHelper
 
   include Slimmer::Template
 
@@ -32,7 +31,6 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticated_via_account?
-    return false unless govuk_account_auth_enabled?
     return false if account_session_header.blank?
     return @authenticated_via_account unless @authenticated_via_account.nil?
 

--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -1,13 +1,8 @@
 class SinglePageSubscriptionsController < ApplicationController
-  include AccountHelper
   include GovukPersonalisation::ControllerConcern
 
   UNSUBSCRIBE_FLASH = "email-unsubscribe-success".freeze
   DEFAULT_FREQUENCY = "immediately".freeze
-
-  before_action do
-    head :not_found unless govuk_account_auth_enabled?
-  end
 
   skip_before_action :verify_authenticity_token, only: [:create]
   before_action :fetch_subscriber_list, only: %i[create]

--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -42,8 +42,6 @@ class SubscriberAuthenticationController < ApplicationController
   end
 
   def process_govuk_account
-    head :not_found and return unless govuk_account_auth_enabled?
-
     if authenticated_via_account?
       redirect_to list_subscriptions_path
     else

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,4 @@
 class SubscriptionsController < ApplicationController
-  include AccountHelper
   include FrequenciesHelper
   include GovukPersonalisation::ControllerConcern
   before_action :assign_attributes
@@ -63,7 +62,6 @@ class SubscriptionsController < ApplicationController
   end
 
   def verify_account
-    head :not_found and return unless govuk_account_auth_enabled?
     return frequency_form_redirect unless valid_frequency
 
     redirect_with_analytics GdsApi.account_api.get_sign_in_url(

--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -1,5 +1,0 @@
-module AccountHelper
-  def govuk_account_auth_enabled?
-    ENV["FEATURE_FLAG_GOVUK_ACCOUNT"] != "disabled"
-  end
-end

--- a/app/services/create_account_subscription_service.rb
+++ b/app/services/create_account_subscription_service.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class CreateAccountSubscriptionService < ApplicationService
-  include AccountHelper
-
   SUCCESS_FLASH = "email-subscription-success"
 
   def initialize(subscriber_list, frequency, govuk_account_session)
@@ -13,7 +11,6 @@ class CreateAccountSubscriptionService < ApplicationService
   end
 
   def call
-    return false unless govuk_account_auth_enabled?
     return false unless @govuk_account_session
 
     response = GdsApi.email_alert_api.link_subscriber_to_govuk_account(

--- a/app/services/verify_subscriber_email_service.rb
+++ b/app/services/verify_subscriber_email_service.rb
@@ -1,6 +1,4 @@
 class VerifySubscriberEmailService < ApplicationService
-  include AccountHelper
-
   include Rails.application.routes.url_helpers
 
   class RatelimitExceededError < StandardError; end
@@ -23,12 +21,7 @@ class VerifySubscriberEmailService < ApplicationService
   def call
     rate_limiter.add(address)
     raise_if_over_rate_limit
-
-    if govuk_account_auth_enabled?
-      authenticate_with_account
-    else
-      authenticate_with_email
-    end
+    authenticate_with_account
   end
 
 private

--- a/app/services/verify_subscription_email_service.rb
+++ b/app/services/verify_subscription_email_service.rb
@@ -1,6 +1,4 @@
 class VerifySubscriptionEmailService < ApplicationService
-  include AccountHelper
-
   class RatelimitExceededError < StandardError; end
 
   # This allows for up to 2 retries, to account for users
@@ -24,12 +22,7 @@ class VerifySubscriptionEmailService < ApplicationService
   def call
     rate_limiter.add(address)
     raise_if_over_rate_limit
-
-    if govuk_account_auth_enabled?
-      authenticate_with_account
-    else
-      authenticate_with_email
-    end
+    authenticate_with_account
   end
 
 private

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -29,289 +29,259 @@ RSpec.describe AccountSubscriptionsController do
   end
 
   describe "GET /email/subscriptions/account/confirm" do
-    context "when the feature flag is disabled" do
-      around do |example|
-        ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "disabled" do
-          example.run
+    before do
+      stub_email_alert_api_authenticate_subscriber_by_govuk_account(
+        session_id,
+        subscriber_id,
+        address,
+        govuk_account_id: linked_govuk_account_id,
+      )
+
+      stub_email_alert_api_has_subscriber_subscriptions(
+        subscriber_id,
+        address,
+        subscriptions: active_subscriptions,
+      )
+    end
+
+    let(:active_subscriptions) { [] }
+
+    it "raises a parameter missing error" do
+      expect { get :confirm, params: {} }.to raise_error(ActionController::ParameterMissing)
+    end
+
+    context "when a topic is provided" do
+      it "returns 200" do
+        get :confirm, params: { topic_id: topic_id }
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "does not list any active subscriptions" do
+        get :confirm, params: { topic_id: topic_id }
+        expect(response.body).not_to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
+      end
+
+      context "when the user has active subscriptions" do
+        let(:active_subscriptions) do
+          [
+            { subscriber_list: { title: "First Subscription" } },
+            { subscriber_list: { title: "Second Subscription" } },
+            { subscriber_list: { title: "Third Subscription" } },
+          ]
+        end
+
+        it "shows the topic sign-up description" do
+          get :confirm, params: { topic_id: topic_id }
+          expect(response.body).to include(I18n.t("account_subscriptions.confirm.description.topic"))
+        end
+
+        it "lists them" do
+          get :confirm, params: { topic_id: topic_id }
+          expect(response.body).to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
+          active_subscriptions.each do |subscription|
+            expect(response.body).to include(subscription.dig(:subscriber_list, :title))
+          end
+        end
+
+        context "when the user is linked to a GOV.UK account" do
+          let(:linked_govuk_account_id) { "user-id" }
+
+          it "does not list them" do
+            get :confirm, params: { topic_id: topic_id }
+            expect(response.body).not_to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
+            active_subscriptions.each do |subscription|
+              expect(response.body).not_to include(subscription.dig(:subscriber_list, :title))
+            end
+          end
+        end
+
+        context "when the subscriberlist is for a single page" do
+          let(:subscriber_list_attributes) do
+            {
+              id: subscriber_list_id,
+              title: subscriber_list_title,
+              content_id: SecureRandom.uuid,
+            }
+          end
+
+          it "shows the page sign-up description" do
+            get :confirm, params: { topic_id: topic_id }
+            expect(response.body).to include(I18n.t("account_subscriptions.confirm.description.page"))
+          end
         end
       end
 
-      it "returns 404" do
-        get :confirm
-        expect(response).to have_http_status(:not_found)
-      end
-    end
+      context "when a frequency is provided" do
+        let(:frequency) { "immediately" }
 
-    context "when the feature flag is not disabled" do
-      before do
-        stub_email_alert_api_authenticate_subscriber_by_govuk_account(
-          session_id,
-          subscriber_id,
-          address,
-          govuk_account_id: linked_govuk_account_id,
-        )
-
-        stub_email_alert_api_has_subscriber_subscriptions(
-          subscriber_id,
-          address,
-          subscriptions: active_subscriptions,
-        )
-      end
-
-      let(:active_subscriptions) { [] }
-
-      it "raises a parameter missing error" do
-        expect { get :confirm, params: {} }.to raise_error(ActionController::ParameterMissing)
-      end
-
-      context "when a topic is provided" do
         it "returns 200" do
-          get :confirm, params: { topic_id: topic_id }
+          get :confirm, params: { topic_id: topic_id, frequency: frequency }
           expect(response).to have_http_status(:ok)
         end
 
-        it "does not list any active subscriptions" do
-          get :confirm, params: { topic_id: topic_id }
-          expect(response.body).not_to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
-        end
+        context "when the frequency is invalid" do
+          let(:frequency) { "foobar" }
 
-        context "when the user has active subscriptions" do
-          let(:active_subscriptions) do
-            [
-              { subscriber_list: { title: "First Subscription" } },
-              { subscriber_list: { title: "Second Subscription" } },
-              { subscriber_list: { title: "Third Subscription" } },
-            ]
-          end
-
-          it "shows the topic sign-up description" do
-            get :confirm, params: { topic_id: topic_id }
-            expect(response.body).to include(I18n.t("account_subscriptions.confirm.description.topic"))
-          end
-
-          it "lists them" do
-            get :confirm, params: { topic_id: topic_id }
-            expect(response.body).to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
-            active_subscriptions.each do |subscription|
-              expect(response.body).to include(subscription.dig(:subscriber_list, :title))
-            end
-          end
-
-          context "when the user is linked to a GOV.UK account" do
-            let(:linked_govuk_account_id) { "user-id" }
-
-            it "does not list them" do
-              get :confirm, params: { topic_id: topic_id }
-              expect(response.body).not_to include(I18n.t("account_subscriptions.confirm.unlinked_subscriptions.title"))
-              active_subscriptions.each do |subscription|
-                expect(response.body).not_to include(subscription.dig(:subscriber_list, :title))
-              end
-            end
-          end
-
-          context "when the subscriberlist is for a single page" do
-            let(:subscriber_list_attributes) do
-              {
-                id: subscriber_list_id,
-                title: subscriber_list_title,
-                content_id: SecureRandom.uuid,
-              }
-            end
-
-            it "shows the page sign-up description" do
-              get :confirm, params: { topic_id: topic_id }
-              expect(response.body).to include(I18n.t("account_subscriptions.confirm.description.page"))
-            end
-          end
-        end
-
-        context "when a frequency is provided" do
-          let(:frequency) { "immediately" }
-
-          it "returns 200" do
+          it "redirects back without the frequency" do
             get :confirm, params: { topic_id: topic_id, frequency: frequency }
-            expect(response).to have_http_status(:ok)
-          end
-
-          context "when the frequency is invalid" do
-            let(:frequency) { "foobar" }
-
-            it "redirects back without the frequency" do
-              get :confirm, params: { topic_id: topic_id, frequency: frequency }
-              expect(response).to redirect_to(confirm_account_subscription_url(topic_id: topic_id))
-            end
+            expect(response).to redirect_to(confirm_account_subscription_url(topic_id: topic_id))
           end
         end
+      end
 
-        context "when the topic doesn't exist in Email Alert API" do
-          before do
-            stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: topic_id)
-          end
-
-          it "returns a 404" do
-            get :confirm, params: { topic_id: topic_id }
-            expect(response).to have_http_status(:not_found)
-          end
+      context "when the topic doesn't exist in Email Alert API" do
+        before do
+          stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: topic_id)
         end
 
-        context "when the user has no session" do
-          before do
-            mock_logged_in_session(nil)
-            stub_account_api_get_sign_in_url(
-              redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
-              auth_uri: auth_uri,
-            )
-          end
+        it "returns a 404" do
+          get :confirm, params: { topic_id: topic_id }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
 
-          let(:auth_uri) { "/sign-in" }
-
-          it "logs the user out and redirects to sign in" do
-            get :confirm, params: { topic_id: topic_id }
-            expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
-            expect(response).to redirect_to(auth_uri)
-          end
+      context "when the user has no session" do
+        before do
+          mock_logged_in_session(nil)
+          stub_account_api_get_sign_in_url(
+            redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
+            auth_uri: auth_uri,
+          )
         end
 
-        context "when the user's session is invalid" do
-          before do
-            stub_email_alert_api_authenticate_subscriber_by_govuk_account_session_invalid(session_id)
-            stub_account_api_get_sign_in_url(
-              redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
-              auth_uri: auth_uri,
-            )
-          end
+        let(:auth_uri) { "/sign-in" }
 
-          let(:auth_uri) { "/sign-in" }
+        it "logs the user out and redirects to sign in" do
+          get :confirm, params: { topic_id: topic_id }
+          expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
+          expect(response).to redirect_to(auth_uri)
+        end
+      end
 
-          it "logs the user out and redirects to sign in" do
-            get :confirm, params: { topic_id: topic_id }
-            expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
-            expect(response).to redirect_to(auth_uri)
-          end
+      context "when the user's session is invalid" do
+        before do
+          stub_email_alert_api_authenticate_subscriber_by_govuk_account_session_invalid(session_id)
+          stub_account_api_get_sign_in_url(
+            redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
+            auth_uri: auth_uri,
+          )
+        end
+
+        let(:auth_uri) { "/sign-in" }
+
+        it "logs the user out and redirects to sign in" do
+          get :confirm, params: { topic_id: topic_id }
+          expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
+          expect(response).to redirect_to(auth_uri)
         end
       end
     end
   end
 
   describe "POST /email/subscriptions/account" do
-    context "when the feature flag is disabled" do
-      around do |example|
-        ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "disabled" do
-          example.run
-        end
-      end
-
-      it "returns 404" do
-        post :create
-        expect(response).to have_http_status(:not_found)
-      end
+    before do
+      stub_email_alert_api_link_subscriber_to_govuk_account(
+        session_id,
+        subscriber_id,
+        address,
+        govuk_account_id: linked_govuk_account_id,
+      )
     end
 
-    context "when the feature flag is not disabled" do
-      before do
-        stub_email_alert_api_link_subscriber_to_govuk_account(
-          session_id,
-          subscriber_id,
-          address,
-          govuk_account_id: linked_govuk_account_id,
+    let(:linked_govuk_account_id) { "user-id" }
+
+    it "raises a parameter missing error" do
+      expect { post :create, params: {} }.to raise_error(ActionController::ParameterMissing)
+    end
+
+    context "when a topic is provided" do
+      let!(:create_stub) do
+        stub_email_alert_api_creates_a_subscription(
+          subscriber_list_id: subscriber_list_id,
+          address: address,
+          frequency: created_frequency,
+          returned_subscription_id: subscription_id,
         )
       end
 
-      let(:linked_govuk_account_id) { "user-id" }
+      let(:subscription_id) { 256 }
 
-      it "raises a parameter missing error" do
-        expect { post :create, params: {} }.to raise_error(ActionController::ParameterMissing)
+      let(:created_frequency) { AccountSubscriptionsController::DEFAULT_FREQUENCY }
+
+      it "creates the subscription with a default frequency, links the subscriber to the GOV.UK account, and redirects to the manage page" do
+        post :create, params: { topic_id: topic_id }
+        expect(flash[:subscription][:id]).to eq(subscription_id)
+        expect(response).to redirect_to(list_subscriptions_path)
+        expect(create_stub).to have_been_made
       end
 
-      context "when a topic is provided" do
-        let!(:create_stub) do
-          stub_email_alert_api_creates_a_subscription(
-            subscriber_list_id: subscriber_list_id,
-            address: address,
-            frequency: created_frequency,
-            returned_subscription_id: subscription_id,
-          )
-        end
+      context "when a frequency is provided" do
+        let(:frequency) { "immediately" }
+        let(:created_frequency) { frequency }
 
-        let(:subscription_id) { 256 }
-
-        let(:created_frequency) { AccountSubscriptionsController::DEFAULT_FREQUENCY }
-
-        it "creates the subscription with a default frequency, links the subscriber to the GOV.UK account, and redirects to the manage page" do
-          post :create, params: { topic_id: topic_id }
-          expect(flash[:subscription][:id]).to eq(subscription_id)
+        it "creates the subscription with the correct frequency" do
+          post :create, params: { topic_id: topic_id, frequency: frequency }
           expect(response).to redirect_to(list_subscriptions_path)
           expect(create_stub).to have_been_made
         end
 
-        context "when a frequency is provided" do
-          let(:frequency) { "immediately" }
-          let(:created_frequency) { frequency }
+        context "when the frequency is invalid" do
+          let(:frequency) { "foobar" }
 
-          it "creates the subscription with the correct frequency" do
+          it "redirects back without the frequency" do
             post :create, params: { topic_id: topic_id, frequency: frequency }
-            expect(response).to redirect_to(list_subscriptions_path)
-            expect(create_stub).to have_been_made
-          end
-
-          context "when the frequency is invalid" do
-            let(:frequency) { "foobar" }
-
-            it "redirects back without the frequency" do
-              post :create, params: { topic_id: topic_id, frequency: frequency }
-              expect(response).to redirect_to(confirm_account_subscription_url(topic_id: topic_id))
-              expect(create_stub).not_to have_been_made
-            end
+            expect(response).to redirect_to(confirm_account_subscription_url(topic_id: topic_id))
+            expect(create_stub).not_to have_been_made
           end
         end
+      end
 
-        context "when the topic has a URL" do
-          let(:subscriber_list_attributes) do
-            {
-              id: subscriber_list_id,
-              title: subscriber_list_title,
-              url: "/some/page",
-            }
-          end
-
-          it "redirects to the manage page when the return_to_url parameter is not given" do
-            post :create, params: { topic_id: topic_id }
-            expect(response).to redirect_to(list_subscriptions_path)
-          end
-
-          it "redirects to the manage page when the return_to_url parameter is given" do
-            post :create, params: { topic_id: topic_id, return_to_url: "1" }
-            expect(response).to redirect_to(subscriber_list_attributes[:url])
-          end
+      context "when the topic has a URL" do
+        let(:subscriber_list_attributes) do
+          {
+            id: subscriber_list_id,
+            title: subscriber_list_title,
+            url: "/some/page",
+          }
         end
 
-        context "when the topic doesn't exist in Email Alert API" do
-          before do
-            stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: topic_id)
-          end
-
-          it "returns a 404" do
-            post :create, params: { topic_id: topic_id }
-            expect(response).to have_http_status(:not_found)
-          end
+        it "redirects to the manage page when the return_to_url parameter is not given" do
+          post :create, params: { topic_id: topic_id }
+          expect(response).to redirect_to(list_subscriptions_path)
         end
 
-        context "when the user's session is invalid" do
-          before do
-            stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
-            stub_account_api_get_sign_in_url(
-              redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
-              auth_uri: auth_uri,
-            )
-          end
+        it "redirects to the manage page when the return_to_url parameter is given" do
+          post :create, params: { topic_id: topic_id, return_to_url: "1" }
+          expect(response).to redirect_to(subscriber_list_attributes[:url])
+        end
+      end
 
-          let(:auth_uri) { "/sign-in" }
+      context "when the topic doesn't exist in Email Alert API" do
+        before do
+          stub_email_alert_api_does_not_have_subscriber_list_by_slug(slug: topic_id)
+        end
 
-          it "logs the user out and redirects to sign in" do
-            post :create, params: { topic_id: topic_id }
-            expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
-            expect(response).to redirect_to(auth_uri)
-          end
+        it "returns a 404" do
+          post :create, params: { topic_id: topic_id }
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "when the user's session is invalid" do
+        before do
+          stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
+          stub_account_api_get_sign_in_url(
+            redirect_path: "/email/subscriptions/account/confirm?frequency=#{AccountSubscriptionsController::DEFAULT_FREQUENCY}&topic_id=#{topic_id}",
+            auth_uri: auth_uri,
+          )
+        end
+
+        let(:auth_uri) { "/sign-in" }
+
+        it "logs the user out and redirects to sign in" do
+          post :create, params: { topic_id: topic_id }
+          expect(response.headers["GOVUK-Account-End-Session"]).to_not be_nil
+          expect(response).to redirect_to(auth_uri)
         end
       end
     end

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -12,176 +12,151 @@ RSpec.describe SinglePageSubscriptionsController do
   let(:redirect_path) { "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=#{topic_slug}" }
   let(:auth_provider) { "http://auth/provider" }
 
-  describe "when feature flag is disabled" do
-    around do |example|
-      ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "disabled" do
-        example.run
-      end
+  describe "POST /email/subscriptions/single-page/new-session" do
+    before { stub_account_api_get_sign_in_url(auth_uri: auth_provider, redirect_path: redirect_path) }
+
+    let(:params) { { topic_id: topic_slug } }
+
+    it "redirects to sign in with a redirect_path param" do
+      post :edit, params: params
+      expect(response).to redirect_to(auth_provider.to_s)
     end
 
-    it "POST /email/subscriptions/single-page/new-session returns 404" do
+    it "redirects with _ga param and cookie_consent if present in the request params" do
+      post :edit, params: params.merge({ _ga: "abc123", cookie_consent: "accept" })
+      expect(response).to redirect_to("#{auth_provider}?_ga=abc123&cookie_consent=accept")
+    end
+
+    it "returns 404 if no topic_id parameter is provided" do
       post :edit
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "POST /email/subscriptions/single-page/new" do
-      post :create
-      expect(response).to have_http_status(:not_found)
-    end
-
-    it "GET /email/subscriptions/single-page/new" do
-      get :show
       expect(response).to have_http_status(:not_found)
     end
   end
 
-  context "when the feature is not disabled" do
-    describe "POST /email/subscriptions/single-page/new-session" do
-      before { stub_account_api_get_sign_in_url(auth_uri: auth_provider, redirect_path: redirect_path) }
+  describe "POST /email/subscriptions/single-page/new" do
+    before do
+      stub_content_store_has_item(base_path, content_item_for_base_path(base_path).merge("content_id" => content_id))
 
-      let(:params) { { topic_id: topic_slug } }
+      stub_email_alert_api_creates_subscriber_list({
+        url: base_path,
+        title: topic_name,
+        slug: topic_slug,
+        id: subscription_list_id,
+        content_id: content_id,
+      })
+    end
 
-      it "redirects to sign in with a redirect_path param" do
-        post :edit, params: params
+    let(:content_id) { SecureRandom.uuid }
+    let(:subscription_list_id) { "subscription-list-id" }
+    let(:params) { { base_path: base_path } }
+
+    it "404s when a content item can't be found" do
+      stub_content_store_does_not_have_item(base_path)
+      post :create, params: params
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "when a user is not logged in" do
+      it "redirects to show and renders a sign in link including the topic_id" do
+        post :create, params: params
+        expect(response).to redirect_to(new_single_page_subscription_path(topic_id: topic_slug))
+      end
+    end
+
+    context "when a user is logged in" do
+      let(:session_id) { "session-id" }
+      let(:user_id) { "user-id" }
+      let(:subscriber_id) { "subscriber-id" }
+      let(:user_email) { "test@gov.uk" }
+
+      before do
+        mock_logged_in_session(session_id)
+        stub_account_api_get_sign_in_url(auth_uri: auth_provider, redirect_path: redirect_path)
+
+        stub_email_alert_api_authenticate_subscriber_by_govuk_account(
+          session_id,
+          subscriber_id,
+          user_email,
+          govuk_account_id: user_id,
+        )
+
+        stub_email_alert_api_has_subscriber_subscriptions(
+          subscriber_id,
+          user_email,
+          subscriptions: [],
+        )
+
+        stub_email_alert_api_creates_a_subscription(
+          subscriber_list_id: subscription_list_id,
+          address: user_email,
+          frequency: "immediately",
+          returned_subscription_id: "subscription-id",
+          subscriber_id: subscriber_id,
+        )
+
+        stub_email_alert_api_link_subscriber_to_govuk_account(
+          session_id,
+          subscriber_id,
+          user_email,
+          govuk_account_id: user_id,
+        )
+      end
+
+      it "logs the user out if the session is invalid" do
+        stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
+        post :create, params: params
         expect(response).to redirect_to(auth_provider.to_s)
       end
 
-      it "redirects with _ga param and cookie_consent if present in the request params" do
-        post :edit, params: params.merge({ _ga: "abc123", cookie_consent: "accept" })
-        expect(response).to redirect_to("#{auth_provider}?_ga=abc123&cookie_consent=accept")
-      end
-
-      it "returns 404 if no topic_id parameter is provided" do
-        post :edit
-        expect(response).to have_http_status(:not_found)
-      end
-    end
-
-    describe "POST /email/subscriptions/single-page/new" do
-      before do
-        stub_content_store_has_item(base_path, content_item_for_base_path(base_path).merge("content_id" => content_id))
-
-        stub_email_alert_api_creates_subscriber_list({
-          url: base_path,
-          title: topic_name,
-          slug: topic_slug,
-          id: subscription_list_id,
-          content_id: content_id,
-        })
-      end
-
-      let(:content_id) { SecureRandom.uuid }
-      let(:subscription_list_id) { "subscription-list-id" }
-      let(:params) { { base_path: base_path } }
-
-      it "404s when a content item can't be found" do
-        stub_content_store_does_not_have_item(base_path)
+      it "subscribes them and redirects back to the page" do
         post :create, params: params
-        expect(response).to have_http_status(:not_found)
+        expect(response).to redirect_to("http://test.host#{base_path}")
       end
 
-      context "when a user is not logged in" do
-        it "redirects to show and renders a sign in link including the topic_id" do
-          post :create, params: params
-          expect(response).to redirect_to(new_single_page_subscription_path(topic_id: topic_slug))
-        end
-      end
-
-      context "when a user is logged in" do
-        let(:session_id) { "session-id" }
-        let(:user_id) { "user-id" }
-        let(:subscriber_id) { "subscriber-id" }
-        let(:user_email) { "test@gov.uk" }
+      context "when the user is already subscribed to that base_path" do
+        let(:subscription_id) { "subscription-id" }
 
         before do
-          mock_logged_in_session(session_id)
-          stub_account_api_get_sign_in_url(auth_uri: auth_provider, redirect_path: redirect_path)
-
-          stub_email_alert_api_authenticate_subscriber_by_govuk_account(
-            session_id,
-            subscriber_id,
-            user_email,
-            govuk_account_id: user_id,
-          )
-
           stub_email_alert_api_has_subscriber_subscriptions(
             subscriber_id,
             user_email,
-            subscriptions: [],
-          )
-
-          stub_email_alert_api_creates_a_subscription(
-            subscriber_list_id: subscription_list_id,
-            address: user_email,
-            frequency: "immediately",
-            returned_subscription_id: "subscription-id",
-            subscriber_id: subscriber_id,
-          )
-
-          stub_email_alert_api_link_subscriber_to_govuk_account(
-            session_id,
-            subscriber_id,
-            user_email,
-            govuk_account_id: user_id,
+            subscriptions: [
+              {
+                "subscriber_id" => subscriber_id,
+                "subscriber_list_id" => subscription_list_id,
+                "frequency" => "immediately",
+                "id" => subscription_id,
+                "subscriber_list" => {
+                  "id" => subscription_list_id,
+                  "slug" => base_path,
+                },
+              },
+            ],
           )
         end
 
-        it "logs the user out if the session is invalid" do
-          stub_email_alert_api_link_subscriber_to_govuk_account_session_invalid(session_id)
-          post :create, params: params
-          expect(response).to redirect_to(auth_provider.to_s)
-        end
+        it "unsubscribes them and redirects back to the page" do
+          unsubscribe_stub = stub_email_alert_api_unsubscribes_a_subscription(subscription_id)
 
-        it "subscribes them and redirects back to the page" do
           post :create, params: params
           expect(response).to redirect_to("http://test.host#{base_path}")
-        end
-
-        context "when the user is already subscribed to that base_path" do
-          let(:subscription_id) { "subscription-id" }
-
-          before do
-            stub_email_alert_api_has_subscriber_subscriptions(
-              subscriber_id,
-              user_email,
-              subscriptions: [
-                {
-                  "subscriber_id" => subscriber_id,
-                  "subscriber_list_id" => subscription_list_id,
-                  "frequency" => "immediately",
-                  "id" => subscription_id,
-                  "subscriber_list" => {
-                    "id" => subscription_list_id,
-                    "slug" => base_path,
-                  },
-                },
-              ],
-            )
-          end
-
-          it "unsubscribes them and redirects back to the page" do
-            unsubscribe_stub = stub_email_alert_api_unsubscribes_a_subscription(subscription_id)
-
-            post :create, params: params
-            expect(response).to redirect_to("http://test.host#{base_path}")
-            expect(unsubscribe_stub).to have_been_made
-          end
+          expect(unsubscribe_stub).to have_been_made
         end
       end
     end
+  end
 
-    describe "GET /email/subscriptions/single-page/new" do
-      let(:params) { { topic_id: topic_slug } }
+  describe "GET /email/subscriptions/single-page/new" do
+    let(:params) { { topic_id: topic_slug } }
 
-      it "returns 404 if no topic_id parameter is provided" do
-        get :show
-        expect(response).to have_http_status(:not_found)
-      end
+    it "returns 404 if no topic_id parameter is provided" do
+      get :show
+      expect(response).to have_http_status(:not_found)
+    end
 
-      it "returns 200 if a topic_id parameter is provided and renders an information page" do
-        get :show, params: params
-        expect(response).to have_http_status(:ok)
-      end
+    it "returns 200 if a topic_id parameter is provided and renders an information page" do
+      get :show, params: params
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/services/verify_subscriber_email_service_spec.rb
+++ b/spec/services/verify_subscriber_email_service_spec.rb
@@ -14,96 +14,76 @@ RSpec.describe VerifySubscriberEmailService do
       allow(Ratelimit).to receive(:new).and_return(rate_limiter)
     end
 
-    context "when GOV.UK accounts auth is disabled" do
-      around do |example|
-        ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "disabled" do
-          example.run
-        end
-      end
-
-      it "makes an API call to send a verification email" do
-        expect(described_class.call(address)).to eq(:email)
-        expect(request).to have_been_requested
-      end
-
-      it "exposes a not_found error if the user's email address cannot be found" do
-        stub_email_alert_api_subscriber_verification_email_no_subscriber
-        expect { described_class.call(address) }.to raise_error(GdsApi::HTTPNotFound)
-      end
+    let!(:match_request) do
+      stub_account_api_match_user_by_email_does_not_exist(email: address)
     end
 
-    context "when GOV.UK accounts auth is not disabled" do
+    it "increments a rate limiter for the address" do
+      expect(rate_limiter).to receive(:add).with(address)
+      described_class.call(address)
+    end
+
+    it "raises an error for too many requests per minute" do
+      allow(rate_limiter).to receive(:exceeded?).with(
+        address,
+        threshold: described_class::MINUTELY_THRESHOLD,
+        interval: 60.seconds.to_i,
+      ).and_return(true)
+
+      expect { described_class.call(address) }
+        .to raise_error(described_class::RatelimitExceededError)
+    end
+
+    it "raises an error for too many requests per minute" do
+      allow(rate_limiter).to receive(:exceeded?).with(
+        address,
+        threshold: described_class::HOURLY_THRESHOLD,
+        interval: 1.hour.to_i,
+      ).and_return(true)
+
+      expect { described_class.call(address) }
+        .to raise_error(described_class::RatelimitExceededError)
+    end
+
+    it "makes an API call to check if the address is associated with an account" do
+      described_class.call(address)
+      expect(match_request).to have_been_requested
+    end
+
+    it "makes an API call to send a verification email" do
+      expect(described_class.call(address)).to eq(:email)
+      expect(request).to have_been_requested
+    end
+
+    context "the email address is associated with a GOV.UK account" do
       let!(:match_request) do
-        stub_account_api_match_user_by_email_does_not_exist(email: address)
+        stub_account_api_match_user_by_email_does_not_match(email: address)
       end
 
-      it "increments a rate limiter for the address" do
-        expect(rate_limiter).to receive(:add).with(address)
-        described_class.call(address)
+      it "reauthenticates the user" do
+        expect(described_class.call(address)).to eq(:account_reauthenticate)
       end
 
-      it "raises an error for too many requests per minute" do
-        allow(rate_limiter).to receive(:exceeded?).with(
-          address,
-          threshold: described_class::MINUTELY_THRESHOLD,
-          interval: 60.seconds.to_i,
-        ).and_return(true)
-
-        expect { described_class.call(address) }
-          .to raise_error(described_class::RatelimitExceededError)
-      end
-
-      it "raises an error for too many requests per minute" do
-        allow(rate_limiter).to receive(:exceeded?).with(
-          address,
-          threshold: described_class::HOURLY_THRESHOLD,
-          interval: 1.hour.to_i,
-        ).and_return(true)
-
-        expect { described_class.call(address) }
-          .to raise_error(described_class::RatelimitExceededError)
-      end
-
-      it "makes an API call to check if the address is associated with an account" do
+      it "does not make an API call to send a verification email" do
         described_class.call(address)
         expect(match_request).to have_been_requested
+        expect(request).not_to have_been_requested
       end
 
-      it "makes an API call to send a verification email" do
-        expect(described_class.call(address)).to eq(:email)
-        expect(request).to have_been_requested
-      end
-
-      context "the email address is associated with a GOV.UK account" do
-        let!(:match_request) do
-          stub_account_api_match_user_by_email_does_not_match(email: address)
-        end
+      context "a GOV.UK account session is provided" do
+        let(:session_id) { "session-id" }
 
         it "reauthenticates the user" do
-          expect(described_class.call(address)).to eq(:account_reauthenticate)
+          expect(described_class.call(address, govuk_account_session: session_id)).to eq(:account_reauthenticate)
         end
 
-        it "does not make an API call to send a verification email" do
-          described_class.call(address)
-          expect(match_request).to have_been_requested
-          expect(request).not_to have_been_requested
-        end
-
-        context "a GOV.UK account session is provided" do
-          let(:session_id) { "session-id" }
-
-          it "reauthenticates the user" do
-            expect(described_class.call(address, govuk_account_session: session_id)).to eq(:account_reauthenticate)
+        context "the provided session matches the email address" do
+          let!(:match_request) do
+            stub_account_api_match_user_by_email_matches(email: address)
           end
 
-          context "the provided session matches the email address" do
-            let!(:match_request) do
-              stub_account_api_match_user_by_email_matches(email: address)
-            end
-
-            it "authenticates the user" do
-              expect(described_class.call(address, govuk_account_session: session_id)).to eq(:account)
-            end
+          it "authenticates the user" do
+            expect(described_class.call(address, govuk_account_session: session_id)).to eq(:account)
           end
         end
       end

--- a/spec/services/verify_subscription_email_service_spec.rb
+++ b/spec/services/verify_subscription_email_service_spec.rb
@@ -15,91 +15,71 @@ RSpec.describe VerifySubscriptionEmailService do
       allow(Ratelimit).to receive(:new).and_return(rate_limiter)
     end
 
-    context "when GOV.UK accounts auth is disabled" do
-      around do |example|
-        ClimateControl.modify FEATURE_FLAG_GOVUK_ACCOUNT: "disabled" do
-          example.run
-        end
-      end
-
-      it "makes an API call to send a verification email" do
-        described_class.call(*args)
-        expect(request).to have_been_requested
-      end
-
-      it "increments a rate limiter for the address" do
-        expect(rate_limiter).to receive(:add).with(address)
-        described_class.call(*args)
-      end
+    let!(:match_request) do
+      stub_account_api_match_user_by_email_does_not_exist(email: address)
     end
 
-    context "when GOV.UK accounts auth is not disabled" do
+    it "raises an error for too many requests per minute" do
+      allow(rate_limiter).to receive(:exceeded?).with(
+        address,
+        threshold: described_class::MINUTELY_THRESHOLD,
+        interval: 60.seconds.to_i,
+      ).and_return(true)
+
+      expect { described_class.call(*args) }
+        .to raise_error(described_class::RatelimitExceededError)
+    end
+
+    it "raises an error for too many requests per minute" do
+      allow(rate_limiter).to receive(:exceeded?).with(
+        address,
+        threshold: described_class::HOURLY_THRESHOLD,
+        interval: 1.hour.to_i,
+      ).and_return(true)
+
+      expect { described_class.call(*args) }
+        .to raise_error(described_class::RatelimitExceededError)
+    end
+
+    it "makes an API call to check if the address is associated with an account" do
+      described_class.call(*args)
+      expect(match_request).to have_been_requested
+    end
+
+    it "makes an API call to send a verification email" do
+      expect(described_class.call(*args)).to eq(:email)
+      expect(request).to have_been_requested
+    end
+
+    context "the email address is associated with a GOV.UK account" do
       let!(:match_request) do
-        stub_account_api_match_user_by_email_does_not_exist(email: address)
+        stub_account_api_match_user_by_email_does_not_match(email: address)
       end
 
-      it "raises an error for too many requests per minute" do
-        allow(rate_limiter).to receive(:exceeded?).with(
-          address,
-          threshold: described_class::MINUTELY_THRESHOLD,
-          interval: 60.seconds.to_i,
-        ).and_return(true)
-
-        expect { described_class.call(*args) }
-          .to raise_error(described_class::RatelimitExceededError)
+      it "reauthenticates the user" do
+        expect(described_class.call(*args)).to eq(:account_reauthenticate)
       end
 
-      it "raises an error for too many requests per minute" do
-        allow(rate_limiter).to receive(:exceeded?).with(
-          address,
-          threshold: described_class::HOURLY_THRESHOLD,
-          interval: 1.hour.to_i,
-        ).and_return(true)
-
-        expect { described_class.call(*args) }
-          .to raise_error(described_class::RatelimitExceededError)
-      end
-
-      it "makes an API call to check if the address is associated with an account" do
+      it "does not make an API call to send a verification email" do
         described_class.call(*args)
         expect(match_request).to have_been_requested
+        expect(request).not_to have_been_requested
       end
 
-      it "makes an API call to send a verification email" do
-        expect(described_class.call(*args)).to eq(:email)
-        expect(request).to have_been_requested
-      end
-
-      context "the email address is associated with a GOV.UK account" do
-        let!(:match_request) do
-          stub_account_api_match_user_by_email_does_not_match(email: address)
-        end
+      context "a GOV.UK account session is provided" do
+        let(:session_id) { "session-id" }
 
         it "reauthenticates the user" do
-          expect(described_class.call(*args)).to eq(:account_reauthenticate)
+          expect(described_class.call(*args, govuk_account_session: session_id)).to eq(:account_reauthenticate)
         end
 
-        it "does not make an API call to send a verification email" do
-          described_class.call(*args)
-          expect(match_request).to have_been_requested
-          expect(request).not_to have_been_requested
-        end
-
-        context "a GOV.UK account session is provided" do
-          let(:session_id) { "session-id" }
-
-          it "reauthenticates the user" do
-            expect(described_class.call(*args, govuk_account_session: session_id)).to eq(:account_reauthenticate)
+        context "the provided session matches the email address" do
+          let!(:match_request) do
+            stub_account_api_match_user_by_email_matches(email: address)
           end
 
-          context "the provided session matches the email address" do
-            let!(:match_request) do
-              stub_account_api_match_user_by_email_matches(email: address)
-            end
-
-            it "authenticates the user" do
-              expect(described_class.call(*args, govuk_account_session: session_id)).to eq(:account)
-            end
+          it "authenticates the user" do
+            expect(described_class.call(*args, govuk_account_session: session_id)).to eq(:account)
           end
         end
       end


### PR DESCRIPTION
We've switched this on in production and are confident we won't be
switching it off.

The diff to the tests will be much easier to review if you hide whitespace changes.