### PR TITLE
Verify correct manifest is used when sassc-rails is bundled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "bootsnap", require: false
 gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_personalisation"
-gem "govuk_publishing_components"
+gem "govuk_publishing_components", git: "https://github.com/alphagov/govuk_publishing_components.git", branch: "migrate-to-dart-sass"
 gem "jwt"
 gem "plek"
 gem "ratelimit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/alphagov/govuk_publishing_components.git
+  revision: 19db9f4673cace730f9c32a5cfc45aca89b39518
+  branch: migrate-to-dart-sass
+  specs:
+    govuk_publishing_components (35.23.0)
+      govuk_app_config
+      govuk_personalisation (>= 0.7.0)
+      kramdown
+      plek
+      rails (>= 6)
+      rouge
+      sprockets (>= 3)
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -139,14 +154,6 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (35.23.0)
-      govuk_app_config
-      govuk_personalisation (>= 0.7.0)
-      kramdown
-      plek
-      rails (>= 6)
-      rouge
-      sprockets (>= 3)
     govuk_schemas (4.7.0)
       json-schema (>= 2.8, < 4.2)
     govuk_test (4.0.1)
@@ -622,7 +629,7 @@ DEPENDENCIES
   gds-api-adapters
   govuk_app_config
   govuk_personalisation
-  govuk_publishing_components
+  govuk_publishing_components!
   govuk_schemas
   govuk_test
   jwt


### PR DESCRIPTION
## What

Verify that applications that use LibSass for compiling stylesheets (`sassc-rails`), and bundle GOV.UK Publishing Components (`gem "govuk_publishing_components"`), that the correct manifest is used and that stylesheets are compiled without errors.

## Why

- GOV.UK Publishing Components now uses Dart Sass for compiling stylesheets. Maintaining two manifests ensures that applications will continue to compile stylesheets without errors
- LibSass is now [deprecated](https://sass-lang.com/blog/libsass-is-deprecated/)
- Making changes ahead of Design System team dropping support for LibSass https://github.com/alphagov/govuk-frontend/discussions/2632.

## Visual Changes

None.

## How can I test these changes?

- run `yarn jasmine:prepare` (or run `bundle exec rake app:assets:clobber app:assets:precompile`)
- what should happen? The Sass files should be compiled; all assets ought to be generated successfully within the `/public` directory
- no test failures to indicate the correct number of stylesheets are generated
- deploy to Integration. You'll notice that in the '**build and publish image**' task, the steps taken resemble those mentioned earlier, `sassc-rails` is bundled
- inspect several pages, e.g. [
  manage your GOV.UK email subscriptions](https://www.integration.publishing.service.gov.uk/email/manage), [what do you want to get emails about?](https://www.integration.publishing.service.gov.uk/email-signup?link=/money), [get emails from GOV.UK](https://www.integration.publishing.service.gov.uk/foreign-travel-advice/canada/email-signup), [how often do you want to get emails?](https://www.integration.publishing.service.gov.uk/email/subscriptions/new?topic_id=statistics-with-1-research-and-statistic-5e2982632b) to ensure the absence of errors.

## Anything else

Once the PR gets the green light, it will be closed.

See:
- https://github.com/alphagov/collections/pull/3447
- https://github.com/alphagov/govuk_publishing_components/pull/3726
- https://github.com/alphagov/static/pull/3190
- https://github.com/alphagov/govuk-developer-docs/pull/4216.