### PR TITLE
Manage your GOVUK emails layout update

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -94,7 +94,7 @@ class SubscriptionsManagementController < ApplicationController
   def use_govuk_account_layout?
     @use_govuk_account_layout ||=
       if authenticated_via_account?
-        set_slimmer_headers(template: "gem_layout_account_manager", remove_search: true, show_accounts: "signed-in")
+        set_slimmer_headers(template: "gem_layout_account_manager_no_nav", remove_search: true, show_accounts: "signed-in")
         true
       end
   end

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -15,20 +15,6 @@
   } if subscription %>
 <% end %>
 
-<% if use_govuk_account_layout? %>
-  <% content_for :before_content do %>
-    <%= render "govuk_publishing_components/components/breadcrumbs", {
-      collapse_on_mobile: true,
-      breadcrumbs: [
-        {
-          title: t("subscriptions_management.account_breadcrumb"),
-          url: GovukPersonalisation::Urls.your_account,
-        },
-      ]
-    } %>
-    <% end %>
-<% end %>
-
 <%= render "govuk_publishing_components/components/heading", {
   text: t("subscriptions_management.heading"),
   heading_level: 1,
@@ -36,20 +22,28 @@
   margin_bottom: 6,
 } %>
 
-<% unless use_govuk_account_layout? %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Subscriptions for #{@subscriber['address']}",
-    heading_level: 2,
-    font_size: "m",
-    margin_bottom: 4,
-  } %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Subscriptions for #{@subscriber['address']}",
+  heading_level: 2,
+  font_size: "s",
+  margin_bottom: 4,
+} %>
 
+<% if use_govuk_account_layout? %>
+  <% change_details_account = capture do %>
+    <p class="govuk-body">
+      <%= sanitize(t("subscriptions_management.update_address_account", href: GovukPersonalisation::Urls.manage)) %>
+    </p>
+  <% end %>
+  <%= render "govuk_publishing_components/components/inset_text", {
+    text: change_details_account
+  } %>
+<% else %>
   <p class="govuk-body">
     <%= link_to "Change email address",
                 update_address_path,
                 class: %w[govuk-link govuk-link--no-visited-state] %>
   </p>
-
   <hr class="govuk-section-break govuk-section-break--l">
 <% end %>
 
@@ -58,24 +52,6 @@
     <%= t("subscriptions_management.no_subscriptions_warning_html") %>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 <% else %>
-  <% unsubscribe_all_text = capture do %>
-    <p class="govuk-body">
-      <%= link_to "Unsubscribe from everything",
-                  confirm_unsubscribe_all_path,
-                  class: %w[govuk-link govuk-link--no-visited-state],
-                  data: {
-                    module: "gem-track-click",
-                    track_category: "Manage_your_email_subscriptions",
-                    track_action: "Unsubscribe",
-                    track_label: use_govuk_account_layout? ? "From_everything_logged_in" : "From_everything_logged_out",
-                  } %>
-    </p>
-  <% end %>
-
-  <%= render "govuk_publishing_components/components/inset_text", {
-    text: unsubscribe_all_text
-  } %>
-
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
   <% @subscriptions.each do |_key, subscription| %>
@@ -89,7 +65,7 @@
 
     <%= render "govuk_publishing_components/components/heading", {
       text: get_heading_content(subscription),
-      heading_level: use_govuk_account_layout? ? 2 : 3,
+      heading_level: 3,
       font_size: "m",
       margin_bottom: 4
     } %>
@@ -99,7 +75,6 @@
         <%= get_updated_at_from_subscription(subscription).to_datetime.strftime(t("subscriptions_management.index.last_updated")) %>
       </p>
     <% end %>
-    
     <p class="govuk-body">
       <%= t("subscriptions_management.index.subscription.#{subscription['frequency']}") %>
       <%= subscription['created_at'].to_datetime.strftime(t("subscriptions_management.index.you_subscribed")) %>
@@ -134,4 +109,17 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   <% end %>
+  <p class="govuk-body">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Unsubscribe from everything",
+      href: confirm_unsubscribe_all_path,
+      data_attributes: {
+        module: "gem-track-click",
+        track_category: "Manage_your_email_subscriptions",
+        track_action: "Unsubscribe",
+        track_label: use_govuk_account_layout? ? "From_everything_logged_in" : "From_everything_logged_out",
+      },
+      secondary_solid: true
+    } %>
+  </p>
 <% end %>

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -1,7 +1,6 @@
 en:
   subscriptions_management:
     heading: Manage your GOV.UK email subscriptions
-    account_breadcrumb: Go back to your account
     index:
       subscription:
         immediately: "You subscribed to get updates as soon as they happen "
@@ -30,6 +29,7 @@ en:
       missing_email: Please enter your email address.
       invalid_email: "That email address isn’t valid, or it’s already in use – check you’ve typed in your email address correctly."
       success: "Your email address has been changed to %{address}"
+    update_address_account: Go to your GOV.UK account to <a href="%{href}" class="govuk-link">update your email address, password or phone number</a>.
     update_frequency:
       title: "How often do you want to get emails about ‘%{subscription_title}’?"
     change_frequency:
@@ -40,4 +40,3 @@ en:
     confirmed_unsubscribe_all:
       success_message: You have been unsubscribed from all your subscriptions.
       success_description: It can take up to an hour for this change to take effect.
-


### PR DESCRIPTION
Implement layout updates for the Manage your emails page:

- use the account layout without a left hand side nav
- update the inset text with a link to manage your GOVUK details
  (appears only when the user is authenticated with a GOVUK account)
- add an unsubscribe from everything button lower down the page (this
  was in the inset text but was replaced by the aforementioned info on
how to update one's email address)

https://trello.com/c/bPoMTXr0

### Before

https://user-images.githubusercontent.com/7116819/157088778-67d45995-a6e2-454b-8a79-5ce71d8ed356.mov


### After



https://user-images.githubusercontent.com/7116819/157089590-9e38f1e1-4f16-4222-ba9e-e012b4ca0c7c.mov






⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
