### PR TITLE
Handle repeat-subscribing to a list without a URL via the account

### DIFF
--- a/app/controllers/account_subscriptions_controller.rb
+++ b/app/controllers/account_subscriptions_controller.rb
@@ -83,8 +83,12 @@ private
   end
 
   def redirect_with_already_subscribed
-    account_flash_add CreateAccountSubscriptionService::ALREADY_SUBSCRIBED_FLASH
+    if @subscriber_list["url"].blank?
+      redirect_to list_subscriptions_path
+    else
+      account_flash_add CreateAccountSubscriptionService::ALREADY_SUBSCRIBED_FLASH
 
-    redirect_with_analytics @subscriber_list["url"]
+      redirect_with_analytics @subscriber_list["url"]
+    end
   end
 end

--- a/spec/controllers/account_subscriptions_controller_spec.rb
+++ b/spec/controllers/account_subscriptions_controller_spec.rb
@@ -115,9 +115,11 @@ RSpec.describe AccountSubscriptionsController do
                 id: subscriber_list_id,
                 title: subscriber_list_title,
                 content_id: SecureRandom.uuid,
-                url: "/some/page",
+                url: url,
               }
             end
+
+            let(:url) { "/some/page" }
 
             let(:active_subscriptions) do
               [
@@ -125,9 +127,18 @@ RSpec.describe AccountSubscriptionsController do
               ]
             end
 
-            it "redirects them to the content page" do
+            it "redirects them to the list URL" do
               get :confirm, params: { topic_id: topic_id }
               expect(response).to redirect_to(subscriber_list_attributes[:url])
+            end
+
+            context "when the list has no URL" do
+              let(:url) { nil }
+
+              it "redirects them to the management page" do
+                get :confirm, params: { topic_id: topic_id }
+                expect(response).to redirect_to(list_subscriptions_path)
+              end
             end
           end
         end


### PR DESCRIPTION
When a user tries to subscribe to a list with their account, we
redirect back to its URL if they're already subscribed.  But this
means that we throw an error for lists without a URL[1].

This can happen if a user, who has already linked their notifications
to their account, goes to sign up to a list-without-a-url which they
have already signed up to, as we redirect such users to continue via
their account (see `verify_account` in `subscriptions_controller.rb`)

[1] https://sentry.io/organizations/govuk/issues/2950527269/
