### PR TITLE
Simplify frequency information content

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -99,12 +99,10 @@
         <%= get_updated_at_from_subscription(subscription).to_datetime.strftime(t("subscriptions_management.index.last_updated")) %>
       </p>
     <% end %>
-
-    <p class='govuk-body'>
-      <%= subscription['created_at'].to_datetime.strftime(t("subscriptions_management.index.you_subscribed")) %>
-    </p>
+    
     <p class="govuk-body">
       <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
+      <%= subscription['created_at'].to_datetime.strftime(t("subscriptions_management.index.you_subscribed")) %>
       <br>
       <% change_frequency_link_text = capture do %>
         Change how often you get emails <span class="govuk-visually-hidden"> about <%= subscription['subscriber_list']['title'] %></span>

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -4,16 +4,16 @@ en:
     account_breadcrumb: Go back to your account
     index:
       subscription:
-        immediately: "You get updates as soon as they happen."
-        daily: "You get daily updates."
-        weekly: "You get weekly updates."
+        immediately: "You subscribed to get updates as soon as they happen "
+        daily: "You subscribed to daily updates "
+        weekly: "You subscribed to weekly updates "
       unsubscribe:
         message: "You have been unsubscribed from ‘%{title}’"
         description: "It can take up to an hour for this change to take effect."
       flashes:
         subscription: "You’ve subscribed to emails about ‘%{title}’."
       last_updated: "This page was last updated on %-d %B %Y"
-      you_subscribed: "You subscribed on %-d %B %Y at %-I:%M%P"
+      you_subscribed: "on %-d %B %Y at %-I:%M%P."
     no_subscriptions_warning_html: |
       <p class="govuk-body">You’re not currently getting emails about updates to GOV.UK.</p>
       <p class="govuk-body">Some GOV.UK pages have a link to ‘get emails’. You can use that link to subscribe to pages or topics you’re interested in.</p>

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe SubscriptionsManagementController do
       it "renders the subscriber's subscriptions" do
         get :index, session: session
         expect(response.body).to include("Some thing")
-        expect(response.body).to include("You subscribed on 16 September 2019 at 2:08am")
+        expect(response.body).to include("You subscribed to weekly updates")
+        expect(response.body).to include("on 16 September 2019 at 2:08am")
       end
 
       context "when the subscription is to a single page" do


### PR DESCRIPTION
Having two lines was potentially confusing, so simplify them into a
single line.

[Trello](https://trello.com/c/1P4BQE4t/1220-changing-frequency-content-change-index-page)

Screenshot of the new text on the manage page:
![image](https://user-images.githubusercontent.com/6362602/150537850-459db5d9-4348-4695-ada0-052e8c1dab57.png)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
