### PR TITLE
Bring black flash message for topic subscriptions

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -51,12 +51,13 @@ class AccountSubscriptionsController < ApplicationController
     result = CreateAccountSubscriptionService.call(@subscriber_list, @frequency, account_session_header)
     reauthenticate_user and return unless result
 
-    account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
     set_account_session_header(result[:govuk_account_session])
 
     if @return_to_url.blank? || @subscriber_list["url"].blank?
-      redirect_to process_govuk_account_path
+      flash[:subscription] = { id: result[:subscription]["id"] }
+      redirect_to list_subscriptions_path
     else
+      account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
       redirect_to @subscriber_list["url"]
     end
   end

--- a/app/controllers/subscription_authentication_controller.rb
+++ b/app/controllers/subscription_authentication_controller.rb
@@ -26,10 +26,7 @@ class SubscriptionAuthenticationController < ApplicationController
         frequency: @frequency,
       )["subscription"]
 
-    flash[:subscription] = {
-      id: subscription["id"],
-      message: t("subscription_authentication.authenticate.message"),
-    }
+    flash[:subscription] = { id: subscription["id"] }
 
     authenticate_subscriber(subscription.dig("subscriber", "id"))
     redirect_to list_subscriptions_path

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -20,9 +20,9 @@ class SubscriptionsController < ApplicationController
 
       result = CreateAccountSubscriptionService.call(@subscriber_list, @frequency, account_session_header)
       if result
-        account_flash_add CreateAccountSubscriptionService::SUCCESS_FLASH
         set_account_session_header(result[:govuk_account_session])
-        redirect_to process_govuk_account_path
+        flash[:subscription] = { id: result[:subscription]["id"] }
+        redirect_to list_subscriptions_path
       else
         redirect_to new_subscription_path(
           topic_id: @topic_id,

--- a/app/services/create_account_subscription_service.rb
+++ b/app/services/create_account_subscription_service.rb
@@ -22,13 +22,16 @@ class CreateAccountSubscriptionService < ApplicationService
 
     subscriber = response.to_h.fetch("subscriber")
 
-    GdsApi.email_alert_api.subscribe(
+    subscription = GdsApi.email_alert_api.subscribe(
       subscriber_list_id: subscriber_list.fetch("id"),
       address: subscriber.fetch("address"),
       frequency: frequency,
-    )
+    )["subscription"]
 
-    { govuk_account_session: response["govuk_account_session"] }
+    {
+      govuk_account_session: response["govuk_account_session"],
+      subscription: subscription,
+    }
   end
 
 private

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -10,19 +10,9 @@
 <% if flash[:subscription] %>
   <% subscription = @subscriptions[flash[:subscription]['id']] %>
 
-  <% if subscription %>
-    <% description = capture do %>
-      <p class="govuk-body">
-        <%= t("subscriptions_management.index.flashes.subscription.#{subscription['frequency']}") %>
-      </p>
-      <p><strong><%= subscription['subscriber_list']['title'] %></strong></p>
-    <% end %>
-
-    <%= render 'govuk_publishing_components/components/success_alert', {
-      message: flash[:subscription]['message'],
-      description: description
-    } %>
-  <% end %>
+  <%= render 'govuk_publishing_components/components/success_alert', {
+    message: t("subscriptions_management.index.flashes.subscription", title: subscription["subscriber_list"]["title"]),
+  } if subscription %>
 <% end %>
 
 <% if use_govuk_account_layout? %>

--- a/config/locales/subscription_authentication.yml
+++ b/config/locales/subscription_authentication.yml
@@ -3,5 +3,3 @@ en:
     expired:
       title: Your link has expired
       description: The links we send only work for 7 days. This is to protect your personal data.
-    authenticate:
-      message: "You’ve subscribed to GOV.UK emails"

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -11,10 +11,7 @@ en:
         message: "You have been unsubscribed from ‘%{title}’"
         description: "It can take up to an hour for this change to take effect."
       flashes:
-        subscription:
-          immediately: "You’ll get an email from GOV.UK each time we add or update a page about:"
-          daily: "You’ll get one email a day from GOV.UK about:"
-          weekly: "You’ll get one email a week from GOV.UK about:"
+        subscription: "You’ve subscribed to emails about ‘%{title}’."
       last_updated: "This page was last updated on %-d %B %Y"
       you_subscribed: "You subscribed on %-d %B %Y at %-I:%M%P"
     no_subscriptions_warning_html: |

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -229,15 +229,18 @@ RSpec.describe AccountSubscriptionsController do
             subscriber_list_id: subscriber_list_id,
             address: address,
             frequency: created_frequency,
+            returned_subscription_id: subscription_id,
           )
         end
+
+        let(:subscription_id) { 256 }
 
         let(:created_frequency) { AccountSubscriptionsController::DEFAULT_FREQUENCY }
 
         it "creates the subscription with a default frequency, links the subscriber to the GOV.UK account, and redirects to the manage page" do
           post :create, params: { topic_id: topic_id }
-          expect(response).to redirect_to(process_govuk_account_path)
-          expect(response.headers["GOVUK-Account-Session"]).to include(CreateAccountSubscriptionService::SUCCESS_FLASH)
+          expect(flash[:subscription][:id]).to eq(subscription_id)
+          expect(response).to redirect_to(list_subscriptions_path)
           expect(create_stub).to have_been_made
         end
 
@@ -247,8 +250,7 @@ RSpec.describe AccountSubscriptionsController do
 
           it "creates the subscription with the correct frequency" do
             post :create, params: { topic_id: topic_id, frequency: frequency }
