### PR TITLE
Remove link to view Brexit checker results

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -97,14 +97,6 @@
     <p class='govuk-body'>
       <%= subscription['created_at'].to_datetime.strftime(t("subscriptions_management.index.you_subscribed")) %>
     </p>
-    <% if subscription['subscriber_list']['url'] =~ %r{transition-check/results} ||
-      subscription['subscriber_list']['url'] =~ %r{get-ready-brexit-check/results} %>
-      <p class="govuk-body">
-        <%= link_to 'You can view a copy of your results on GOV.UK',
-                    subscription['subscriber_list']['url'],
-                    class: %w[govuk-link govuk-link--no-visited-state] %>
-      </p>
-    <% end %>
     <p class="govuk-body">
       <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
       <br>

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -77,34 +77,6 @@ RSpec.describe SubscriptionsManagementController do
       end
     end
 
-    %w[transition-check get-ready-brexit-check].each do |prefix|
-      context "when the subscription is for a #{prefix} list" do
-        before do
-          stub_email_alert_api_has_subscriber_subscriptions(
-            subscriber_id,
-            subscriber_address,
-            subscriptions: [
-              {
-                "id" => subscription_id,
-                "created_at" => "2019-09-16 02:08:08 01:00",
-                "subscriber_list" => {
-                  "title" => "Some thing",
-                  "url" => "/#{prefix}/results?c%5B%5D=automotive",
-                },
-              },
-            ],
-          )
-        end
-
-        it "renders a link to the list URL" do
-          get :index, session: session
-          expect(response.body).to include(
-            "href=\"/#{prefix}/results?c%5B%5D=automotive\">You can view a copy of your results on GOV.UK</a>",
-          )
-        end
-      end
-    end
-
     context "when there is a subscriber without any subscription" do
       let(:subscriber_id_with_no_subscriptions) { 2 }
       let(:subscriber_address_with_no_subscriptions) { "nothing@example.com" }


### PR DESCRIPTION
The checker doesn't exist anymore so this will just redirect to gov.uk/brexit

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
