### PR TITLE
Remove the `blue_bar` option from the account layout template

### DIFF
--- a/app/views/layouts/account.html.erb
+++ b/app/views/layouts/account.html.erb
@@ -20,7 +20,6 @@
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
   title: yield(:title),
-  blue_bar: false,
   emergency_banner:,
   omit_feedback_form: true,
   omit_footer_navigation: true,


### PR DESCRIPTION
## What

Remove the `blue_bar` option from the account layout template

## What

Using the `blue_bar` option in the layout_for_public component has no impact, the blue_bar functionality was removed as part of the brand update

Jira: https://gov-uk.atlassian.net/browse/NAV-18190
