### PR TITLE
Fix GA4 text value for unsubscribe all

### DIFF
--- a/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
+++ b/app/views/subscriptions_management/confirm_unsubscribe_all.html.erb
@@ -19,6 +19,7 @@
   ga4_data = {
     event_name: "form_response",
     type: "email subscription",
+    text: "You won't get any more automated emails from GOV.UK",
     section: t("subscriptions_management.confirm_unsubscribe_all.heading", locale: :en),
     action: "unsubscribe",
     tool_name: "Get emails from GOV.UK"


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Include a value for 'text' in the form tracker GA4 data attributes on the email subscriptions 'unsubscribe from all emails' page.

- text attribute was missing from unsubscribe all form tracker data attributes. This meant that the form tracker was looking and failing to find a value (since the form has no inputs, just the button to confirm)
- hard coding the text attribute into the form data attributes should hopefully fix this
- difficult to test as cannot render page locally

## Why
Part of the GA4 migration.

## Visual changes
None.

Trello card: https://trello.com/c/Jov85mLj/686-amend-text-value-on-unsubscribe-event-on-unsubscribe-from-all-emails-journey
