### PR TITLE
Disable source map line comments for css in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,6 +27,9 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
+  # Do not add source map line comments into css files
+  config.sass.line_comments = false
+
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 


### PR DESCRIPTION
This removes the line comments for css in production as we don't need them in production and only increase css file size. Line comments make assets differ depending on compilation environment. This is an issue when we build the application for our EKS environment vs our old as our assets differ and ultimately end having a different filename hash. This makes it difficult to do a traffic split as the css will have a different filename for old vs new infra.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
