### PR TITLE
Support single page email subscriptions without a gov.uk account

### DIFF
--- a/app/controllers/govuk_account_signups_controller.rb
+++ b/app/controllers/govuk_account_signups_controller.rb
@@ -1,4 +1,4 @@
-class SinglePageSubscriptionsController < ApplicationController
+class GovukAccountSignupsController < ApplicationController
   include GovukPersonalisation::ControllerConcern
 
   UNSUBSCRIBE_FLASH = "email-unsubscribe-success".freeze
@@ -13,7 +13,7 @@ class SinglePageSubscriptionsController < ApplicationController
 
   def create
     unless logged_in?
-      redirect_to new_single_page_subscription_path(topic_id: @topic_id) and return
+      redirect_to new_govuk_account_signup_path(topic_id: @topic_id) and return
     end
 
     subscriber = GdsApi.email_alert_api.authenticate_subscriber_by_govuk_account(

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -18,6 +18,7 @@
 
 <%= form_tag(action: :create) do %>
   <%= hidden_field_tag 'link', @content_item['base_path'] %>
+  <%= hidden_field_tag 'single_page_subscription', single_page_subscription %>
   <%= render 'govuk_publishing_components/components/button', {
     text: 'Continue',
     margin_bottom: true,

--- a/app/views/govuk_account_signups/show.html.erb
+++ b/app/views/govuk_account_signups/show.html.erb
@@ -42,7 +42,7 @@ end %>
   margin_bottom: 6
 } %>
 
-<%= form_tag single_page_new_session_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
+<%= form_tag govuk_account_signups_new_session_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
   <%= render "govuk_publishing_components/components/button", {
     text: t("single_page_subscriptions.create_or_sign_in_description"),
     data_attributes: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,9 +36,9 @@ Rails.application.routes.draw do
       post "/verify" => "subscriptions#verify", as: :verify_subscription
       post "/verify/account" => "subscriptions#verify_account", as: :verify_subscription_account
       get "/authenticate" => "subscription_authentication#authenticate", as: :confirm_subscription
-      post "/single-page/new" => "single_page_subscriptions#create"
-      get "/single-page/new" => "single_page_subscriptions#show", as: :new_single_page_subscription
-      post "/single-page/new-session" => "single_page_subscriptions#edit", as: :single_page_new_session
+      post "/single-page/new" => "govuk_account_signups#create"
+      get "/single-page/new" => "govuk_account_signups#show", as: :new_govuk_account_signup
+      post "/single-page/new-session" => "govuk_account_signups#edit", as: :govuk_account_signups_new_session
       scope "/account" do
         get "/confirm" => "account_subscriptions#confirm", as: :confirm_account_subscription
         post "/" => "account_subscriptions#create"

--- a/spec/controllers/govuk_account_signups_controller_spec.rb
+++ b/spec/controllers/govuk_account_signups_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe SinglePageSubscriptionsController do
+RSpec.describe GovukAccountSignupsController do
   include GdsApi::TestHelpers::ContentStore
   include GdsApi::TestHelpers::AccountApi
   include GdsApi::TestHelpers::EmailAlertApi
@@ -67,7 +67,7 @@ RSpec.describe SinglePageSubscriptionsController do
     context "when a user is not logged in" do
       it "redirects to show and renders a sign in link including the topic_id" do
         post(:create, params:)
-        expect(response).to redirect_to(new_single_page_subscription_path(topic_id: topic_slug))
+        expect(response).to redirect_to(new_govuk_account_signup_path(topic_id: topic_slug))
       end
     end
 


### PR DESCRIPTION
## What

We will soon be allowing users to signup to emails on document collection pages. 

[Adding the single page notification button to document collections](https://github.com/alphagov/government-frontend/pull/2535/files) is trivial, but the button is currently [hardcoded](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb#L12) to send users down a route to sign up to a GOV.UK Account. This PR supports signing up to single page notifications without enforcing the GOV.UK Account.

## How

This app provides two endpoints for email subscriptions:

#### Email sign up with a magic link( /email-signup)
This flow is handled by the [content_items_signup controller](https://github.com/alphagov/email-alert-frontend/blob/main/app/controllers/content_item_signups_controller.rb). It bypasses the need for a govuk-account. It is used on topic pages such as [here](https://www.gov.uk/topic/benefits-credits/tax-credits).

#### Email sign up with a GOV.UK Account ( /email/subscriptions/single-page/new)
The [single_page_subscription controller](https://github.com/alphagov/email-alert-frontend/blob/main/app/controllers/single_page_subscriptions_controller.rb) handles requests that enforce the gov.uk account. This is the endpoint that is hardcoded by the single page notification button ([here](https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_single_page_notification_button.html.erb#L12))

This PR contains the changes needed to allow the content_items_signup controller to format the request for email alert API for content-id based subscriptions: If the params sent to the /email-signup endpoint contain the param `single_page_subscription`, the content_items_signup_controller will use the `GenerateSinglePageListParamsService` instead of the `GenerateLinksBasedListParamsService`

#### Follow up work:

- https://github.com/alphagov/govuk_publishing_components/pull/3229
- https://github.com/alphagov/government-frontend/pull/2535

This PR is based on [this spike](https://github.com/alphagov/email-alert-frontend/pull/1416)

https://trello.com/c/DCLGQJU4/1457-extend-email-alert-frontend-to-support-an-account-less-sign-up-journey-from-the-single-page-notification-button-l, [Jira issue NAV-8498](https://gov-uk.atlassian.net/browse/NAV-8498)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
