### PR TITLE
Move from Uglifier to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "plek"
 gem "ratelimit"
 gem "slimmer"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 
 group :development, :test do
   gem "climate_control"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     gds-api-adapters (95.1.0)
       addressable
       link_header
@@ -603,13 +603,13 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     stringio (3.1.0)
+    terser (1.2.2)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timecop (0.9.8)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     webmock (3.23.0)
       addressable (>= 2.8.0)
@@ -651,8 +651,8 @@ DEPENDENCIES
   simplecov
   slimmer
   sprockets-rails
+  terser
   timecop
-  uglifier
   webmock
 
 RUBY VERSION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = false
 
   # Compress JS using a preprocessor.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
## What
Use Terser instead of Uglifier to compile our JavaScript.

## Why
This change is preparation for upgrading to V5 of govuk-frontend in the govuk-publishing-components gem.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l), [Jira issue NAV-12307](https://gov-uk.atlassian.net/browse/NAV-12307)

## Changes

### JS Size
Overall the minified JS has increased slightly, by 0.2KB in the example below, the overall GZIP size remains the same at 13.7KB

| minifier | file | minified JS | minified JS (gzip) |
| --- | --- | --- | --- |
| uglifer |  email-alert-frontend/application.js | 68.6KB | 13.7KB |
| terser |  email-alert-frontend/application.js | 68.8KB | 13.7KB |

I will also add a note to SpeedCurve when the change is released.

### Compilation options
I have tested other [compilation options](https://github.com/ahorek/terser-ruby?tab=readme-ov-file#usage), including those used in the Design System - https://github.com/alphagov/govuk-frontend/blob/f04749907cbab1fddc3dc488b42319c7022ca1a2/packages/govuk-frontend/rollup.release.config.mjs#L31-L51. I have decided to leave the defaults in place for now as this is currently how we use Uglifier in our apps (no custom options) and provides the smallest file size. It is something that we will likely want to explore further in the future, for example if we do add custom options to our apps, how would we keep these in sync? should we provide a base level custom config and apps can then change as needed.

## Browser testing

I've tested the changes on Integration using the browser below, functionality works as expected without any console errors.

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11

## Tracking which JavaScript compiler is used

I've added a new column to the GOV.UK frontend apps consistency spreadsheet for "JS Compiler", it is worth noting Whitehall is currently using Terser - https://github.com/alphagov/whitehall/blob/main/Gemfile#L55