### PR TITLE
Remove cross domain tracking parameters from sign in page

### DIFF
--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -25,7 +25,7 @@
   } %>
 </div>
 
-<%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate", :"data-module" => "explicit-cross-domain-links" do %>
+<%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate" do %>
   <%= render 'govuk_publishing_components/components/input', {
     error_message: flash[:error] &&
       t("subscriber_authentication.sign_in.#{flash[:error]}.message"),


### PR DESCRIPTION
Submitting this form never takes you directly to the OAuth provider.

A user either:

1. Has a GOV.UK account and is signed in. They are redirected
	through to the subscriptions page without needing to sign in.

2. Has a GOV.UK account and is not signed in. They are shown a
	page that tells them they have a GOV.UK account and must sign
	in again. There's a button on the page which redirects them to
	the OAuth provider which has the cross domain tracking
	parameters on the link.

3. They have an account using the old system of sending a
	magic link to their email address. Here, they see a page
	telling them to check their email for an sign in link, which
	will take them to the subscriptions page.

The case that sends the user to sign in again is 2, but this form isn't
the last one in this app before they're sent to do so. The next form in
the journey adds the tracking parameters before sending the user to
sign in.

Therefore, we don't need to add the cross domain tracking parameters on
this page.

---
[Trello](https://trello.com/c/Fj2cDeAq/1272-single-data-environment-project-tracking-issue-cross-domain)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
