### PR TITLE
Add GA4 link tracking to 'Create a GOV.UK account or sign in' button

### DIFF
--- a/app/views/single_page_subscriptions/show.html.erb
+++ b/app/views/single_page_subscriptions/show.html.erb
@@ -46,10 +46,15 @@ end %>
   <%= render "govuk_publishing_components/components/button", {
     text: t("single_page_subscriptions.create_or_sign_in_description"),
     data_attributes: {
-      module: "gem-track-click",
+      module: "gem-track-click ga4-link-tracker",
       track_action: t("single_page_subscriptions.create_or_sign_in_description"),
       track_category: "External link clicked",
       track_label: @topic_id,
+      ga4_link: {
+        "event_name": "navigation",
+        "type": "generic link",
+        "url": "https://signin.account.gov.uk/sign-in-or-create"
+      }.to_json
     }
   } %>
 


### PR DESCRIPTION
Hi @andysellick - Would you be able to review this? Thanks :+1:

## What
Adds the `ga4-link-tracker` to the `Create a GOV.UK account or sign in` button on [these types of page](https://www.gov.uk/email/subscriptions/single-page/new?topic_id=cost-of-living-payment)

## Why
We were asked to add this button as a link to be tracked. [See trello card](https://trello.com/c/uRQJP1gE/401-subscription-page-not-tracking-external-links).

## Testing
To test this branch, use `govuk-docker`. Note that you run `make email-alert-frontend` as usual, but to start the server you need to use `govuk-docker up email-alert-frontend-live` otherwise the static assets do not load.

Here's a page you can test : http://email-alert-frontend.dev.gov.uk/email/subscriptions/single-page/new?topic_id=cost-of-living-payment

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
