### PR TITLE
Replace title components with headings

### DIFF
--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,6 +1,11 @@
 <% content_for :title, "Email Alert Frontend" %>
 
-<%= render "govuk_publishing_components/components/title", title: "Email Alert Frontend" %>
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Email Alert Frontend",
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 8
+} %>
 
 <p class="govuk-body">
   This page is intended to only be shown in development.

--- a/app/views/subscription_authentication/expired.html.erb
+++ b/app/views/subscription_authentication/expired.html.erb
@@ -1,8 +1,11 @@
 <% content_for :title, t("subscription_authentication.expired.title") %>
 <% content_for :meta_description, t("subscription_authentication.expired.description") %>
 
-<%= render "govuk_publishing_components/components/title", {
-  title: t("subscription_authentication.expired.title")
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("subscription_authentication.expired.title"),
+  heading_level: 1,
+  font_size: "xl",
+  margin_bottom: 8
 } %>
 
 <p class="govuk-body">


### PR DESCRIPTION
⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Replace title components with headings.

## Why
We are attempting to retire the page title component in favour of the heading component. [Trello](https://trello.com/c/KIUk6JsE/445-replace-title-with-heading-in-email-alert-frontend), [Jira issue PNP-9225](https://gov-uk.atlassian.net/browse/PNP-9225)

## Visual Changes
No changes for titles on the main template.

The main content is now higher on the expired view:

![image](https://github.com/user-attachments/assets/79166805-3dd9-4f71-850a-fa5d85f0dc36)

