### PR TITLE
Redact email addresses as [email]

### DIFF
--- a/app/views/subscriber_authentication/sign_in.html.erb
+++ b/app/views/subscriber_authentication/sign_in.html.erb
@@ -55,6 +55,7 @@
   novalidate: "novalidate",
   data: {
     module: "ga4-form-tracker",
+    ga4_form_include_text: "",
     ga4_form: ga4_data
   }) do %>
   <%= render 'govuk_publishing_components/components/input', {


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- where you enter your email address (https://www.gov.uk/email/manage/authenticate) we have GA4 tracking
- the tracking currently defaults to not collecting any data from the form, so inputs are listed as [redacted]
- we want to make the redaction more specific so it says [email]
- to do this, set an attribute on the form so that values of inputs are collected, but when this occurs we apply our PII stripping code, which means that any email address entered into this field is returned as [email] instead

## Why
To make the GA4 data more understandable.

## Visual changes
None.

Trello card: https://trello.com/c/AvcrXf8U/703-emails-should-be-email-not-redacted-on-email-subscription-journey