### PR TITLE
Move jasmine packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
   "stylelint": {
     "extends": "stylelint-config-gds/scss"
   },
-  "dependencies": {
-    "jasmine-browser-runner": "^4.0.0",
-    "jasmine-core": "^6.3.0"
-  },
   "devDependencies": {
+    "jasmine-browser-runner": "^4.0.0",
+    "jasmine-core": "^6.3.0",
     "standardx": "^7.0.0",
     "stylelint": "^15.11.0",
     "stylelint-config-gds": "^1.1.1"


### PR DESCRIPTION
## What

Move jasmine packages to devDependencies

## What

The jasmine-browser-runner and jasmine-core packages are not essential to running the application on production.

- "dependencies": Packages required by your application in production
- "devDependencies": Packages that are only needed for local development and testing

https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file
