### PR TITLE
Move es6-components.js back into application.js

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,3 @@
 //= link application.js
-//= link es6-components.js
 
 //= link_tree ../builds

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,3 @@
 //= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/radio

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,2 +1,0 @@
-//= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/radio

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,5 @@
   <body class="govuk-template__body">
     <%= yield :body %>
     <%= javascript_include_tag 'application', type: "module" %>
-    <%= javascript_include_tag "es6-components", type: "module" %>
   </body>
 </html>


### PR DESCRIPTION
## What / Why
- Moves `es6-components.js` back into `application.js`, as the separation between the files is no longer needed now that IE11 is not supported.
- Trello card: https://trello.com/c/bqyOdz3C/311-post-typemodule-changes-clean-up, [Jira issue PNP-8557](https://gov-uk.atlassian.net/browse/PNP-8557)