### PR TITLE
Improve specs and refactor hotfix

### DIFF
--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -1,7 +1,13 @@
 # This controller takes any content item and makes it possible to subscribe
 # to alerts when documents linked to them are changed (taxons, orgs etc).
-# This is in contrast to EmailAlertSignupsController, which takes a
+# This is in contrast to the EmailAlertSignupsController, which takes a
 # finder_email_signup content item.
+#  This controller also supports subscribing users to changes to the document itself
+# (aka a content id based or single page list) if the paramater 'single_page_subscription'
+# is present in the request.
+# The govuk_account_signups controller also supports single page subscriptions, but it
+# enforces the govuk account.
+
 class ContentItemSignupsController < ApplicationController
   include TaxonsHelper
 
@@ -14,16 +20,15 @@ class ContentItemSignupsController < ApplicationController
     if is_taxon_with_children?(@content_item)
       render "taxon"
     else
-      render_confirm_page
+      render "confirm"
     end
   end
 
   def confirm
     if is_taxon_with_children?(@content_item) && params[:topic].nil?
       flash[:error] = t("content_item_signups.taxon.no_selection")
-      render "taxon" and return
+      render "taxon"
     end
-    render_confirm_page
   end
 
   def create
@@ -64,18 +69,15 @@ private
   end
 
   def params_service
-    if single_page_subscription?
+    if sign_up_to_content_id_based_subscription?
       SubscriberListParams::GenerateSinglePageListParamsService
     else
       SubscriberListParams::GenerateLinksBasedListParamsService
     end
   end
 
-  def single_page_subscription?
-    params[:single_page_subscription].present? && params[:single_page_subscription] == "true"
+  def sign_up_to_content_id_based_subscription?
+    params[:single_page_subscription] == "true"
   end
-
-  def render_confirm_page
-    render "confirm", locals: { single_page_subscription: single_page_subscription? }
-  end
+  helper_method :sign_up_to_content_id_based_subscription?
 end

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -18,7 +18,9 @@
 
 <%= form_tag(action: :create) do %>
   <%= hidden_field_tag 'link', @content_item['base_path'] %>
