### PR TITLE
Add symlinks to /tmp for file permission errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update -qq && \
     apt-get install -y build-essential nodejs && \
     apt-get clean
 
-RUN mkdir /app
+RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
 
 WORKDIR /app
 COPY Gemfile* .ruby-version /app/
@@ -33,9 +33,16 @@ RUN apt-get update -qy && \
     apt-get install -y nodejs && \
     apt-get clean
 
+RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
+
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 
 WORKDIR /app
+
+RUN groupadd -g 1001 app && \
+    useradd app -u 1001 -g 1001 --home /home/app
+
+USER app
 
 CMD bundle exec puma


### PR DESCRIPTION
This is a update to softlink of /tmp /app/tmp

Identical to https://github.com/alphagov/service-manual-frontend/commit/8906f2a861ea56fa68c7e028000cfbdf5058883c

https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
