### PR TITLE
Sort .dockerignore and remove `vendor` from it.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 .dockerignore
 .git
-.gitignore
 .github
+.gitignore
 Dockerfile
 Jenkinsfile
 Procfile
@@ -16,5 +16,4 @@ script
 spec
 test
 tmp
-vendor
 yarn.lock


### PR DESCRIPTION
Since we always build from a clean working copy, there's no benefit to having `vendor` in dockerignore. It just creates a slight risk of confusion in future if someone were to check in third-party JS/CSS files into `vendor/{javascripts,stylesheets}` that were needed at runtime, as has been done for some GOV.UK apps.

No change for EC2/Puppet (i.e. the current production system).