### PR TITLE
Updating base image to use a new image with Ruby on Minideb.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,24 @@
-ARG base_image=ruby:2.7.6-slim-buster
-
-FROM $base_image AS builder
-
-ENV RAILS_ENV=production
-
-# TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qq && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \
-    apt-get clean
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
+ 
+FROM $builder_image AS builder
 
 RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
 
 WORKDIR /app
+
 COPY Gemfile* .ruby-version /app/
 
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install -j8 --retry=2
+RUN bundle install
 
 COPY . /app
 # TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
-RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bin/bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile && rm -fr /app/log
 
 
 FROM $base_image
 
-ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=email-alert-frontend
-
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs && \
-    apt-get clean
+ENV GOVUK_APP_NAME=email-alert-frontend
 
 RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
 
@@ -39,9 +26,6 @@ COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/
 
 WORKDIR /app
-
-RUN groupadd -g 1001 app && \
-    useradd app -u 1001 -g 1001 --home /home/app
 
 USER app
 


### PR DESCRIPTION
Updating base image to use a new base and builder image. 

New Images are based on Ruby built from source on top of [Minideb](https://github.com/bitnami/minideb)


Base image repo, for more info:
https://github.com/alphagov/govuk-ruby-images

Further details:
https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
