### PR TITLE
Add GA4 tracking to email subscriptions

### DIFF
--- a/app/views/account_subscriptions/confirm.html.erb
+++ b/app/views/account_subscriptions/confirm.html.erb
@@ -19,7 +19,22 @@
   <strong><%= @subscriber_list["title"] %></strong>
 </p>
 
-<%= form_tag(action: :create) do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("account_subscriptions.confirm.title", locale: :en),
+    text: @subscriber_list["title"],
+    action: t("account_subscriptions.confirm.confirm", locale: :en),
+    tool_name: "Get emails from GOV.UK",
+  }.to_json
+%>
+<%= form_tag(
+  { action: :create },
+  data: {
+    module: "ga4-form-tracker",
+    ga4_form: ga4_data
+  }) do %>
   <%= hidden_field_tag "topic_id", @topic_id %>
   <%= hidden_field_tag "frequency", @frequency %>
   <%= hidden_field_tag "return_to_url", @return_to_url %>
@@ -63,8 +78,7 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/details", {
-  title: t("account_subscriptions.confirm.how_we_use_information.title") 
+  title: t("account_subscriptions.confirm.how_we_use_information.title")
   } do %>
-    <%= t("account_subscriptions.confirm.how_we_use_information.expanded_html") %>
-  <% end %>
-  
+  <%= t("account_subscriptions.confirm.how_we_use_information.expanded_html") %>
+<% end %>

--- a/app/views/content_item_signups/confirm.html.erb
+++ b/app/views/content_item_signups/confirm.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title, t("content_item_signups.confirm.title") %>
 
-
 <%= render "govuk_publishing_components/components/heading", {
   text: t("content_item_signups.confirm.title"),
   heading_level: 1,
@@ -15,8 +14,21 @@
 <p class="govuk-body govuk-!-margin-bottom-8">
   <strong><%= @content_item['title'] %></strong>
 </p>
-
-<%= form_tag(action: :create) do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("content_item_signups.confirm.title", locale: :en),
+    action: "continue",
+    text: @content_item['title'],
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
+<%= form_tag({ action: :create },
+  data: {
+    module: "ga4-form-tracker",
+    ga4_form: ga4_data
+  }) do %>
   <%= hidden_field_tag 'link', @content_item['base_path'] %>
   <% if sign_up_to_content_id_based_subscription? %>
     <%= hidden_field_tag 'single_page_subscription', "true" %>

--- a/app/views/content_item_signups/taxon.html.erb
+++ b/app/views/content_item_signups/taxon.html.erb
@@ -1,15 +1,31 @@
 <% content_for :title, t("content_item_signups.taxon.title") %>
 
 <% if flash[:error] %>
-  <%= render "govuk_publishing_components/components/error_summary", {
-    title: t('content_item_signups.taxon.general_problem'),
-    items: [
-      {
-        text: flash[:error],
-        href: "#topic",
-      }
-    ]
-  } %>
+  <%
+    ga4_data = {
+      event_name: "form_error",
+      type: "email subscription",
+      text: flash[:error],
+      section: t("content_item_signups.taxon.title", locale: :en),
+      action: "error",
+      tool_name: "Get emails from GOV.UK"
+    }.to_json
+  %>
+  <%= content_tag(:div,
+    data: {
+      module: "ga4-auto-tracker",
+      ga4_auto: ga4_data
+    }) do %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: t('content_item_signups.taxon.general_problem'),
+      items: [
+        {
+          text: flash[:error],
+          href: "#topic",
+        }
+      ]
+    } %>
+  <% end %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/heading", {
@@ -19,18 +35,28 @@
   margin_bottom: 6,
 } %>
 
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("content_item_signups.taxon.title", locale: :en),
+    action: "continue",
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
 <%= form_tag({ action: :confirm },
-             method: "get",
-             data: {
-               module: "track-email-alert-signup-choices",
-               track_action: "new_topic",
-               track_category: "email_subscriptions",
-             }) do %>
+  method: "get",
+  data: {
+    module: "track-email-alert-signup-choices ga4-form-tracker",
+    ga4_form: ga4_data,
+    track_action: "new_topic",
+    track_category: "email_subscriptions",
+  }) do %>
 
   <%
