### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "govuk_app_config"
 gem "govuk_personalisation"
 gem "govuk_publishing_components"
 gem "jwt"
-gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "plek"
 gem "ratelimit"
 gem "sassc-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,8 +155,11 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.0.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -386,7 +389,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_test
   jwt
-  mail (~> 2.7.1)
   plek
   pry-byebug
   rails (= 7.0.4)


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
