### PR TITLE
Suppress Sass dependency deprecation warnings

### DIFF
--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -4,3 +4,5 @@ APP_STYLESHEETS = {
 
 all_stylesheets = APP_STYLESHEETS.merge(GovukPublishingComponents::Config.all_stylesheets)
 Rails.application.config.dartsass.builds = all_stylesheets
+
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
## What

Suppress Sass dependency deprecation warnings

## Why

To only show deprecation warnings originating from the application and GOV.UK Publishing Components while silencing those coming from GOV.UK Frontend.