-     radio_items = taxon_children(@content_item).map do |taxon|
-       { :value => taxon['base_path'], :text => taxon['title'] }
-     end
+    radio_items = taxon_children(@content_item).map do |taxon|
+      { :value => taxon['base_path'], :text => taxon['title'] }
+    end
   %>
 
   <%= render "govuk_publishing_components/components/radio", {

--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -6,15 +6,30 @@
   font_size: "l",
   margin_bottom: 6,
 } %>
-
 <% if flash[:error] %>
-  <%= render 'govuk_publishing_components/components/error_summary', {
-    title: t("subscriber_authentication.sign_in.#{flash[:error]}.title"),
-    items: [{
-      text: t("subscriber_authentication.sign_in.#{flash[:error]}.description"),
-      href: '#email-address-input'
-    }]
-  } %>
+  <%
+    ga4_data = {
+      event_name: "form_error",
+      type: "email subscription",
+      text: t("subscriber_authentication.sign_in.#{flash[:error]}.description", locale: :en),
+      section: t("subscriber_authentication.sign_in.heading", locale: :en),
+      action: "error",
+      tool_name: "Get emails from GOV.UK"
+    }.to_json
+  %>
+  <%= content_tag(:div,
+    data: {
+      module: "ga4-auto-tracker",
+      ga4_auto: ga4_data
+    }) do %>
+    <%= render 'govuk_publishing_components/components/error_summary', {
+      title: t("subscriber_authentication.sign_in.#{flash[:error]}.title"),
+      items: [{
+        text: t("subscriber_authentication.sign_in.#{flash[:error]}.description"),
+        href: '#email-address-input'
+      }]
+    } %>
+  <% end %>
 <% end %>
 
 <div class="govuk-body">
@@ -25,7 +40,23 @@
   } %>
 </div>
 
-<%= form_tag verify_subscriber_path, method: :post, novalidate: "novalidate" do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("subscriber_authentication.sign_in.heading", locale: :en),
+    action: "continue",
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
+<%= form_tag(
+  verify_subscriber_path,
+  method: :post,
+  novalidate: "novalidate",
+  data: {
+    module: "ga4-form-tracker",
+    ga4_form: ga4_data
+  }) do %>
   <%= render 'govuk_publishing_components/components/input', {
     error_message: flash[:error] &&
       t("subscriber_authentication.sign_in.#{flash[:error]}.message"),

--- a/app/views/subscriptions/new_address.html.erb
+++ b/app/views/subscriptions/new_address.html.erb
@@ -1,29 +1,58 @@
 <% content_for :title, t("subscriptions.new_address.title") %>
 
 <% if flash[:error] %>
-  <%= render "govuk_publishing_components/components/error_summary", {
-    title: t('subscriptions.new_address.general_problem'),
-    items: [
-      {
-        text: flash[:error],
-        href: "#email-address-input",
-      }
-    ]
-  } %>
+  <%
+    ga4_data = {
+      event_name: "form_error",
+      type: "email subscription",
+      text: flash[:error],
+      section: t("subscriptions.new_address.title", locale: :en),
+      action: "error",
+      tool_name: "Get emails from GOV.UK"
+    }.to_json
+  %>
+  <%= content_tag(:div,
+    data: {
+      module: "ga4-auto-tracker",
+      ga4_auto: ga4_data
+    }) do %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: t('subscriptions.new_address.general_problem'),
+      items: [
+        {
+          text: flash[:error],
+          href: "#email-address-input",
+        }
+      ]
+    } %>
+  <% end %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("subscriptions.new_address.title"),
-  heading_level: 1,
-  font_size: "l",
-  margin_bottom: 6,
-} %>
-
-<%= form_tag verify_subscription_path, method: :post, novalidate: "novalidate" do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("subscriptions.new_address.title", locale: :en),
+    action: "continue",
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
+<%= form_tag verify_subscription_path,
+  method: :post,
+  data: {
+    module: "ga4-form-tracker",
+    ga4_form: ga4_data
+  },
+  novalidate: "novalidate" do %>
   <%= hidden_field_tag :topic_id, @topic_id %>
   <%= hidden_field_tag :frequency, @frequency %>
 
   <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: t("subscriptions.new_address.title"),
