### PR TITLE
Tidy up controller code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ private
 
   def invalid_token
     reset_session
-    head :unprocessable_entity
+    head :unprocessable_content
   end
 
   def bad_request

--- a/app/controllers/content_item_signups_controller.rb
+++ b/app/controllers/content_item_signups_controller.rb
@@ -11,7 +11,7 @@
 class ContentItemSignupsController < ApplicationController
   include TaxonsHelper
 
-  protect_from_forgery except: [:create]
+  skip_forgery_protection only: [:create]
   before_action :assign_content_item
   before_action :handle_redirects
   before_action :assign_list_params

--- a/app/controllers/email_alert_signups_controller.rb
+++ b/app/controllers/email_alert_signups_controller.rb
@@ -1,5 +1,5 @@
 class EmailAlertSignupsController < ApplicationController
-  protect_from_forgery except: [:create]
+  skip_forgery_protection only: [:create]
 
   def new; end
 

--- a/app/controllers/govuk_account_signups_controller.rb
+++ b/app/controllers/govuk_account_signups_controller.rb
@@ -57,7 +57,7 @@ private
     URI.parse(params.fetch(:base_path))
   rescue URI::InvalidURIError => e
     Rails.logger.warn("Bad base path passed to SinglePageSubscriptionsController: #{e}")
-    head :unprocessable_entity
+    head :unprocessable_content
   end
 
   def fetch_subscriber_list

--- a/app/controllers/govuk_account_signups_controller.rb
+++ b/app/controllers/govuk_account_signups_controller.rb
@@ -4,7 +4,7 @@ class GovukAccountSignupsController < ApplicationController
   UNSUBSCRIBE_FLASH = "email-unsubscribe-success".freeze
   DEFAULT_FREQUENCY = "immediately".freeze
 
-  skip_before_action :verify_authenticity_token, only: [:create]
+  skip_forgery_protection only: [:create]
   before_action :validate_base_path, only: %i[create]
   before_action :fetch_subscriber_list, only: %i[create]
   before_action :not_found_without_topic_id, only: %i[edit show]

--- a/app/controllers/subscription_authentication_controller.rb
+++ b/app/controllers/subscription_authentication_controller.rb
@@ -12,7 +12,7 @@ class SubscriptionAuthenticationController < ApplicationController
     end
 
     unless valid_params?
-      head :unprocessable_entity
+      head :unprocessable_content
       return
     end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -83,7 +83,7 @@ private
     @address = subscription_params[:address]
   rescue Addressable::URI::InvalidURIError => e
     Rails.logger.warn("Bad topic passed to SubscriptionsController: #{e}")
-    head :unprocessable_entity
+    head :unprocessable_content
   end
 
   def subscription_params

--- a/app/controllers/unsubscriptions_controller.rb
+++ b/app/controllers/unsubscriptions_controller.rb
@@ -1,5 +1,5 @@
 class UnsubscriptionsController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: %i[one_click]
+  skip_forgery_protection only: [:one_click]
 
   before_action :set_attributes
   before_action :check_owns_subscription, except: %i[one_click]


### PR DESCRIPTION
- standardise how we mark exceptions to forgery protection - application controller has forgery protection turned on for all routes, so we should mark skips in the specific controllers and use a standardised way of doing that.
- update deprecated `:unprocessable_entity` values to `:unprocessable_content`

Note that this PR triggers the same four code scanning issues that the existing code triggers - it dings the code for weakening forgery protection. The forgery protection has to be turned off here because we're receiving POSTs from forms potentially created in other apps, which means we can't share forgery protection tokens easily. It's possible we could revisit this if this app is consolidated, but since that's unlikely, it's something we'll have to live with for the moment. 

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
