### PR TITLE
Restoring lost form hidden inputs

### DIFF
--- a/app/views/subscriptions/use_your_govuk_account.html.erb
+++ b/app/views/subscriptions/use_your_govuk_account.html.erb
@@ -27,6 +27,8 @@
     module: "explicit-cross-domain-links ga4-form-tracker",
     ga4_form: ga4_data
   }) do %>
+  <%= hidden_field_tag :topic_id, @topic_id %>
+  <%= hidden_field_tag :frequency, @frequency %>
   <%= render "govuk_publishing_components/components/button", {
     text: t("subscriptions.use_your_govuk_account.continue"),
   } %>


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why
Restore some form hidden inputs on the page at https://www.gov.uk/email/subscriptions/verify

These were mistakenly removed in https://github.com/alphagov/email-alert-frontend/pull/1587/commits/40c9de7dee8acf8f636bb63641248da303acd7aa

<img width="688" alt="Screenshot 2023-08-21 at 11 11 16" src="https://github.com/alphagov/email-alert-frontend/assets/861310/8404b345-7aa9-4281-a2cd-8033b1dfb9b7">

## Visual changes
None.

Trello card: https://trello.com/c/TXQOqtZ0/628-email-subscriptions-manage-subscriptions-sign-in-change-unsubscribe-forms