-            expect(response).to redirect_to(process_govuk_account_path)
-            expect(response.headers["GOVUK-Account-Session"]).to include(CreateAccountSubscriptionService::SUCCESS_FLASH)
+            expect(response).to redirect_to(list_subscriptions_path)
             expect(create_stub).to have_been_made
           end
 
@@ -274,7 +276,7 @@ RSpec.describe AccountSubscriptionsController do
 
           it "redirects to the manage page when the return_to_url parameter is not given" do
             post :create, params: { topic_id: topic_id }
-            expect(response).to redirect_to(process_govuk_account_path)
+            expect(response).to redirect_to(list_subscriptions_path)
           end
 
           it "redirects to the manage page when the return_to_url parameter is given" do

--- a/spec/controllers/subscription_authentication_controller_spec.rb
+++ b/spec/controllers/subscription_authentication_controller_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe SubscriptionAuthenticationController do
 
       it "shows a success flash message" do
         get :authenticate, params: params
-        expect(flash[:subscription][:message]).to eq(I18n.t!("subscription_authentication.authenticate.message"))
         expect(flash[:subscription][:id]).to eq(subscription_id)
       end
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -129,17 +129,19 @@ RSpec.describe SubscriptionsController do
               subscriber_list_id: subscriber_list_id,
               address: address,
               frequency: frequency,
+              returned_subscription_id: subscription_id,
             )
           end
 
+          let(:subscription_id) { 256 }
           let(:subscriber_id) { "subscriber-id" }
           let(:address) { "email@example.com" }
           let(:linked_govuk_account_id) { 42 }
 
           it "creates the subscription and redirects to the manage page" do
             post :frequency, params: { topic_id: topic_id, frequency: frequency }
-            expect(response).to redirect_to(process_govuk_account_path)
-            expect(response.headers["GOVUK-Account-Session"]).to include(CreateAccountSubscriptionService::SUCCESS_FLASH)
+            expect(response).to redirect_to(list_subscriptions_path)
+            expect(flash[:subscription][:id]).to eq(subscription_id)
             expect(link_stub).to have_been_made
             expect(create_stub).to have_been_made
           end

--- a/spec/features/subscribe_verify_email_spec.rb
+++ b/spec/features/subscribe_verify_email_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Subscribe verify email" do
       subscriptions: [{
         "id": subscription_id,
         "frequency": "immediately",
-        "subscriber_list": { "title": "Title" },
+        "subscriber_list": { "title": @title },
         "created_at": Time.zone.now.to_s,
       }],
     )
@@ -62,8 +62,7 @@ RSpec.feature "Subscribe verify email" do
 
   def then_i_see_i_am_subscribed
     expect(@request).to have_been_requested
-    expect(page).to have_content(I18n.t!("subscription_authentication.authenticate.message"))
-    expect(page).to have_content(I18n.t!("subscriptions_management.index.flashes.subscription.immediately"))
+    expect(page).to have_content(I18n.t!("subscriptions_management.index.flashes.subscription", title: @title))
   end
 
   def and_i_can_manage_my_subscriptions

--- a/spec/views/subscriptions_management/index.html.erb_spec.rb
+++ b/spec/views/subscriptions_management/index.html.erb_spec.rb
@@ -18,13 +18,12 @@ RSpec.describe "subscriptions_management/index" do
         }
 
         assign(:subscriptions, { subscription["id"] => subscription })
-        flash[:subscription] = { "message" => "message", "id" => subscription["id"] }
+        flash[:subscription] = { "id" => subscription["id"] }
 
         render
-        expect(rendered).to have_content("message")
 
         expect(rendered).to have_content(
-          I18n.t!("subscriptions_management.index.flashes.subscription.#{frequency}"),
+          I18n.t!("subscriptions_management.index.flashes.subscription", title: subscription["subscriber_list"]["title"]),
         )
         expect(rendered).to have_css("a[href='#{confirm_unsubscribe_path(subscription['id'])}'] .govuk-visually-hidden", text: "from #{subscription['subscriber_list']['title']}")
         expect(rendered).to have_css("a[href='#{update_frequency_path(subscription['id'])}'] .govuk-visually-hidden", text: "about #{subscription['subscriber_list']['title']}")
@@ -37,10 +36,10 @@ RSpec.describe "subscriptions_management/index" do
   context "if the subscription is not found" do
     it "does not render a flash" do
       assign(:subscriptions, {})
-      flash[:subscription] = { "message" => "message", "id" => 1 }
+      flash[:subscription] = { "id" => 1 }
 
       render
-      expect(rendered).to_not have_content("message")
+      expect(rendered).to_not have_content("You’ve subscribed to emails about")
     end
   end
 end


### PR DESCRIPTION
We introduced a regression, where creating a topic subscription
through the account would not show a success flash message on the
manage page.  This commit fixes that, and also updates the content of
the flash to match our designs.

I could have made the template use the account flash, but decided
that, as we have both account and non-account topic subscriptions for
now, it would be best for them to both use the same approach.  So
these flash messages do not use the account flash.

I also changed some places where we were redirecting to the manage
page via the `process_govuk_account_path`, even though we know at this
point the user is signed in.

---

<img width="678" alt="Screenshot 2021-11-26 at 13 48 09" src="https://user-images.githubusercontent.com/75235/143590627-582ea7b7-86c0-4dd6-9d89-2a4001d2839b.png">


---

[Trello card](https://trello.com/c/CufkfjRa/1164-fix-flash-messages-when-subscribing-to-a-topic)
