### PR TITLE
Prevent Bad URI errors from getting into Sentry

### DIFF
--- a/app/controllers/single_page_subscriptions_controller.rb
+++ b/app/controllers/single_page_subscriptions_controller.rb
@@ -5,6 +5,7 @@ class SinglePageSubscriptionsController < ApplicationController
   DEFAULT_FREQUENCY = "immediately".freeze
 
   skip_before_action :verify_authenticity_token, only: [:create]
+  before_action :validate_base_path, only: %i[create]
   before_action :fetch_subscriber_list, only: %i[create]
   before_action :not_found_without_topic_id, only: %i[edit show]
 
@@ -50,6 +51,13 @@ private
 
   def topic_id
     @topic_id = params[:topic_id]
+  end
+
+  def validate_base_path
+    URI.parse(params.fetch(:base_path))
+  rescue URI::InvalidURIError => e
+    Rails.logger.warn("Bad base path passed to SinglePageSubscriptionsController: #{e}")
+    head :unprocessable_entity
   end
 
   def fetch_subscriber_list

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -81,6 +81,9 @@ private
       .to_h.fetch("subscriber_list")
     @frequency = subscription_params[:frequency]
     @address = subscription_params[:address]
+  rescue Addressable::URI::InvalidURIError => e
+    Rails.logger.warn("Bad topic passed to SubscriptionsController: #{e}")
+    head :unprocessable_entity
   end
 
   def subscription_params

--- a/spec/controllers/single_page_subscriptions_controller_spec.rb
+++ b/spec/controllers/single_page_subscriptions_controller_spec.rb
@@ -58,6 +58,12 @@ RSpec.describe SinglePageSubscriptionsController do
       expect(response).to have_http_status(:not_found)
     end
 
+    it "422s and writes to the log when a bad base path is passed" do
+      expect(Rails.logger).to receive(:warn)
+      post :create, params: { base_path: "/invalid{}" }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
     context "when a user is not logged in" do
       it "redirects to show and renders a sign in link including the topic_id" do
         post :create, params: params

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe SubscriptionsController do
       end
     end
 
+    context "when an unprocessable topic is provided" do
+      let(:topic_id) { "ofsted<https://wwww.gov.uk/" }
+      it "returns 422 and logs the error" do
+        expect(Rails.logger).to receive(:warn)
+        get :new, params: { topic_id: }
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
     context "when a topic is provided" do
       it "returns 200" do
         get :new, params: { topic_id: }


### PR DESCRIPTION
Since we're not doing anything about these (they're just background noise of hacking attempts), we catch these errors and return 422s instead of crashing. To make sure we can still monitor if we want to, add the error details as logged warnings.

This also pulls the URL parsing that's done in the content store API call forwards into email-alert-frontend so we protect content store from bogus calls.

https://trello.com/c/Wd2RY7tJ/1632-silence-bad-uri-errors-on-email-alert-frontend

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
