### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "govuk_publishing_components"
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
## What
Ignore the govuk_publishing_components gem from dependabot updates - https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--

## Why
A recent release of the gem caused a rendering issue in the super navigation menu in `feedback`, we want to stop any further updates of the gem in this application until we know the root cause of the issue

Release of the gem that caused the issue in feedback - https://github.com/alphagov/feedback/pull/2195