+    },
+    heading_level: 1,
+    heading_size: "l",
     error_message: flash[:error],
     id: "email-address-input",
     name: :address,

--- a/app/views/subscriptions/new_frequency.html.erb
+++ b/app/views/subscriptions/new_frequency.html.erb
@@ -1,23 +1,49 @@
 <% content_for :title, t("subscriptions.new_frequency.title") %>
 
 <% if flash[:error] %>
-  <%= render "govuk_publishing_components/components/error_summary", {
-    title: t('subscriptions.new_frequency.general_problem'),
-    items: [
-      {
-        text: flash[:error],
-        href: "#email-frequency-input",
-      }
-    ]
-  } %>
+  <%
+    ga4_data = {
+      event_name: "form_error",
+      type: "email subscription",
+      text: flash[:error],
+      section: t("subscriptions.new_frequency.title", locale: :en),
+      action: "error",
+      tool_name: "Get emails from GOV.UK"
+    }.to_json
+  %>
+  <%= content_tag(:div,
+    data: {
+      module: "ga4-auto-tracker",
+      ga4_auto: ga4_data
+    }) do %>
+    <%= render "govuk_publishing_components/components/error_summary", {
+      title: t('subscriptions.new_frequency.general_problem'),
+      items: [
+        {
+          text: flash[:error],
+          href: "#email-frequency-input",
+        }
+      ]
+    } %>
+  <% end %>
 <% end %>
 
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("subscriptions.new_frequency.title", locale: :en),
+    action: "continue",
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
 <%= form_tag(subscription_frequency_path,
   class: "checklist-email-signup",
   data: {
-    module: "track-email-alert-signup-choices",
+    module: "track-email-alert-signup-choices ga4-form-tracker",
     track_category: "email_subscriptions",
     track_action: 'new_address',
+    ga4_form: ga4_data
   }) do %>
   <%= hidden_field_tag :topic_id, @topic_id %>
 

--- a/app/views/subscriptions/use_your_govuk_account.html.erb
+++ b/app/views/subscriptions/use_your_govuk_account.html.erb
@@ -10,11 +10,23 @@
 <p class="govuk-body"><%= t("subscriptions.use_your_govuk_account.description") %></p>
 
 <p class="govuk-body"><strong><%= @subscriber_list["title"] %></strong></p>
-
-<%= form_tag verify_subscription_account_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
-  <%= hidden_field_tag :topic_id, @topic_id %>
-  <%= hidden_field_tag :frequency, @frequency %>
-
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("subscriptions.use_your_govuk_account.heading", locale: :en),
+    action: "continue",
+    text: t("subscriptions.use_your_govuk_account.continue", locale: :en),
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
+<%= form_tag(
+  verify_subscription_account_path,
+  method: "post",
+  data: {
+    module: "explicit-cross-domain-links ga4-form-tracker",
+    ga4_form: ga4_data
+  }) do %>
   <%= render "govuk_publishing_components/components/button", {
     text: t("subscriptions.use_your_govuk_account.continue"),
   } %>

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -9,10 +9,27 @@
 
 <% if flash[:subscription] %>
   <% subscription = @subscriptions[flash[:subscription]['id']] %>
