### PR TITLE
Upgrade to v3 of the One Login cross service header

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/search-with-autocomplete
+//= require govuk_publishing_components/components/service-navigation
 //= require govuk_publishing_components/components/skip-link
 
 //= require govuk_web_banners/dependencies

--- a/app/views/layouts/account.html.erb
+++ b/app/views/layouts/account.html.erb
@@ -12,6 +12,7 @@
   <%= csp_meta_tag %>
   <meta name="robots" content="noindex, nofollow">
   <% add_gem_component_stylesheet("cross-service-header") %>
+  <% add_gem_component_stylesheet("service-navigation") %>
   <% add_gem_component_stylesheet("phase-banner") %>
 
   <%= render_component_stylesheets %>
@@ -24,7 +25,7 @@
   omit_feedback_form: true,
   omit_footer_border: true,
   omit_footer_navigation: true,
-  product_name: "GOV.UK email subscriptions",
+  service_name: "GOV.UK email subscriptions",
   show_account_layout: true,
   show_cross_service_header: true,
   omit_account_navigation: true,


### PR DESCRIPTION
## What

Upgrade to v3 of the One Login cross service header

## Why

The Digital Identity team have updated the version of govuk-frontend on the GOVUK One Login service header component to v5.9.0.

As part of this, the service navigation in the GOVUK One Login header has been replaced with the nearly-identical Design System service navigation component, (alongside some other fixes outlined in [these notes](https://github.com/govuk-one-login/service-header/releases/tag/v3.0.0))

[Trello card](https://trello.com/c/SdJPTbtC/3474-update-cross-service-header-component-to-v300-govuk-publishing-components-gem), [Jira issue NAV-1727](https://gov-uk.atlassian.net/browse/NAV-1727)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
