### PR TITLE
Adds handler for from=your-services param hint in /email/manage

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -1,6 +1,7 @@
 class SubscriptionsManagementController < ApplicationController
   include Slimmer::Headers
   include Slimmer::Template
+  before_action :handle_one_login_hint, only: [:index]
   before_action :require_authentication
   before_action :get_subscription_details
   before_action :set_back_url
@@ -100,6 +101,12 @@ class SubscriptionsManagementController < ApplicationController
   end
 
 private
+
+  def handle_one_login_hint
+    return unless params[:from] == "your-services" && !authenticated?
+
+    redirect_with_analytics GdsApi.account_api.get_sign_in_url(redirect_path: list_subscriptions_path)["auth_uri"]
+  end
 
   def get_subscription_details
     subscription_details = GdsApi.email_alert_api.get_subscriptions(


### PR DESCRIPTION
In order to improve the logged-in experience, in https://github.com/alphagov/frontend/pull/3670 we are redirecting /account directly to home.account.gov.uk. This means that we are skipping session creation. It improves the general logged in behaviour, but means that if someone goes to /account and logs in, then follows the link to /email/manage, email-alert-frontend will not know that the user is logged in (because no session will exist), and they'll be prompted for their email address. To get around this, we add support for a hint parameter (from=your-services) which will be added to the link in the home.account.gov.uk/your-services page. When we go to /email/manage?from=your-services, the app knows that we came from One Login and are therefore probably logged in, so attempts a silent login.

https://trello.com/c/SiAQ3dZU/2086-redirect-govuk-account-to-homeaccountgovuk

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
