### PR TITLE
Pass analytics params when signing in to manage page

### DIFF
--- a/app/controllers/subscriber_authentication_controller.rb
+++ b/app/controllers/subscriber_authentication_controller.rb
@@ -43,7 +43,7 @@ class SubscriberAuthenticationController < ApplicationController
 
   def process_govuk_account
     if authenticated_via_account?
-      redirect_to list_subscriptions_path
+      redirect_with_analytics list_subscriptions_path
     else
       redirect_with_analytics GdsApi.account_api.get_sign_in_url(redirect_path: process_govuk_account_path)["auth_uri"]
     end

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -164,6 +164,11 @@ RSpec.describe SubscriberAuthenticationController do
       expect(response).to redirect_to(list_subscriptions_path)
     end
 
+    it "passes on _ga and cookie_consent parameters in the redirect if present" do
+      get :process_govuk_account, params: { _ga: "abc123", cookie_consent: "accept" }
+      expect(response).to redirect_to(list_subscriptions_path(_ga: "abc123", cookie_consent: "accept"))
+    end
+
     it "does not create a new session" do
       get :process_govuk_account
       expect(session["authentication"]).to be_nil


### PR DESCRIPTION
When an unauthenticated user tries to go to `/email/manage` they are
redirected through the sign in process. If they sign in with a GOV.UK
account this means they'll be taken off the `www.gov.uk` domain which
breaks the analytics tracking when they return as we weren't preserving
the linker parameters GOV.UK sign in are passing back to the app.

Now, pass through the parameters in the final redirect so they're
present on the page that Google Analytics loads on. Also add a test so
we don't accidentally break this in the future.

[Trello](https://trello.com/c/nNT2WjDH/1088-account-manager-tracking-and-reporting-update-after-di-migration)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
