### PR TITLE
Configure AssetHelper to load individual stylesheets

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,1 @@
 //= link application.js
-//= link application.css

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,4 @@
-$govuk-compatibility-govuktemplate: false;
-$govuk-use-legacy-palette: false;
-$govuk-new-link-styles: true;
+// The AssetHelper module is configured for this application to load individual stylesheets
+// for components and views on pages where they are needed.
 
-// This flag stops the font from being included in this application's
-// stylesheet - the font is being served by Static across all of GOV.UK, so is
-// not needed here.
-$govuk-include-default-font-face: false;
+// https://github.com/alphagov/govuk_publishing_components/blob/main/docs/set-up-individual-component-css-loading.md

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,11 +6,3 @@ $govuk-new-link-styles: true;
 // stylesheet - the font is being served by Static across all of GOV.UK, so is
 // not needed here.
 $govuk-include-default-font-face: false;
-
-@import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/components/back-link";
-@import "govuk_publishing_components/components/details";
-@import "govuk_publishing_components/components/error-summary";
-@import "govuk_publishing_components/components/inset-text";
-@import "govuk_publishing_components/components/radio";
-@import "govuk_publishing_components/components/success-alert";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,30 @@
+<% content_for :body do %>
+  <% if use_govuk_account_layout? %>
+    <div id="wrapper">
+      <% content_for :before_content do %>
+        <%= yield :back_link %>
+      <% end %>
+      <%= yield :before_content %>
+      <main role="main" id="content">
+        <%= yield %>
+      </main>
+    </div>
+  <% else %>
+    <div class="govuk-width-container" id="wrapper">
+      <%= yield :back_link %>
+      <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" role="main" id="content">
+        <div id="email-alert-frontend">
+          <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+              <%= yield %>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  <% end %>
+<% end %>
+
 <!DOCTYPE html>
 <html>
   <head>
@@ -10,32 +37,12 @@
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= yield :head %>
     <meta name="robots" content="noindex, nofollow">
+    <%=
+      render_component_stylesheets
+    %>
   </head>
   <body class="govuk-template__body">
-    <% if use_govuk_account_layout? %>
-      <div id="wrapper">
-        <% content_for :before_content do %>
-          <%= yield :back_link %>
-        <% end %>
-        <%= yield :before_content %>
-        <main role="main" id="content">
-          <%= yield %>
-        </main>
-      </div>
-    <% else %>
-      <div class="govuk-width-container" id="wrapper">
-        <%= yield :back_link %>
-        <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank?%>" role="main" id="content">
-          <div id="email-alert-frontend">
-            <div class="govuk-grid-row">
-              <div class="govuk-grid-column-two-thirds">
-                <%= yield %>
-              </div>
-            </div>
-          </div>
-        </main>
-      </div>
-    <% end %>
+    <%= yield :body %>
     <%= javascript_include_tag 'application' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,6 @@
     <% if content_for(:meta_description).present? %>
       <meta name="description" content="<%= content_for(:meta_description) %>" />
     <% end %>
-    <%= stylesheet_link_tag "application", media: "all" %>
     <%= yield :head %>
     <meta name="robots" content="noindex, nofollow">
     <%=

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ Bundler.require(*Rails.groups)
 
 module EmailAlertFrontend
   class Application < Rails::Application
+    include GovukPublishingComponents::AppHelpers::AssetHelper
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
@@ -34,5 +36,7 @@ module EmailAlertFrontend
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    config.assets.precompile << get_component_css_paths
   end
 end


### PR DESCRIPTION
## What

https://trello.com/c/ws6n64fm/1870-enable-individual-loading-of-stylesheets-in-email-alert-frontend

Changes to load component and view style sheets only required on the page being viewed. For example, CSS for "radio" only loads on the following pages:

- https://www.integration.publishing.service.gov.uk/email-signup/?link=/money

## Why

This reduces the amount of CSS required for each page and increases the ability of a browser to cache the stylesheets - this should mean a faster load time for both first time and repeat visitors.

See [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152) for more details.

## Review URL(s)

- https://www.integration.publishing.service.gov.uk/email-signup/?link=/money
- https://www.integration.publishing.service.gov.uk/foreign-travel-advice/canada/email-signup
- https://www.integration.publishing.service.gov.uk/email/subscriptions/new?topic_id=statistics-with-1-research-and-statistic-5e2982632b
- https://www.integration.publishing.service.gov.uk/email/subscriptions/single-page/new?topic_id=pro-innovation-regulation-of-technologies-review-life-sciences-interim-report
- https://www.integration.publishing.service.gov.uk/email/manage
- https://www.integration.publishing.service.gov.uk/email/manage/address (if no "change your sign in details in your GOV.UK One Login" message)
- https://www.integration.publishing.service.gov.uk/email/manage/authenticate
- https://www.integration.publishing.service.gov.uk/email/manage/frequency/dd1e3465-6598-4c72-b7ac-94f785164ae6
- https://www.integration.publishing.service.gov.uk/email/manage/unsubscribe-all
- https://www.integration.publishing.service.gov.uk/email/unsubscribe/dd1e3465-6598-4c72-b7ac-94f785164ae6
- https://www.integration.publishing.service.gov.uk/email/subscriptions/verify

## Visual changes

None

## Anything else
- I've removed `application.scss` from the manifest and current layout since it no longer imports any partials and compiles to an empty style sheet. I think this is a good approach since developers can still find the expected `application.scss` file and read the comment as to why it's empty / not loaded.
- https://github.com/alphagov/govuk_publishing_components/pull/3014
- https://github.com/alphagov/frontend/pull/3342
- https://github.com/alphagov/smart-answers/pull/6213
- [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152)