### PR TITLE
Content update to New single page subs page

### DIFF
--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -27,6 +27,22 @@ end %>
 
 <%= t("single_page_subscriptions.usage_description_html") %>
 
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("single_page_subscriptions.other_subs_heading") ,
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 6
+} %>
+
+<%= t("single_page_subscriptions.other_subs_description_html") %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("single_page_subscriptions.button_heading") ,
+  heading_level: 2,
+  font_size: "m",
+  margin_bottom: 6
+} %>
+
 <%= form_tag single_page_new_session_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/config/locales/single_page_subscriptions.yml
+++ b/config/locales/single_page_subscriptions.yml
@@ -1,6 +1,6 @@
 en:
   single_page_subscriptions:
-    title: The way you subscribe to emails from GOV.UK is changing
+    title: The way you subscribe to get emails from GOV.UK is changing
     account_required_description: You need a GOV.UK account to get these emails.
     subheading: GOV.​UK accounts are new
     accounts_are_new_description_html: |
@@ -11,4 +11,8 @@ en:
     usage_description_html: |
       <p class="govuk-body">Currently you can only use a GOV.UK account to manage your GOV.UK email subscriptions.</p>
       <p class="govuk-body">We’ll be adding more features and services in the next few months.</p>
+    other_subs_heading: If you have other GOV.UK email subscriptions
+    other_subs_description_html: |
+      <p class="govuk-body">If you have subscriptions to other GOV.UK topics or pages, these will be moved to your new account so you can manage all your subscriptions in one place.</p>
     create_or_sign_in_description: Create a GOV.UK account or sign in
+    button_heading: Create a GOV.UK account or sign in


### PR DESCRIPTION
[Trello](https://trello.com/c/a1mZyxzA/1221-interrupt-page-text-for-people-who-already-have-email-subscriptions)

Here's the thinking:

Page h1 change: Consistency and clarity. We talk about email
subscriptions and about getting emails, not about subscribing to emails.

Adding the  H2 ‘If you have other GOV.UK email subscriptions’ to
reassure users who are worried about their other subscriptions.

Adding the H2 ‘Create a GOV.UK account or sign in’ for accessibility -
the green button needs to be nested under a heading that describes it
coherently.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
