### PR TITLE
More tracking fixes

### DIFF
--- a/app/controllers/subscriptions_management_controller.rb
+++ b/app/controllers/subscriptions_management_controller.rb
@@ -38,6 +38,7 @@ class SubscriptionsManagementController < ApplicationController
 
     flash[:success] = {
       message: t("subscriptions_management.change_frequency.success", subscription_title:, frequency: frequency_text),
+      message_en: t("subscriptions_management.change_frequency.success", subscription_title:, frequency: frequency_text, locale: :en),
     }
 
     redirect_to list_subscriptions_path
@@ -67,6 +68,7 @@ class SubscriptionsManagementController < ApplicationController
     )
     flash[:success] = {
       message: t("subscriptions_management.update_address.success", address: new_address),
+      message_en: t("subscriptions_management.update_address.success", address: new_address, locale: :en),
     }
 
     redirect_to list_subscriptions_path
@@ -83,8 +85,8 @@ class SubscriptionsManagementController < ApplicationController
       GdsApi.email_alert_api.unsubscribe_subscriber(authenticated_subscriber_id)
       flash[:success] = {
         message: t("subscriptions_management.confirmed_unsubscribe_all.success_message"),
+        message_en: t("subscriptions_management.confirmed_unsubscribe_all.success_message", locale: :en),
         description: t("subscriptions_management.confirmed_unsubscribe_all.success_description"),
-        description_en: t("subscriptions_management.confirmed_unsubscribe_all.success_description", locale: :en),
       }
     rescue GdsApi::HTTPNotFound
       # The user has already unsubscribed.

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -22,6 +22,7 @@ class UnsubscriptionsController < ApplicationController
     if authenticated?
       flash[:success] = {
         message: t("subscriptions_management.index.unsubscribe.message", title: @title),
+        message_en: t("subscriptions_management.index.unsubscribe.message", title: @title, locale: :en),
         description: t("subscriptions_management.index.unsubscribe.description"),
       }
 

--- a/app/views/subscriptions_management/index.html.erb
+++ b/app/views/subscriptions_management/index.html.erb
@@ -5,7 +5,7 @@
     ga4_data = {
       event_name: "form_complete",
       type: "email subscription",
-      text: flash[:success]["description_en"],
+      text: flash[:success]["message_en"],
       section: t("subscriptions_management.heading", locale: :en),
       action: "complete",
       tool_name: "Get emails from GOV.UK"


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- for the index page of the email subscriptions management, when returning from a successful action such as changing the frequency of an email or unsubscribing from all emails
- we need the message (not the description of the message) to be in English for tracking purposes, so we add `message_en` to all of the `flash[:success]` objects, that are used to display the success element as well as track in GA4 that it has appeared
- this was partly done before but not extensively enough (some success tracking was missing text or had the wrong text)

## Visual changes
None.

Trello card: https://trello.com/c/TXQOqtZ0/628-email-subscriptions-manage-subscriptions-sign-in-change-unsubscribe-forms