### PR TITLE
Pass page description when creating a subscriber list

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -59,6 +59,7 @@ private
         url: @content_item.fetch("base_path"),
         title: @content_item.fetch("title"),
         content_id: @content_item.fetch("content_id"),
+        description: @content_item.fetch("description"),
       },
     ).to_h.fetch("subscriber_list")
     @topic_id = @subscriber_list.fetch("slug")

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SinglePageSubscriptionsController do
   let(:topic_name) { "Test" }
   let(:redirect_path) { "/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=#{topic_slug}" }
   let(:auth_provider) { "http://auth/provider" }
+  let(:description) { "A list description" }
 
   describe "POST /email/subscriptions/single-page/new-session" do
     before { stub_account_api_get_sign_in_url(auth_uri: auth_provider, redirect_path: redirect_path) }
@@ -35,7 +36,7 @@ RSpec.describe SinglePageSubscriptionsController do
 
   describe "POST /email/subscriptions/single-page/new" do
     before do
-      stub_content_store_has_item(base_path, content_item_for_base_path(base_path).merge("content_id" => content_id))
+      stub_content_store_has_item(base_path, content_item_for_base_path(base_path).merge("content_id" => content_id, "description" => description))
 
       stub_email_alert_api_creates_subscriber_list({
         url: base_path,
@@ -43,6 +44,7 @@ RSpec.describe SinglePageSubscriptionsController do
         slug: topic_slug,
         id: subscription_list_id,
         content_id: content_id,
+        description: description,
       })
     end
 


### PR DESCRIPTION
So that we can store it on email alert API and use it in emails. This is
currently only for single page subscriber lists, see [[1]] for more
details on the API side.

[Trello](https://trello.com/c/dm5ZxFVB/1226-pass-through-page-descriptions-to-subscriberlists-on-major-minor-publishing-change)

[1]: https://github.com/alphagov/email-alert-api/pull/1705

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
