### PR TITLE
Add user research banner for One Login

### DIFF
--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -1,5 +1,14 @@
 <% content_for :title, t("subscriber_authentication.sign_in.heading") %>
 
+<div class="govuk-width-container">
+  <%= render "govuk_publishing_components/components/intervention", {
+    suggestion_text: "Help improve GOV.UK",
+    suggestion_link_text: "Take part in user research",
+    suggestion_link_url: "https://surveys.publishing.service.gov.uk/s/4J4QD4/",
+    new_tab: true,
+  } %>
+</div>
+
 <%= render "govuk_publishing_components/components/heading", {
   text: t("subscriber_authentication.sign_in.heading"),
   heading_level: 1,

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -22,6 +22,13 @@ RSpec.describe SubscriberAuthenticationController do
         get :sign_in
         expect(response.body).to include(%(action="#{verify_subscriber_path}"))
       end
+
+      it "displays Recruitment Banner" do
+        get :sign_in
+
+        expect(response.body).to include('href="https://surveys.publishing.service.gov.uk/s/4J4QD4/"')
+        expect(response.body).to include("Take part in user research (opens in a new tab)")
+      end
     end
   end
 


### PR DESCRIPTION
Add user research banner on https://www.gov.uk/email/manage/authenticate

Trello card: https://trello.com/c/95rRCft2/1999-authentication-team-one-login-program-user-research-banner-request-for-going-live-m, [Jira issue NAV-8548](https://gov-uk.atlassian.net/browse/NAV-8548)

![Screenshot 2023-08-22 at 15 35 49](https://github.com/alphagov/email-alert-frontend/assets/96050928/0be327f5-4311-43c0-af0c-ee20cc80d15f)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
