### PR TITLE
Tidy up by removing redundant omit_footer_border

### DIFF
--- a/app/views/layouts/account.html.erb
+++ b/app/views/layouts/account.html.erb
@@ -23,7 +23,6 @@
   blue_bar: false,
   emergency_banner:,
   omit_feedback_form: true,
-  omit_footer_border: true,
   omit_footer_navigation: true,
   service_name: "GOV.UK email subscriptions",
   show_account_layout: true,


### PR DESCRIPTION
Remove the redundant `omit_footer_border` variable definition.

The actual functionality was removed from govuk_publishing_components in v58.0.0 in [this commit](https://github.com/alphagov/govuk_publishing_components/commit/167b5a5dfdef603f0dceb06e80d9630874b4625b), with the intention of removing it from frontend apps at a later date. This is just to tidy up post v58.0.0 going out.

There is no visual difference resulting from the removal of this option since the footer component's border was updated to match the one used on GOV.UK in the same release.

Fixes https://trello.com/c/hh3oU8IX/3608-remove-omitfooterborder-option-from-gem-and-various-apps-that-pass-this-option, [Jira issue NAV-2464](https://gov-uk.atlassian.net/browse/NAV-2464)

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
