### PR TITLE
Add tracking to details components

### DIFF
--- a/app/views/account_subscriptions/confirm.html.erb
+++ b/app/views/account_subscriptions/confirm.html.erb
@@ -78,7 +78,10 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/details", {
-  title: t("account_subscriptions.confirm.how_we_use_information.title")
-  } do %>
+  title: t("account_subscriptions.confirm.how_we_use_information.title"),
+  ga4_attributes: {
+    index_section_count: 1
+  }
+} do %>
   <%= t("account_subscriptions.confirm.how_we_use_information.expanded_html") %>
 <% end %>

--- a/app/views/subscriber_authentication/check_email.html.erb
+++ b/app/views/subscriber_authentication/check_email.html.erb
@@ -11,7 +11,11 @@
   <%= t("subscriber_authentication.check_email.description_html", address: @address) %>
 </div>
 
-<%= render("govuk_publishing_components/components/details",
-           title: t("subscriber_authentication.check_email.delay_title")) do %>
+<%= render "govuk_publishing_components/components/details", {
+  title: t("subscriber_authentication.check_email.delay_title"),
+  ga4_attributes: {
+    index_section_count: 1
+  }
+} do %>
   <%= t("subscriber_authentication.check_email.delay_html") %>
 <% end %>

--- a/app/views/subscriptions/check_email.html.erb
+++ b/app/views/subscriptions/check_email.html.erb
@@ -25,6 +25,9 @@
 
 <%= render "govuk_publishing_components/components/details", {
   title: t("subscriptions.check_email.not_received_title"),
+  ga4_attributes: {
+    index_section_count: 1
+  }
 } do %>
   <%= t("subscriptions.check_email.not_received_detail_html") %>
 <% end %>


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Adds GA4 tracking to the details component on some pages, specifically the `index_section_count` attribute, which the details component cannot generate itself. In this case all of the details components are by themselves on these pages, so the `index_section_count` is 1.

Details component is on this page: https://www.gov.uk/email/subscriptions/account/confirm?frequency=immediately&return_to_url=true&topic_id=cost-of-living-payments-2023-to-2024

I'm not exactly sure of the URLs of the two other pages where the details component appears, but I've tested the code in an visible page and it functions correctly.

## Why

## Visual changes
None.

Trello card: https://trello.com/c/itsQy9UH/820-no-indexsectioncount-on-detail-in-email-subscription-journey
