### PR TITLE
Minor markup adjustment on Manage your emails page

### DIFF
--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -22,12 +22,7 @@
   margin_bottom: 6,
 } %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Subscriptions for #{@subscriber['address']}",
-  heading_level: 2,
-  font_size: "s",
-  margin_bottom: 4,
-} %>
+<p class="govuk-body">Subscriptions for <strong><%= @subscriber['address'] %></strong></p>
 
 <% if use_govuk_account_layout? %>
   <% change_details_account = capture do %>

--- a/spec/controllers/subscriptions_management_controller_spec.rb
+++ b/spec/controllers/subscriptions_management_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SubscriptionsManagementController do
     context "when there is a subscriber with a subscription" do
       it "renders the subscriber's email address" do
         get :index, session: session
-        expect(response.body).to include("Subscriptions for #{subscriber_address}")
+        expect(response.body).to have_content("Subscriptions for #{subscriber_address}")
       end
 
       it "renders the subscriber's subscriptions" do
@@ -93,7 +93,7 @@ RSpec.describe SubscriptionsManagementController do
 
       it "renders the subscriber's email address" do
         get :index, session: session_with_no_subscriptions
-        expect(response.body).to include("Subscriptions for #{subscriber_address_with_no_subscriptions}")
+        expect(response.body).to have_content("Subscriptions for #{subscriber_address_with_no_subscriptions}")
       end
 
       it "renders a message" do


### PR DESCRIPTION
Adjustment to the "Subscriptions for emailaddress" snippet so that is no
longer a heading but a regular paragraph with the email address in bold.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