-
-  <%= render 'govuk_publishing_components/components/success_alert', {
-    message: t("subscriptions_management.index.flashes.subscription", title: subscription["subscriber_list"]["title"]),
-  } if subscription %>
+  <% if subscription %>
+    <%
+      ga4_data = {
+        event_name: "form_response",
+        type: "email subscription",
+        text: t("subscriptions_management.index.flashes.subscription", title: subscription["subscriber_list"]["title"], locale: :en),
+        section: t("subscriptions_management.heading", locale: :en),
+        action: "complete",
+        tool_name: "Get emails from GOV.UK"
+      }.to_json
+    %>
+    <%= content_tag(:div,
+      data: {
+        module: "ga4-auto-tracker",
+        ga4_auto: ga4_data
+      }) do %>
+      <%= render 'govuk_publishing_components/components/success_alert', {
+        message: t("subscriptions_management.index.flashes.subscription", title: subscription["subscriber_list"]["title"]),
+      } %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/subscriptions_management/update_address.html.erb
+++ b/app/views/subscriptions_management/update_address.html.erb
@@ -14,20 +14,51 @@
 } %>
 
 <% if flash[:error] %>
-  <%= render 'govuk_publishing_components/components/error_summary', {
-    title: t("subscriptions_management.update_address.error_title"),
-    items: [
-      {
-        text: t("subscriptions_management.update_address.error_description"),
-        href: '#email-address-input',
-      }
-    ]
-  } %>
+  <%
+    ga4_data = {
+      event_name: "form_error",
+      type: "email subscription",
+      text: t("subscriptions_management.update_address.error_description", locale: :en),
+      section: t("subscriptions_management.update_address.heading", locale: :en),
+      action: "error",
+      tool_name: "Get emails from GOV.UK"
+    }.to_json
+  %>
+  <%= content_tag(:div,
+    data: {
+      module: "ga4-auto-tracker",
+      ga4_auto: ga4_data
+    }) do %>
+    <%= render 'govuk_publishing_components/components/error_summary', {
+      title: t("subscriptions_management.update_address.error_title"),
+      items: [
+        {
+          text: t("subscriptions_management.update_address.error_description"),
+          href: '#email-address-input',
+        }
+      ]
+    } %>
+  <% end %>
 <% end %>
 
 <p class="govuk-body"><%= t("subscriptions_management.update_address.current_email", address: @address) %></p>
 
-<%= form_tag change_address_path, method: :post do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("subscriptions_management.update_address.heading", locale: :en),
+    action: "continue",
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
+<%= form_tag(
+  change_address_path,
+  method: :post,
+  data: {
+    module: "track-email-alert-signup-choices ga4-form-tracker",
+    ga4_form: ga4_data,
+  }) do %>
   <%= render 'govuk_publishing_components/components/input', {
     error_message: flash[:error],
     id: 'email-address-input',

--- a/app/views/unsubscriptions/confirm.html.erb
+++ b/app/views/unsubscriptions/confirm.html.erb
@@ -16,8 +16,22 @@
 } %>
 
 <%= render "confirmation" %>
-
-<%= form_tag(action: :confirmed) do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("unsubscriptions.title.confirm", locale: :en),
+    text: t("unsubscriptions.confirmation.with_title", title: @title, locale: :en),
+    action: "unsubscribe",
+    tool_name: "Get emails from GOV.UK",
+  }.to_json
+%>
+<%= form_tag(
+  { action: :confirmed },
+  data: {
+    module: "ga4-form-tracker",
+    ga4_form: ga4_data
+  }) do %>
   <%= hidden_field_tag :token, params[:token] %>
 
   <%= render 'govuk_publishing_components/components/button', {


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the various pages involved in the email subscription process.

There's quite a lot of them, and some aren't testable locally as they depend upon a connection to One Login (we might not be able to test them properly until they go live). I've written this PR as separate commits for each page to try to make it as clear as possible, see individual commits for details.

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/TXQOqtZ0/628-email-subscriptions-manage-subscriptions-sign-in-change-unsubscribe-forms