### PR TITLE
Hotfix for single page subscriptions

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -72,7 +72,7 @@ private
   end
 
   def single_page_subscription?
-    params[:single_page_subscription].present?
+    params[:single_page_subscription].present? && params[:single_page_subscription] == "true"
   end
 
   def render_confirm_page


### PR DESCRIPTION
This code was originally introduced to handle special cases for subscriptions. However, this affected sign-ups for other pages using this same flow, since the value of the `single_page_subscription` can be present but a string with the value of false. This meant that for non single page subscriptions, the subscriptions were still going through the single page flow, resulting in users not receiving email alerts for content changes.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
