### PR TITLE
Fix Plek URL for Static in development

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,7 +18,7 @@
       "value": "https://www.gov.uk/api"
     },
     "PLEK_SERVICE_STATIC_URI": {
-      "value": "assets.digital.cabinet-office.gov.uk"
+      "value": "https://assets.publishing.service.gov.uk"
     },
     "RAILS_SERVE_STATIC_ASSETS": {
       "value": "yes"


### PR DESCRIPTION
This updates the URLs to use the asset domain and use HTTPS. This
is required for the Static proxy to correctly forward request.
