### PR TITLE
GUA-523: GOVUK account name change

### DIFF
--- a/config/locales/single_page_subscriptions.yml
+++ b/config/locales/single_page_subscriptions.yml
@@ -1,16 +1,16 @@
 en:
   single_page_subscriptions:
     title: The way you subscribe to get emails from GOV.UK is changing
-    account_required_description: You need a GOV.UK account to get these emails.
-    subheading: GOV.​UK accounts are new
+    account_required_description: You need a GOV.UK One Login to get these emails.
+    subheading: GOV.UK One Login is new
     accounts_are_new_description_html: |
-      <p class="govuk-body">At the moment you can only use your GOV.UK account with a few services, for example to manage your GOV.UK email subscriptions.</p>
+      <p class="govuk-body">At the moment you can only use GOV.UK One Login with a few services, for example to manage your GOV.UK email subscriptions.</p>
     inset_description_html: |
-      GOV.UK accounts do not work with <a href="/sign-in" class="govuk-link">all government accounts and services</a> yet (for example Government Gateway or Universal Credit).
+      GOV.UK One Login does not work with <a href="/sign-in" class="govuk-link">all government accounts and services</a> yet (for example Government Gateway or Universal Credit).
     usage_description_html: |
-      <p class="govuk-body">In the future, you’ll be able to use your GOV.UK account to access all services on GOV.UK.</p>
+      <p class="govuk-body">In the future, you’ll be able to use GOV.UK One Login to access all services on GOV.UK.</p>
     other_subs_heading: If you have other GOV.UK email subscriptions
     other_subs_description_html: |
-      <p class="govuk-body">If you have subscriptions to other GOV.UK topics or pages, these will be moved to your new account so you can manage all your subscriptions in one place.</p>
-    create_or_sign_in_description: Create a GOV.UK account or sign in
-    button_heading: Create a GOV.UK account or sign in
+      <p class="govuk-body">If you have subscriptions to other GOV.UK topics or pages, these will be moved so you can manage all your subscriptions in one place.</p>
+    create_or_sign_in_description: Create a GOV.UK One Login or sign in
+    button_heading: Create a GOV.UK One Login or sign in

--- a/config/locales/subscriber_authentication.yml
+++ b/config/locales/subscriber_authentication.yml
@@ -36,9 +36,9 @@ en:
         <p>If you do not receive an email soon, check your spam or junk folder.</p>
         <p>If this does not work, <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/contact/govuk">contact GOV.UK</a> for help.</p>
     use_your_govuk_account:
-      heading: You have a GOV.UK account
+      heading: You have a GOV.UK One Login
       description: Sign in to see and manage your GOV.UK emails.
-      continue: Continue to sign in to your account
+      continue: Sign in to your GOV.UK One Login
     no_subscriber:
       heading: You’re not subscribed to emails about updates to GOV.UK
       description_html: "You’re not currently getting emails about updates to GOV.UK at this email address: <strong>%{email}</strong>"

--- a/config/locales/subscriptions.yml
+++ b/config/locales/subscriptions.yml
@@ -21,6 +21,6 @@ en:
         <p>If you do not receive an email soon, check your spam or junk folder.</p>
         <p>If this does not work, <a class="govuk-link" href="https://www.gov.uk/contact/govuk">contact GOV.UK</a> for help.</p>
     use_your_govuk_account:
-      heading: You have a GOV.UK account
+      heading: You have a GOV.UK One Login
       description: "Sign in to subscribe to emails about:"
-      continue: Continue to sign in to your account
+      continue: Sign in to your GOV.UK One Login

--- a/config/locales/subscriptions_management.yml
+++ b/config/locales/subscriptions_management.yml
@@ -29,7 +29,7 @@ en:
       missing_email: Please enter your email address.
       invalid_email: "That email address isn’t valid, or it’s already in use – check you’ve typed in your email address correctly."
       success: "Your email address has been changed to %{address}"
-    update_address_account: You can <a href="%{href}" class="govuk-link">change your email address, password or mobile number in your GOV.UK account</a>.
+    update_address_account: You can <a href="%{href}" class="govuk-link">change your sign in details in your GOV.UK One Login</a>.
     update_frequency:
       title: "How often do you want to get emails about ‘%{subscription_title}’?"
     change_frequency:


### PR DESCRIPTION
The GOV.UK account is being rebranded to GOV.UK One Login. These are all content updates necessary to support this change

https://trello.com/c/EbkPjP8y/1817-thursday-9th-feb-email-alerts-pr-approvals-for-digital-identity-accounts-team

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
