### PR TITLE
Show subscription name on the update frequency page

### DIFF
--- a/app/helpers/subscriptions_management_helper.rb
+++ b/app/helpers/subscriptions_management_helper.rb
@@ -1,0 +1,5 @@
+module SubscriptionsManagementHelper
+  def get_subscription_title(subscription)
+    subscription["subscriber_list"]["title"]
+  end
+end

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -1,4 +1,4 @@
-<% page_heading = 'How often do you want to receive emails?' %>
+<% page_heading = t("subscriptions_management.update_frequency.title", subscription_title: get_subscription_title(@subscriptions[@subscription_id])) %>
 <% content_for :title, page_heading + ' - ' + t("subscriptions_management.heading") %>
 
 <% content_for :back_link do %>

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -30,6 +30,8 @@ en:
       missing_email: Please enter your email address.
       invalid_email: "That email address isn’t valid, or it’s already in use – check you’ve typed in your email address correctly."
       success: "Your email address has been changed to %{address}"
+    update_frequency:
+      title: "How often do you want to get emails about ‘%{subscription_title}’?"
     change_frequency:
       success: "You’ll now get updates about ‘%{subscription_title}’ %{frequency}"
     confirm_unsubscribe_all:

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -149,6 +149,11 @@ RSpec.describe SubscriptionsManagementController do
       expect(response.body).to include(%(action="/email/manage/frequency/#{subscription_id}/change"))
     end
 
+    it "includes the subscription name in the page title" do
+      get :update_frequency, params: { id: subscription_id }, session: session
+      expect(response.body).to include("Some thing")
+    end
+
     it "returns 404 when the subscription doesn't belong to the subscriber" do
       stub_email_alert_api_has_subscriber_subscriptions(
         subscriber_id,

--- a/spec/helpers/subscriptions_management_helper_spec.rb
+++ b/spec/helpers/subscriptions_management_helper_spec.rb
@@ -1,0 +1,20 @@
+describe SubscriptionsManagementHelper do
+  let(:title) { "A subscription list" }
+  let(:subscription) do
+    {
+      "id" => 12_345,
+      "subscriber_list" => {
+        "id" => "abc123",
+        "url" => "/url",
+        "title" => title,
+      },
+    }
+  end
+
+  describe "#get_subscription_title" do
+    it "gets the title from the subscriber list" do
+      subscription_title = get_subscription_title(subscription)
+      expect(subscription_title).to eq(title)
+    end
+  end
+end


### PR DESCRIPTION
Previously there was no mention of what subscription you're changing the
frequency of on this page which was confusing. Add the title from the
subscriber list so people know what they're changing.

Having `@subscriptions[@subscription_id]["subscriber_list"]["title"]` in
the view is a bit ugly, so add a new `SubscriptionsManagementHelper`
module to hold some new methods that are only used in the view.

[Trello](https://trello.com/c/ojh8IxlC/1223-changing-frequency-content-manage-page)

Screenshot of the new heading: 
![image](https://user-images.githubusercontent.com/6362602/150544955-ee8cde32-3006-4198-a2aa-97941a88a63b.png)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
