### PR TITLE
Change GA4 confirm form action data

### DIFF
--- a/app/views/account_subscriptions/confirm.html.erb
+++ b/app/views/account_subscriptions/confirm.html.erb
@@ -25,7 +25,7 @@
     type: "email subscription",
     section: t("account_subscriptions.confirm.title", locale: :en),
     text: @subscriber_list["title"],
-    action: t("account_subscriptions.confirm.confirm", locale: :en),
+    action: "confirm",
     tool_name: "Get emails from GOV.UK",
   }.to_json
 %>


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Change the value of `action` for the GA4 event on the 'Confirm you want to get emails' page from `Confirm` to `confirm`.

This was using an existing value from the locale file but this is also used for the visible button text. Given the choice between creating a new entry in the locale file just for this, and simply hard coding it, I went with hard coding on the basis that this isn't text that needs translating - in fact it should always be just `confirm` for the GA4 data.

![Screenshot 2024-03-28 at 15 47 39](https://github.com/alphagov/email-alert-frontend/assets/861310/199d6d61-98e4-4159-9163-3d2ecfc146c5)


## Why
GA4 event data values like this should normally be lowercase.

## Visual changes
None.

Trello card: https://trello.com/c/JDJgPslu/805-lowercase-confirm-action-in-email-subscription-journey
