### PR TITLE
Optimize CSS and JS on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,9 +24,14 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  # Compress JS using a preprocessor.
+  config.assets.js_compressor = :uglifier
+
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
+  # Rather than use a CSS compressor, use the SASS style to perform compression.
+  config.sass.style = :compressed
   # Do not add source map line comments into css files
   config.sass.line_comments = false
 


### PR DESCRIPTION
## What

This change ensures that CSS and JS is optimized on production. The settings used are consistent with other frontend rendering applications.

## Why

We are currently serving larger asset sizes than required to end users, optimizing the CSS and JS should improve performance on the frontend.

The table below shows the results when CSS and JS is optimized:

| asset | current size (resource / network) | optimized size (resource / network) |
| --- | --- | --- |
| app.css | 28.8 kB / 3.3 kB | 23.6 kB / 3.1 kB |
| app.js | 177 kB / 26.7 kB | 65.6 kB / 11.4 kB |

Total size saved when transferring the CSS and JS over the network is around 15.5 kB.

Trello card: https://trello.com/c/uxPZxhqq/1706-email-alert-frontend-css-and-js-not-optimized

---

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
