### PR TITLE
GA4 tracking fixes

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -84,6 +84,7 @@ class SubscriptionsManagementController < ApplicationController
       flash[:success] = {
         message: t("subscriptions_management.confirmed_unsubscribe_all.success_message"),
         description: t("subscriptions_management.confirmed_unsubscribe_all.success_description"),
+        description_en: t("subscriptions_management.confirmed_unsubscribe_all.success_description", locale: :en),
       }
     rescue GdsApi::HTTPNotFound
       # The user has already unsubscribed.

--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -15,7 +15,21 @@
 
 <p class="govuk-body"><%= t("subscriptions_management.confirm_unsubscribe_all.description") %></p>
 
-<%= form_tag(action: :confirmed_unsubscribe_all) do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("subscriptions_management.confirm_unsubscribe_all.heading", locale: :en),
+    action: "unsubscribe",
+    tool_name: "Get emails from GOV.UK"
+  }.to_json
+%>
+<%= form_tag(
+  { action: :confirmed_unsubscribe_all },
+  data: {
+    module: "ga4-form-tracker",
+    ga4_form: ga4_data
+  }) do %>
   <%= hidden_field_tag(:from, @from) %>
   <%= render 'govuk_publishing_components/components/button', {
     text: 'Unsubscribe',

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -12,7 +12,7 @@
   <% if subscription %>
     <%
       ga4_data = {
-        event_name: "form_response",
+        event_name: "form_complete",
         type: "email subscription",
         text: t("subscriptions_management.index.flashes.subscription", title: subscription["subscriber_list"]["title"], locale: :en),
         section: t("subscriptions_management.heading", locale: :en),

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -1,10 +1,26 @@
 <% content_for :title, t("subscriptions_management.heading") %>
 
 <% if flash[:success] %>
-  <%= render 'govuk_publishing_components/components/success_alert', {
-    message: flash[:success]["message"],
-    description: flash[:success]["description"],
-  } %>
+  <%
+    ga4_data = {
+      event_name: "form_complete",
+      type: "email subscription",
+      text: flash[:success]["description_en"],
+      section: t("subscriptions_management.heading", locale: :en),
+      action: "complete",
+      tool_name: "Get emails from GOV.UK"
+    }.to_json
+  %>
+  <%= content_tag(:div,
+    data: {
+      module: "ga4-auto-tracker",
+      ga4_auto: ga4_data
+    }) do %>
+    <%= render 'govuk_publishing_components/components/success_alert', {
+      message: flash[:success]["message"],
+      description: flash[:success]["description"],
+    } %>
+  <% end %>
 <% end %>
 
 <% if flash[:subscription] %>

--- a/app/views/subscriptions_management/update_frequency.html.erb
+++ b/app/views/subscriptions_management/update_frequency.html.erb
@@ -14,7 +14,22 @@
   margin_bottom: 6,
 } %>
 
-<%= form_tag change_frequency_path, method: :post do %>
+<%
+  ga4_data = {
+    event_name: "form_response",
+    type: "email subscription",
+    section: t("subscriptions_management.update_frequency.title", subscription_title: get_subscription_title(@subscriptions[@subscription_id]), locale: :en),
+    action: "save",
+    tool_name: "Get emails from GOV.UK"
+  }
+%>
+<%= form_tag(
+  change_frequency_path,
+  method: :post,
+  data: {
+    module: "ga4-form-tracker",
+    ga4_form: ga4_data
+  }) do %>
   <%= hidden_field_tag :id, @subscription_id %>
     <%= render 'govuk_publishing_components/components/radio', {
       name: 'new_frequency',


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Fixes some of the GA4 tracking [previously added](https://github.com/alphagov/email-alert-frontend/pull/1587). See individual commits for details.

## Why

## Visual changes
None.

Trello card: https://trello.com/c/TXQOqtZ0/628-email-subscriptions-manage-subscriptions-sign-in-change-unsubscribe-forms
