### PR TITLE
Allow AuthToken to accept SHA256 or SHA1 hashes

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -22,6 +22,8 @@ private
     len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
     key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
     crypt = ActiveSupport::MessageEncryptor.new(key, **OPTIONS)
+    key_sha1 = ActiveSupport::KeyGenerator.new(secret, hash_digest_class: OpenSSL::Digest::SHA1).generate_key("", len)
+    crypt.rotate(key_sha1)
     decrypted_data = crypt.decrypt_and_verify(token)
     decrypted_data&.symbolize_keys
   rescue ActiveSupport::MessageEncryptor::InvalidMessage

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,8 +17,6 @@ module EmailAlertFrontend
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-    Rails.application.config.active_support.hash_digest_class = OpenSSL::Digest::SHA1
-    Rails.application.config.active_support.key_generator_hash_digest_class = OpenSSL::Digest::SHA1
 
     # Add lib directory to autoload paths
     config.autoload_paths += Dir[Rails.root.join("lib")]

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -2,14 +2,14 @@ describe AuthToken do
   include TokenHelper
 
   describe "#data" do
-    it "returns the data hash when valid" do
-      token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }))
+    it "returns the data hash when given a valid SHA1 token" do
+      token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA1))
       expect(token.data).to eq(a: "b")
     end
 
-    it "returns nil after the expiry time" do
-      token = AuthToken.new(encrypt_and_sign_token(expiry: 0))
-      expect(token.data).to be_nil
+    it "returns the data hash when given a valid SHA256 token" do
+      token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA256))
+      expect(token.data).to eq(a: "b")
     end
 
     it "returns nil if the token is malformed" do
@@ -20,6 +20,32 @@ describe AuthToken do
     it "returns nil if the token is invalid" do
       token = AuthToken.new("1HmD8E9iHE7LWl6vT+dfRiKoxX9fU/BY--0MJPSBtYJqtox940--q/zvsHND7yFOeVsIdFbbIQ==")
       expect(token.data).to be_nil
+    end
+  end
+
+  describe "#valid?" do
+    context "with a SHA1 token" do
+      it "returns true when valid" do
+        token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA1))
+        expect(token.valid?).to be true
+      end
+
+      it "returns false after the expiry time" do
+        token = AuthToken.new(encrypt_and_sign_token(expiry: 0, hash_digest_class: OpenSSL::Digest::SHA1))
+        expect(token.valid?).to be false
+      end
+    end
+
+    context "with a SHA256 token" do
+      it "returns true when valid" do
+        token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA256))
+        expect(token.valid?).to be true
+      end
+
+      it "returns false after the expiry time" do
+        token = AuthToken.new(encrypt_and_sign_token(expiry: 0, hash_digest_class: OpenSSL::Digest::SHA256))
+        expect(token.valid?).to be false
+      end
     end
   end
 end

--- a/spec/support/token_helper.rb
+++ b/spec/support/token_helper.rb
@@ -1,8 +1,8 @@
 module TokenHelper
-  def encrypt_and_sign_token(data: {}, expiry: 5.minutes)
+  def encrypt_and_sign_token(data: {}, expiry: 5.minutes, hash_digest_class: OpenSSL::Digest::SHA256)
     len = ActiveSupport::MessageEncryptor.key_len(AuthToken::CIPHER)
     secret = Rails.application.secrets.email_alert_auth_token
-    key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
+    key = ActiveSupport::KeyGenerator.new(secret, hash_digest_class: hash_digest_class).generate_key("", len)
     crypt = ActiveSupport::MessageEncryptor.new(key, **AuthToken::OPTIONS)
     crypt.encrypt_and_sign(data, expires_in: expiry)
   end


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- Makes SHA256 tokens the default again (as per Rails 7 defaults)
- Adds a rotate to the decrypter that allows it to accept SHA1 tokens as well as SHA256 tokens.

This will allow it to accept the current SHA1 tokens from email-alert-api, and the SHA256 tokens from when email-alert-api is updated properly.

https://trello.com/c/Iz4TyAzx/1321-fixes-for-email-alert-api-email-alert-frontend-update-incident

Note - due to the way email-alert-api is set up, not currently possible to test this end to end. Has been tested by generating a token in the email-alert-api integration console:

`token = AuthTokenGeneratorService.call(hello: 'world')`

...then checking it decrypts on the email-alert-frontend integration console:

```
irb(main):007:0> token = AuthToken.new(data)
=> #<AuthToken:0x00007f23de69fb78 @token="1xZjrFbz4korhQywWP9H2nycQBNdySnzq...
irb(main):008:0> token.valid?
=> true
irb(main):009:0> token.data
=> {:hello=>"world"}
```