### PR TITLE
Remove specialist topic code

### DIFF
--- a/app/services/subscriber_list_params/generate_links_based_list_params_service.rb
+++ b/app/services/subscriber_list_params/generate_links_based_list_params_service.rb
@@ -23,8 +23,6 @@ module SubscriberListParams
       case content_item_type
       when "taxon"
         single_link(key: "taxon_tree")
-      when "topic"
-        single_link(key: "topics")
       when "organisation"
         single_link(key: "organisations")
       when "person"

--- a/spec/services/subscriber_list_params/generate_links_based_list_params_service_spec.rb
+++ b/spec/services/subscriber_list_params/generate_links_based_list_params_service_spec.rb
@@ -43,13 +43,6 @@ RSpec.describe SubscriberListParams::GenerateLinksBasedListParamsService do
         .to match(list_params.merge("links" => { "topical_events" => %w[foo-id] }))
     end
 
-    it "returns subscriber list params for topics" do
-      content_item.merge!("document_type" => "topic")
-
-      expect(described_class.call(content_item))
-        .to match(list_params.merge("links" => { "topics" => %w[foo-id] }))
-    end
-
     it "returns subscriber list params for service manual topics" do
       content_item.merge!("document_type" => "service_manual_topic")
 


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello Card](https://trello.com/c/XukdB8lT/2403-remove-specialist-topic-code-from-email-alert-frontend-s-m), [Jira issue NAV-12544](https://gov-uk.atlassian.net/browse/NAV-12544)

This PR removes the specialist topic code in the Email Alert Frontend repository. We're doing this because we've retired all specialist topic pages, and we want to clean up our code to avoid any lingering old code. The main aim is to make sure we're not accumulating unnecessary technical debt.