### PR TITLE
Remove user research banner for One Login

### DIFF
--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -1,14 +1,5 @@
 <% content_for :title, t("subscriber_authentication.sign_in.heading") %>
 
-<div class="govuk-width-container">
-  <%= render "govuk_publishing_components/components/intervention", {
-    suggestion_text: "Help improve GOV.UK",
-    suggestion_link_text: "Take part in user research",
-    suggestion_link_url: "https://surveys.publishing.service.gov.uk/s/4J4QD4/",
-    new_tab: true,
-  } %>
-</div>
-
 <%= render "govuk_publishing_components/components/heading", {
   text: t("subscriber_authentication.sign_in.heading"),
   heading_level: 1,

--- a/spec/controllers/subscriber_authentication_controller_spec.rb
+++ b/spec/controllers/subscriber_authentication_controller_spec.rb
@@ -22,13 +22,6 @@ RSpec.describe SubscriberAuthenticationController do
         get :sign_in
         expect(response.body).to include(%(action="#{verify_subscriber_path}"))
       end
-
-      it "displays Recruitment Banner" do
-        get :sign_in
-
-        expect(response.body).to include('href="https://surveys.publishing.service.gov.uk/s/4J4QD4/"')
-        expect(response.body).to include("Take part in user research (opens in a new tab)")
-      end
     end
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/Pze4Y7Sg/556-authentication-team-one-login-program-user-research-request-for-removing-the-banner-m, [Jira issue NAV-3043](https://gov-uk.atlassian.net/browse/NAV-3043)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
