### PR TITLE
[PNP-10105] Replace bare 410 returns with 460

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ private
   end
 
   def gone
-    render status: :gone, plain: "410 gone"
+    render status: 460, plain: "460 gone"
   end
 
   def require_authentication

--- a/spec/controllers/content_item_signups_controller_spec.rb
+++ b/spec/controllers/content_item_signups_controller_spec.rb
@@ -62,10 +62,10 @@ RSpec.describe ContentItemSignupsController do
       expect(response).to have_http_status(:not_found)
     end
 
-    it "returns a 410 if the content item is unpublished" do
+    it "returns a 460 if the content item is unpublished" do
       stub_content_store_has_gone_item("/taxon-is-gone")
       make_request(link: "/taxon-is-gone")
-      expect(response).to have_http_status(:gone)
+      expect(response).to have_http_status(460)
     end
   end
 


### PR DESCRIPTION
- In order to support both intercepted and custom 410s, we have decided that apps returning a bare 410 should instead return 460. 410s are currently intercepted by the nginx layer and replaced with the prerendered 410.html error page. But this means we can't return a 410 page with custom content.
- Instead, if an app wants to return a bare 410 it will now be required to return a 460. Nginx will then decorate it with the pre-rendered 410.html page, and adjust the status code to 410.
- Email alert frontend is the only app other than router which returns these bare 410s, so we adjust it to return 460s.

https://gov-uk.atlassian.net/browse/PNP-10105

Do not merge until https://github.com/alphagov/govuk-helm-charts/pull/4392 is deployed

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
