### PR TITLE
Handle signed out users who are already subscribed to a page

### DIFF
--- a/app/services/create_account_subscription_service.rb
+++ b/app/services/create_account_subscription_service.rb
@@ -2,6 +2,7 @@
 
 class CreateAccountSubscriptionService < ApplicationService
   SUCCESS_FLASH = "email-subscription-success"
+  ALREADY_SUBSCRIBED_FLASH = "email-subscription-already-subscribed"
 
   def initialize(subscriber_list, frequency, govuk_account_session)
     super()

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -108,6 +108,28 @@ RSpec.describe AccountSubscriptionsController do
             get :confirm, params: { topic_id: topic_id }
             expect(response.body).to include(I18n.t("account_subscriptions.confirm.description.page"))
           end
+
+          context "when the user is already subscribed to this subscriber list" do
+            let(:subscriber_list_attributes) do
+              {
+                id: subscriber_list_id,
+                title: subscriber_list_title,
+                content_id: SecureRandom.uuid,
+                url: "/some/page",
+              }
+            end
+
+            let(:active_subscriptions) do
+              [
+                { subscriber_list: subscriber_list_attributes },
+              ]
+            end
+
+            it "redirects them to the content page" do
+              get :confirm, params: { topic_id: topic_id }
+              expect(response).to redirect_to(subscriber_list_attributes[:url])
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Previously, if a user was signed out and clicked the 'get emails about
this page' button to subscribe to email alerts about a single page, we
didn't check if they already had a subscription to that page.

If they did we'd ask them to confirm again and send a new confirmation
email, but the manage emails page would show the date of when they
originally subscribed which was a bit confusing.

Now, do that check and if they're already subscribed redirect them back
to the content page after they sign in with a flash message to display
an info banner telling them they were already subscribed.

Note that this implementation does skip the confirmation page after signing 
in. We think this is ok - we're checking that the user is successfully logged 
in before we do anything (so we can't leak information) and we're not 
updating any information (because they already have the subscription) so 
it keeps the RESTful design of our app.

[Trello](https://trello.com/c/PkNG9Ecl/1190-journey-when-clicking-on-get-email-updates-when-i-have-a-subscription-already-but-am-not-signed-in)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
