### PR TITLE
Add click tracking to button

### DIFF
--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -30,7 +30,13 @@ end %>
 <%= form_tag single_page_new_session_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
 
   <%= render "govuk_publishing_components/components/button", {
-    text: t("single_page_subscriptions.create_or_sign_in_description")
+    text: t("single_page_subscriptions.create_or_sign_in_description"),
+    data_attributes: {
+      module: "gem-track-click",
+      track_action: t("single_page_subscriptions.create_or_sign_in_description"),
+      track_category: "External link clicked",
+      track_label: @topic_id,
+    }
   } %>
 
   <%= hidden_field_tag(:topic_id, @topic_id) %>


### PR DESCRIPTION
In addition to cross-domain tracking, the "Create a GOV.UK account or
sign in" button on the [The way you subscribe to emails from GOV.UK is
changing](https://www.gov.uk/email/subscriptions/single-page/new?topic_id=open-standards-for-government) page also needs explicit click tracking as per our PA's
advice.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
