### PR TITLE
Upgrade to govuk frontend 5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link application.js
+//= link es6-components.js
 
 //= link_tree ../builds

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,2 @@
 //= require govuk_publishing_components/lib
 //= require govuk_publishing_components/components/details
-//= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/radio

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,2 @@
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/radio

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,5 +43,6 @@
   <body class="govuk-template__body">
     <%= yield :body %>
     <%= javascript_include_tag 'application' %>
+    <%= javascript_include_tag "es6-components", type: "module" %>
   </body>
 </html>


### PR DESCRIPTION
## What

Move components that rely on govuk-frontend modules to separate `es6-components.js` file

## Why

In the event that a browser below the target for `govuk-frontend` loads a page with JS on it, attempting to parse the JS from `govuk-frontend` will cause an error. To avoid this from happening, JS that contains `govuk-frontend` JS has been moved to separate file which will be loaded in a script tag with `type="module"`. This will prevent the JS from being parsed and so prevent the error

[Trello](https://trello.com/c/TkEsbnAY/2517-upgrade-email-alert-frontend-to-run-on-v51-of-govuk-frontend), [Jira issue NAV-12192](https://gov-uk.atlassian.net/browse/NAV-12192)

The intention is for the PR to include the upgrade to the version of the publishing_components_gem as well, once released.

---

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️