### PR TITLE
Account layout template rename

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -94,7 +94,7 @@ class SubscriptionsManagementController < ApplicationController
   def use_govuk_account_layout?
     @use_govuk_account_layout ||=
       if authenticated_via_account?
-        set_slimmer_headers(template: "gem_layout_account_manager_no_nav", remove_search: true, show_accounts: "signed-in")
+        set_slimmer_headers(template: "gem_layout_account_manager", remove_search: true, show_accounts: "signed-in")
         true
       end
   end


### PR DESCRIPTION
~🙅🏻‍♀️**Do not merge**🙅🏻‍♀️, depends on https://github.com/alphagov/static/pull/2808~ 

Replacing `gem_layout_account_manager_no_nav` with
`gem_layout_account_manager` since the "no nav" bit has become irrelevant
since this page is the last page on GOVUK using the account layout
template.

There should be no visual change. 

The next step will be to remove `gem_layout_account_manager_no_nav` from `static` entirely as this is the last place referencing it.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
