### PR TITLE
Add tracking to Manage your emails page links

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -62,7 +62,13 @@
     <p class="govuk-body">
       <%= link_to "Unsubscribe from everything",
                   confirm_unsubscribe_all_path,
-                  class: %w[govuk-link govuk-link--no-visited-state] %>
+                  class: %w[govuk-link govuk-link--no-visited-state],
+                  data: {
+                    module: "gem-track-click",
+                    track_category: "Manage_your_email_subscriptions",
+                    track_action: "Unsubscribe",
+                    track_label: use_govuk_account_layout? ? "From_everything_logged_in" : "From_everything_logged_out",
+                  } %>
     </p>
   <% end %>
 
@@ -105,7 +111,13 @@
       <% end %>
       <%= link_to change_frequency_link_text,
                   update_frequency_path(id: subscription['id']),
-                  class: %w[govuk-link govuk-link--no-visited-state] %>
+                  class: %w[govuk-link govuk-link--no-visited-state],
+                  data: {
+                    module: "gem-track-click",
+                    track_category: "Manage_your_email_subscriptions",
+                    track_action: "Change-frequency",
+                    track_label: use_govuk_account_layout? ? "From_specific_logged_in" : "From_specific_logged_out",
+                  } %>
     </p>
     <p class="govuk-body">
       <% unsubscribe_link_text = capture do %>
@@ -113,7 +125,13 @@
       <% end %>
       <%= link_to unsubscribe_link_text,
                   confirm_unsubscribe_path(id: subscription['id']),
-                  class: %w[govuk-link govuk-link--no-visited-state] %>
+                  class: %w[govuk-link govuk-link--no-visited-state],
+                  data: {
+                    module: "gem-track-click",
+                    track_category: "Manage_your_email_subscriptions",
+                    track_action: "Unsubscribe",
+                    track_label: use_govuk_account_layout? ? "From_specific_logged_in" : "From_specific_logged_out",
+                  } %>
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">


### PR DESCRIPTION
Add data attributes for tracking to the "Unsubscribe" and "Change how often you get emails" links on "Manage your GOV.UK email subscriptions".

https://trello.com/c/3tRhGf2w

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
