### PR TITLE
Add account privacy information to subscription confirmation page

### DIFF
--- a/app/views/account_subscriptions/confirm.html.erb
+++ b/app/views/account_subscriptions/confirm.html.erb
@@ -61,3 +61,10 @@
     <%= t("account_subscriptions.confirm.unlinked_subscriptions.after") %>
   </p>
 <% end %>
+
+<%= render "govuk_publishing_components/components/details", {
+  title: t("account_subscriptions.confirm.how_we_use_information.title") 
+  } do %>
+    <%= t("account_subscriptions.confirm.how_we_use_information.expanded_html") %>
+  <% end %>
+  

--- a/config/locales/account_subscriptions.yml
+++ b/config/locales/account_subscriptions.yml
@@ -13,3 +13,16 @@ en:
           <p class="govuk-body">There are more GOV.UK email subscriptions for <strong>%{address}</strong></p>
           <p class="govuk-body">These will be moved to your GOV.UK account:</p>
         after: You’ll be able to use your account to unsubscribe or change how often you get these emails.
+      how_we_use_information:
+        title: How we use your information
+        expanded_html: |
+          <p class="govuk-body">GOV.UK email subscriptions will only store the information you've provided.</p>
+          <p class="govuk-body">You can access, update or permanently delete your subscriptions and the information associated with them at any time.</p>
+          <p class="govuk-body">We will never:<ul class="govuk-list govuk-list--bullet">
+          <li>sell or rent your information to third parties</li>
+          <li>share your information with third parties for marketing purposes</li></ul></p>
+          <p class="govuk-body">We may collect and store information about how you use GOV.UK.
+          We’ll use this data to decide what improvements we can make to GOV.UK and the email updates you’ve subscribed to.
+          You will never be identified personally.</p>
+          <p class="govuk-body">You can read the <a class="govuk-link" href="/help/privacy-notice">full GOV.UK privacy notice</a>
+          for more detail on how your information is stored, shared and used.</p>


### PR DESCRIPTION
In [[1]] we removed the first time sign up page that asked users for
consent to use cookies, to email them for feedback, and displayed
privacy information about how we use the data associated with their
account.

We're not going to be collecting consent for cookies or feedback
centrally in the account any more, so that doesn't need moving, but we
do need to show users the privacy information at some point in the
creation journey.

Add this information to the confirmation page instead, so users can
read it before finalising their subscriptions.

[1]: https://github.com/alphagov/frontend/pull/3224

---

*DO NOT MERGE* until [the PR to remove the first time sign in page](https://github.com/alphagov/frontend/pull/3224) is ready. These need to be deployed at the same time

---
[Trello](https://trello.com/c/ZmuMTQy5/1370-remove-cookies-and-feedback)
[Figma design](https://www.figma.com/file/9RzsNFl3iYBXM5QfKO2HkE/Single-page-notifications-feature?node-id=2716%3A24352)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

---

The new content (details expanded):
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/6362602/168081270-fe0f4fa9-9d0c-42e9-812c-10d9b14a5c9b.png">

