### PR TITLE
Update content on manage your subscriptions page

### DIFF
--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -29,7 +29,7 @@ en:
       missing_email: Please enter your email address.
       invalid_email: "That email address isn’t valid, or it’s already in use – check you’ve typed in your email address correctly."
       success: "Your email address has been changed to %{address}"
-    update_address_account: Go to your GOV.UK account to <a href="%{href}" class="govuk-link">update your email address, password or phone number</a>.
+    update_address_account: You can <a href="%{href}" class="govuk-link">change your email address, password or mobile number in your GOV.UK account</a>.
     update_frequency:
       title: "How often do you want to get emails about ‘%{subscription_title}’?"
     change_frequency:


### PR DESCRIPTION
Amend content of the account callout on the "Manage your GOVUK email subscriptions" page.

### Before
 
 ![email-alert-frontend dev gov uk_email_manage_ (1)](https://user-images.githubusercontent.com/7116819/175009466-401ec1e3-6495-4736-a55a-8f83e0b0d392.png)  


### After

 ![email-alert-frontend dev gov uk_email_manage_](https://user-images.githubusercontent.com/7116819/175009472-ae00ef1a-fa2b-4a5c-8721-8ac974c244a6.png)  


https://govukverify.atlassian.net/browse/GUA-224


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

