### PR TITLE
[DO NOT MERGE] Force SSL on production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,10 +39,10 @@ Rails.application.configure do
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)


### PR DESCRIPTION
The app has stopped working on integration, claiming that its base url is http:// so CSRF tokens from https:// are throwing a 422. This is an attempt to fix that.

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
