### PR TITLE
Add one-click unsubscribe route and tests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   scope "/email" do
     get "/unsubscribe/:id" => "unsubscriptions#confirm", as: :confirm_unsubscribe
+    post "/unsubscribe/one-click/:id" => "unsubscriptions#one_click", as: :one_click
     post "/unsubscribe/:id" => "unsubscriptions#confirmed", as: :unsubscribe
 
     scope "/manage" do


### PR DESCRIPTION
Adds the route POST /email/unsubscribe/one-click/(subscription id), which expects a query parameter with a signed token. This is like the existing unsubscribe with token routes, but if valid cancels the subscription immediately without any user intervention. This is intended for use in one-click unsubscribe headers.

https://trello.com/c/ONisAn0b/52-add-one-click-unsubscribe-support-to-email-alert-api-frontend, [Jira issue PNP-7964](https://gov-uk.atlassian.net/browse/PNP-7964)

Related: https://github.com/alphagov/email-alert-api/pull/2162

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
