### PR TITLE
Add dependabot cooldown periods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,20 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
+      exclude:
+        - gds-api-adapters
+        - govuk_*
+        - plek
+        - rubocop-govuk        
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -21,3 +30,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
- To add cooldown periods for bundler(3 days) with exclusion for alphagov gems that have their own cooldown, npm(3 days) and docker(7 days) as per the documentation - https://docs.publishing.service.gov.uk/manual/manage-dependencies.html#example-configurations

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
