### PR TITLE
Up hourly rate limit for email subscriptions

### DIFF
--- a/app/services/verify_subscription_email_service.rb
+++ b/app/services/verify_subscription_email_service.rb
@@ -6,10 +6,9 @@ class VerifySubscriptionEmailService < ApplicationService
   # and for users who subscribe to several things quickly.
   MINUTELY_THRESHOLD = 4
 
-  # This allows for up to 10 subscriptions per hour. Analysis
-  # shows 99% of subscribers have 10 or fewer active subs,
-  # so this covers someone creating all their subs in bulk.
-  HOURLY_THRESHOLD = 11
+  # This allows for up to 40 subscriptions per hour. The previous threshold of
+  # 11 requests per hour seemed too strict as legitimate users hit this limit.
+  HOURLY_THRESHOLD = 40
 
   def initialize(address, frequency, topic_id, govuk_account_session: nil)
     super()


### PR DESCRIPTION
This allows for up to 40 subscriptions per hour. The previous threshold of 11 requests per hour seemed too strict as legitimate users hit this limit. We've confirmed the new limit with FCDO (they brought this to our attention) and they think that the new limit is reasonable.

Trello:
https://trello.com/c/6CwyYXCw/2248-increase-rate-limit-to-40-rpm-for-email-signup-journeys

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
