### PR TITLE
Remove ability to accept SHA1 tokens.

### DIFF
--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -22,8 +22,6 @@ private
     len = ActiveSupport::MessageEncryptor.key_len(CIPHER)
     key = ActiveSupport::KeyGenerator.new(secret).generate_key("", len)
     crypt = ActiveSupport::MessageEncryptor.new(key, **OPTIONS)
-    key_sha1 = ActiveSupport::KeyGenerator.new(secret, hash_digest_class: OpenSSL::Digest::SHA1).generate_key("", len)
-    crypt.rotate(key_sha1)
     decrypted_data = crypt.decrypt_and_verify(token)
     decrypted_data&.symbolize_keys
   rescue ActiveSupport::MessageEncryptor::InvalidMessage

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -2,11 +2,6 @@ describe AuthToken do
   include TokenHelper
 
   describe "#data" do
-    it "returns the data hash when given a valid SHA1 token" do
-      token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA1))
-      expect(token.data).to eq(a: "b")
-    end
-
     it "returns the data hash when given a valid SHA256 token" do
       token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA256))
       expect(token.data).to eq(a: "b")
@@ -24,16 +19,9 @@ describe AuthToken do
   end
 
   describe "#valid?" do
-    context "with a SHA1 token" do
-      it "returns true when valid" do
-        token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA1))
-        expect(token.valid?).to be true
-      end
-
-      it "returns false after the expiry time" do
-        token = AuthToken.new(encrypt_and_sign_token(expiry: 0, hash_digest_class: OpenSSL::Digest::SHA1))
-        expect(token.valid?).to be false
-      end
+    it "returns false when given a SHA1 token" do
+      token = AuthToken.new(encrypt_and_sign_token(data: { a: "b" }, hash_digest_class: OpenSSL::Digest::SHA1))
+      expect(token.valid?).to be false
     end
 
     context "with a SHA256 token" do


### PR DESCRIPTION
By the time this is merged, email-alert-api should have been generating 
only  generating SHA256 tokens for a week, so no SHA1 tokens are left in 
the wild.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/Iz4TyAzx/1321-fixes-for-email-alert-api-email-alert-frontend-update-incident

NOT TO BE MERGED UNTIL 1 WEEK AFTER https://github.com/alphagov/email-alert-api/pull/1757 reaches production!