### PR TITLE
SPIKE Format params for email-alert-api

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -57,7 +57,8 @@ private
   end
 
   def assign_list_params
-    @list_params = GenerateSubscriberListParamsService.call(@content_item.to_h)
+    @single_page = params[:single_page].present?
+    @list_params = GenerateSubscriberListParamsService.call(@content_item.to_h, @single_page)
   rescue GenerateSubscriberListParamsService::UnsupportedContentItemError
     bad_request
   end

--- a/app/services/generate_subscriber_list_params_service.rb
+++ b/app/services/generate_subscriber_list_params_service.rb
@@ -1,10 +1,23 @@
 class GenerateSubscriberListParamsService < ApplicationService
-  def initialize(content_item)
+  def initialize(content_item, single_page = nil)
     super()
     @content_item = content_item
+    @single_page = single_page
   end
 
   def call
+    return attributes_for_content_id_based_lists if single_page
+
+    attributes_for_links_based_lists
+  end
+
+private
+
+  attr_reader :content_item, :single_page
+
+  class UnsupportedContentItemError < StandardError; end
+
+  def attributes_for_links_based_lists
     {
       "title" => content_item["title"],
       "links" => link_hash,
@@ -12,11 +25,13 @@ class GenerateSubscriberListParamsService < ApplicationService
     }
   end
 
-private
-
-  attr_reader :content_item
-
-  class UnsupportedContentItemError < StandardError; end
+  def attributes_for_content_id_based_lists
+    {
+      "title" => content_item["title"],
+      "content_id" => content_item["content_id"],
+      "url" => content_item["base_path"],
+    }
+  end
 
   def link_hash
     case content_item_type

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -18,6 +18,7 @@
 
 <%= form_tag(action: :create) do %>
   <%= hidden_field_tag 'link', @content_item['base_path'] %>
+  <%= hidden_field_tag 'single_page', @single_page %>
   <%= render 'govuk_publishing_components/components/button', {
     text: 'Continue',
     margin_bottom: true,


### PR DESCRIPTION
As part of our epic to retire specialist topics, the navigation-and-presentation team will be converting some high value topics into document collections ([example of a doc collection](https://www.gov.uk/government/collections/technology-case-studies)). 

Adding the single page notification button to document collections [is trivial](https://github.com/alphagov/government-frontend/pull/2535), but the button is currently hardcoded to send users down a route to sign up to a GOV.UK Account.  This spike is to see how we might support single page email subscriptions, without enforcing the account.

This app provides two endpoints for email subscriptions:

- #### Email sign up with a magic link( `/email-signup`)

This flow is handled by the [content_items_signup controller](https://github.com/alphagov/email-alert-frontend/blob/main/app/controllers/content_item_signups_controller.rb). It bypasses the need for a govuk-account. It is used on topic pages such as [here](https://www.gov.uk/topic/benefits-credits/tax-credits). 

- ####  Email sign up with a GOV.UK Account ( `/email/subscriptions/single-page/new`)

The [single_page_subscription controller](https://github.com/alphagov/email-alert-frontend/blob/main/app/controllers/single_page_subscriptions_controller.rb) handles requests that enforce the gov.uk account. This is the endpoint that is hardcoded by the single page notification button ([here](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb#L12))

This spike contains the changes needed to allow the content_items_signup controller to format the request for email alert API for content-id based subscriptions: If the params sent to the `/email-signup` endpoint contain `single_page=true`, email alert frontend will add the content ID of the page to the payload for email-alert-api. 

An alternative method would be to check the `content_type` of the content item that's being subscribed to. ie if this piece of content is a document collection then send the content id. But that felt hacky and harder to maintain. This way, if we want to allow more document types to be subscribed to without an account, we won't need to make any further changes to this app.

Related work:
- [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/commit/957e1657676e106fc2b8509ddd59d95c9c514b58)
- Update government-frontend which calls this component, and add the param on document collection pages. Not spiked.

Trello card: 
https://trello.com/c/iRtlSdUA/1413-investigate-how-should-we-build-email-notification-for-document-collections-time-box-3-days, [Jira issue NAV-5505](https://gov-uk.atlassian.net/browse/NAV-5505)


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
