### PR TITLE
Interrupt page content update

### DIFF
--- a/config/locales/single_page_subscriptions.yml
+++ b/config/locales/single_page_subscriptions.yml
@@ -4,13 +4,13 @@ en:
     account_required_description: You need a GOV.UK account to get these emails.
     subheading: GOV.​UK accounts are new
     accounts_are_new_description_html: |
-      <p class="govuk-body">They are a first step towards creating a single account where you can access all your government services.</p>
+      <p class="govuk-body">They are a first step towards creating a single account that you can use to sign in to all government services.</p>
       <p class="govuk-body">GOV.UK accounts will eventually replace all other government accounts.</p>
     inset_description_html: |
       At the moment, GOV.UK accounts are separate from <a href="/sign-in" class="govuk-link">other government accounts</a> (for example Government Gateway or Universal Credit).
     usage_description_html: |
       <p class="govuk-body">Currently you can only use a GOV.UK account to manage your GOV.UK email subscriptions.</p>
-      <p class="govuk-body">We’ll be adding more features and services in the next few months.</p>
+      <p class="govuk-body">We’re working on adding more features and services.</p>
     other_subs_heading: If you have other GOV.UK email subscriptions
     other_subs_description_html: |
       <p class="govuk-body">If you have subscriptions to other GOV.UK topics or pages, these will be moved to your new account so you can manage all your subscriptions in one place.</p>


### PR DESCRIPTION
Update two sentences on the interrupt page.

GOVUK Account content folks met with the DI content team and agreed on
consistent language to use throughout the journey.

https://trello.com/c/eA2AfKYK/1232-update-content-in-the-interrupt-page

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