-  <%= hidden_field_tag 'single_page_subscription', single_page_subscription %>
+  <% if sign_up_to_content_id_based_subscription? %>
+    <%= hidden_field_tag 'single_page_subscription', "true" %>
+  <% end %>
   <%= render 'govuk_publishing_components/components/button', {
     text: 'Continue',
     margin_bottom: true,

--- a/spec/features/content_item_signup_spec.rb
+++ b/spec/features/content_item_signup_spec.rb
@@ -9,12 +9,19 @@ RSpec.feature "Content item signup" do
     then_i_can_subscribe_to_alerts
   end
 
+  scenario "a single page subscription button with skip account enabled" do
+    given_there_is_a_piece_of_content_with_a_single_page_notification_button_with_skip_account_enabled
+    when_i_visit_the_signup_page_the_single_page_subscription_param_is_set
+    and_i_click_to_signup_to_alerts
+    then_i_can_subscribe_to_alerts
+  end
+
   scenario "taxon with children" do
     given_there_is_a_topic
     when_i_visit_the_signup_page
     and_i_refine_my_selection
-    and_i_click_to_signup_to_alerts
-    then_i_can_subscribe_to_alerts
+    and_i_click_to_signup_to_taxon_alerts
+    then_i_can_subscribe_to_taxon_alerts
   end
 
   def given_there_is_a_topic
@@ -44,8 +51,25 @@ RSpec.feature "Content item signup" do
     stub_content_store_has_item(@content_item[:base_path], @content_item)
   end
 
+  def given_there_is_a_piece_of_content_with_a_single_page_notification_button_with_skip_account_enabled
+    @single_page_notification_with_skip_account = "true"
+    @content_item = {
+      content_id: SecureRandom.uuid,
+      title: "Piece of content",
+      base_path: "/my-content",
+      document_type: "anything-goes",
+      description: "Some information",
+    }
+    stub_content_store_has_item(@content_item[:base_path], @content_item)
+  end
+
   def when_i_visit_the_signup_page
     visit new_content_item_signup_path(link: @content_item[:base_path])
+    expect(page).to have_content(@content_item[:title])
+  end
+
+  def when_i_visit_the_signup_page_the_single_page_subscription_param_is_set
+    visit new_content_item_signup_path(link: @content_item[:base_path], single_page_subscription: "true")
     expect(page).to have_content(@content_item[:title])
   end
 
@@ -58,17 +82,59 @@ RSpec.feature "Content item signup" do
   end
 
   def and_i_click_to_signup_to_alerts
+    generic_links_based_params = {
+      "title" => @content_item[:title],
+      "links" => { "organisations" => [@content_item[:content_id]] },
+      "url" => @content_item[:base_path],
+    }
+
+    content_id_based_params = {
+      "title" => @content_item[:title],
+      "content_id" => @content_item[:content_id],
+      "description" => @content_item[:description],
+      "url" => @content_item[:base_path],
+    }
+
+    params =
+      @single_page_notification_with_skip_account.present? ? content_id_based_params : generic_links_based_params
+
+    assert_email_alert_api_find_and_create(params)
+  end
+
+  def and_i_click_to_signup_to_taxon_alerts
     stub_email_alert_api_creates_subscriber_list(
       "links" => { @links_type => [@content_item[:content_id]] },
       "slug" => "my-list",
     )
-
     stub_email_alert_api_has_subscriber_list_by_slug(slug: "my-list", returned_attributes: {})
     click_on "Continue"
   end
 
-  def then_i_can_subscribe_to_alerts
+  def then_i_can_subscribe_to_taxon_alerts
     expected_path = new_subscription_path(topic_id: "my-list")
     expect(page).to have_current_path(expected_path)
+  end
+
+  def then_i_can_subscribe_to_alerts
+    slug = @content_item[:base_path].parameterize
+    expected_path = new_subscription_path(topic_id: slug)
+    expect(page).to have_current_path(expected_path)
+  end
+
+  def assert_email_alert_api_find_and_create(params)
+    endpoint = GdsApi::TestHelpers::EmailAlertApi::EMAIL_ALERT_API_ENDPOINT
+    find_or_create_link = "#{endpoint}/subscriber-lists"
+    slug = params["url"].parameterize
+    email_alert_api_response = { "subscriber_list" => { "slug" => slug } }
+
+    create_stub = stub_request(:post, find_or_create_link)
+                  .with(body: hash_including(params))
+                  .to_return(status: 200, body: email_alert_api_response.to_json)
+
+    stub_email_alert_api_has_subscriber_list_by_slug(slug:, returned_attributes: {})
+
+    click_on "Continue"
+
+    expect(create_stub).to have_been_requested
   end
 end


### PR DESCRIPTION
The feature added in [Support single page email subscriptions without a gov.uk account](https://github.com/alphagov/email-alert-frontend/pull/1489) contained a bug. This PR contains a refactor to replace the hotfix added in https://github.com/alphagov/email-alert-frontend/pull/1518, and improves the test coverage.

## Before 
Confirmation page form action contains hidden field "single_page_subscription" = "false"

<img width="1584" alt="Screenshot 2023-04-17 at 09 52 22" src="https://user-images.githubusercontent.com/17908089/232434968-8c2d2674-9ed5-475d-b1aa-bb0dd9c5e086.png">

## After 
Confirmation page form action has no hidden field "single_page_subscription"

<img width="1580" alt="Screenshot 2023-04-17 at 09 54 08" src="https://user-images.githubusercontent.com/17908089/232435388-1a036057-bb53-4444-879e-79919b57ad3b.png">

Trello: https://trello.com/c/o1QRND0Q/1779-refactor-hotfix-and-add-regression-test-for-single-page-notifications-without-a-govuk-account, [Jira issue NAV-8414](https://gov-uk.atlassian.net/browse/NAV-8414)
