### PR TITLE
Pass contents read permission to build image workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:
       id-token: write
+      contents: read
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image


### PR DESCRIPTION
This is required as the reusuable workflow no requires that permission to be explicitly passed it. This is so the reusuable workflow can checkout the repository if it private.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
