### PR TITLE
Update account-related content

### DIFF
--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -43,11 +43,6 @@ end %>
 } %>
 
 <%= form_tag single_page_new_session_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
-
-  <%= render "govuk_publishing_components/components/inset_text" do
-    t("single_page_subscriptions.mobile_phone_warning")
-  end %>
-
   <%= render "govuk_publishing_components/components/button", {
     text: t("single_page_subscriptions.create_or_sign_in_description"),
     data_attributes: {
@@ -59,5 +54,4 @@ end %>
   } %>
 
   <%= hidden_field_tag(:topic_id, @topic_id) %>
-
 <% end %>

--- a/config/locales/single_page_subscriptions.yml
+++ b/config/locales/single_page_subscriptions.yml
@@ -6,12 +6,11 @@ en:
     accounts_are_new_description_html: |
       <p class="govuk-body">At the moment you can only use your GOV.UK account with a few services, for example to manage your GOV.UK email subscriptions.</p>
     inset_description_html: |
-      GOV.UK accounts are currently separate from <a href="/sign-in" class="govuk-link">other government accounts</a> (for example Government Gateway or Universal Credit).
+      GOV.UK accounts do not work with <a href="/sign-in" class="govuk-link">all government accounts and services</a> yet (for example Government Gateway or Universal Credit).
     usage_description_html: |
-      <p class="govuk-body">In the future, you’ll be able to use your GOV.UK account to sign in to most services on GOV.UK.</p>
+      <p class="govuk-body">In the future, you’ll be able to use your GOV.UK account to access all services on GOV.UK.</p>
     other_subs_heading: If you have other GOV.UK email subscriptions
     other_subs_description_html: |
       <p class="govuk-body">If you have subscriptions to other GOV.UK topics or pages, these will be moved to your new account so you can manage all your subscriptions in one place.</p>
     create_or_sign_in_description: Create a GOV.UK account or sign in
-    mobile_phone_warning: You need a UK mobile number to create an account.
     button_heading: Create a GOV.UK account or sign in


### PR DESCRIPTION
Update content on the single page subscriptions "interrupt" page aka "The way you subscribe to get emails from GOV.UK is changing" page.

The purpose of this update is to bring this page in line with a series of updates the accounts team are implementing on the GOV.UK account. Besides rewording existing comment, it also removes the claim that you need a UK phone number to create an account as this is no longer a requirement.

### Before

![Screenshot 2022-12-14 at 10 33 13](https://user-images.githubusercontent.com/7116819/207596867-9385f8f5-765a-4f3e-9948-f675ca2c4fe6.png)

### After

![Screenshot 2022-12-14 at 10 49 14](https://user-images.githubusercontent.com/7116819/207596870-9c2d6495-d1ba-4381-8fdc-5785724a0d30.png)


⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
