### PR TITLE
Simplify One Login interstitial page

### DIFF
--- a/app/views/govuk_account_signups/show.html.erb
+++ b/app/views/govuk_account_signups/show.html.erb
@@ -11,36 +11,9 @@
   <%= t("single_page_subscriptions.account_required_description") %>
 </p>
 
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("single_page_subscriptions.subheading"),
-  heading_level: 2,
-  font_size: "m",
-  margin_bottom: 6
-} %>
-
-<%= t("single_page_subscriptions.accounts_are_new_description_html") %>
-
-<%= render "govuk_publishing_components/components/inset_text" do
-  t("single_page_subscriptions.inset_description_html")
-end %>
-
-<%= t("single_page_subscriptions.usage_description_html") %>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("single_page_subscriptions.other_subs_heading") ,
-  heading_level: 2,
-  font_size: "m",
-  margin_bottom: 6
-} %>
-
-<%= t("single_page_subscriptions.other_subs_description_html") %>
-
-<%= render "govuk_publishing_components/components/heading", {
-  text: t("single_page_subscriptions.button_heading") ,
-  heading_level: 2,
-  font_size: "m",
-  margin_bottom: 6
-} %>
+<p class="govuk-body">
+  <%= t("single_page_subscriptions.other_subs_description") %>
+</p>
 
 <%= form_tag govuk_account_signups_new_session_path, method: :post, :"data-module" => "explicit-cross-domain-links" do %>
   <%= render "govuk_publishing_components/components/button", {

--- a/config/locales/single_page_subscriptions.yml
+++ b/config/locales/single_page_subscriptions.yml
@@ -1,16 +1,6 @@
 en:
   single_page_subscriptions:
-    title: The way you subscribe to get emails from GOV.UK is changing
+    title: Create a GOV.UK One Login to get emails
     account_required_description: You need a GOV.UK One Login to get these emails.
-    subheading: GOV.UK One Login is new
-    accounts_are_new_description_html: |
-      <p class="govuk-body">At the moment you can only use GOV.UK One Login with a few services, for example to manage your GOV.UK email subscriptions.</p>
-    inset_description_html: |
-      GOV.UK One Login does not work with <a href="/sign-in" class="govuk-link">all government accounts and services</a> yet (for example Government Gateway or Universal Credit).
-    usage_description_html: |
-      <p class="govuk-body">In the future, you’ll be able to use GOV.UK One Login to access all services on GOV.UK.</p>
-    other_subs_heading: If you have other GOV.UK email subscriptions
-    other_subs_description_html: |
-      <p class="govuk-body">If you have subscriptions to other GOV.UK topics or pages, these will be moved so you can manage all your subscriptions in one place.</p>
+    other_subs_description: If you have subscriptions to other GOV.UK topics or pages, these will be moved so you can manage all your subscriptions in one place.
     create_or_sign_in_description: Create a GOV.UK One Login or sign in
-    button_heading: Create a GOV.UK One Login or sign in


### PR DESCRIPTION
Simplify the interstitial page that comes when a user comes via the single-page-notification-button path and is required to create/use a One Login account.

https://trello.com/c/yxBLErqj/2135-improve-account-journeys-in-email-alert-frontend

BEFORE:
![Screenshot 2023-10-09 at 11 04 16](https://github.com/alphagov/email-alert-frontend/assets/4225737/71594455-8ddb-4a20-9dcb-89d9761364df)

AFTER:

<img width="675" alt="Screenshot 2023-10-09 at 12 13 25" src="https://github.com/alphagov/email-alert-frontend/assets/4225737/65eae13b-f161-4d8b-82d5-ae1e6d85f7f4">

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
